### PR TITLE
Capitalize OR

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -3,7 +3,7 @@ Welcome to Write the Docs's documentation!
 
 Write the Docs is a community that we are building around the concept of documentation. There are a lot of people out there that write docs, but there isn't a good place to go to find information, ask questions, and generally be a member of a community of documentation writers. We hope to slowly solve this problem by building a place to go with lots of information, and other folks who are interested in similar things.
 
-The first step is a website and a conference. We'll be holding the first incantation of Write the Docs the conference in Portland, Or in early April 2013.
+The first step is a website and a conference. We'll be holding the first incantation of Write the Docs the conference in Portland, OR in early April 2013.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Proper and easier to read because it isn't mistakable for the word `or`.
