### PR TITLE
Index includes readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,1 +1,25 @@
-.. include:: docs/index.rst
+=======
+Welcome
+=======
+
+Write the Docs is a place where the art of documentation can be practiced and appreciated. There are a lot of people out there that write docs, but there isn't a good place to go to find good information, ask questions, and generally be a member of a community of documentatarians. We hope to slowly solve this problem by building a place with high quality information about the art of writing documentation. Along with that, we hope to open communication between all the awesome people out there writing documentation.
+
+
+Resources
+---------
+
+* Discover & learn:
+
+  * Online documentation: http://docs.writethedocs.org/
+
+* Meet:
+
+  * Conference: http://conf.writethedocs.org/
+  * IRC: `#writethedocs on freenode <http://webchat.freenode.net/?channels=writethedocs>`_
+  * Twitter: http://twitter.com/writethedocs
+  * Mailing List: https://groups.google.com/forum/?fromgroups=#!forum/write-the-docs
+
+* Contribute:
+
+  * Issues & feature requests: https://github.com/writethedocs/docs/issues
+  * Source repository: https://github.com/writethedocs/docs

--- a/README.rst
+++ b/README.rst
@@ -1,1 +1,1 @@
-.. include:: index.rst
+.. include:: docs/index.rst

--- a/README.rst
+++ b/README.rst
@@ -8,18 +8,10 @@ Write the Docs is a place where the art of documentation can be practiced and ap
 Resources
 ---------
 
-* Discover & learn:
-
-  * Online documentation: http://docs.writethedocs.org/
-
-* Meet:
-
-  * Conference: http://conf.writethedocs.org/
-  * IRC: `#writethedocs on freenode <http://webchat.freenode.net/?channels=writethedocs>`_
-  * Twitter: http://twitter.com/writethedocs
-  * Mailing List: https://groups.google.com/forum/?fromgroups=#!forum/write-the-docs
-
-* Contribute:
-
-  * Issues & feature requests: https://github.com/writethedocs/docs/issues
-  * Source repository: https://github.com/writethedocs/docs
+* Online documentation: http://docs.writethedocs.org/
+* Conference: http://conf.writethedocs.org/
+* IRC: `#writethedocs on freenode <http://webchat.freenode.net/?channels=writethedocs>`_
+* Twitter: http://twitter.com/writethedocs
+* Mailing List: https://groups.google.com/forum/?fromgroups=#!forum/write-the-docs
+* Issues & feature requests: https://github.com/writethedocs/docs/issues
+* Source repository: https://github.com/writethedocs/docs

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,4 @@
-Welcome
-=======
-
-Write the Docs is a place where the art of documentation can be practiced and appreciated. There are a lot of people out there that write docs, but there isn't a good place to go to find good information, ask questions, and generally be a member of a community of documentatarians. We hope to slowly solve this problem by building a place with high quality information about the art of writing documentation. Along with that, we hope to open communication between all the awesome people out there writing documentation.
+.. include:: ../README.rst
 
 These docs
 ----------
@@ -27,7 +24,7 @@ The conference
 We'll be holding the first version of Write the Docs, the conference, in Portland, OR in early April 2013. This will bring together the community of documentarians into a room, for a number of reasons. We hope to help people discover a sense of community, to introduce new and interesting approaches and ideas, and generally have a meeting of the minds around documentation.
 
 
-Information abut Write the Docs
+Information about Write the Docs
 -------------------------------
 
 .. toctree::


### PR DESCRIPTION
At https://github.com/writethedocs/docs/tree/e9b4482a9c8496d4d203841d04739c8846dd5df5 the `.. include:: index.rst` is wrong: should be `docs/index.rst`.

Fixed with https://github.com/benoitbryon/docs.writethedocs/commit/e4d57a61627c186bffc5083e3ffca812f609e4ee

But, the `.. include::` still doesn't work as expected with Github RST parser: [nothing is displayed](https://github.com/benoitbryon/docs.writethedocs/tree/e4d57a61627c186bffc5083e3ffca812f609e4ee)

[This pull request proposes a fix where docs/index includes readme](https://github.com/benoitbryon/docs.writethedocs/tree/87224f80139dd8a9131819333d6e73788145c511).

The README has also been modified: added links to project's resources. So that the README becomes an entry point for the project. When one comes to writethedocs on Github, he gets a summary of the project, and quick links to project's resources, i.e. have the opportunity to continue at the right location.

docs/index includes README, so...
- don't repeat README. README is the document to maintain.
- docs/index also provides quick links to project's resources.
