### PR TITLE
Fix includes in docs/about/ folder

### DIFF
--- a/docs/about/authors.rst
+++ b/docs/about/authors.rst
@@ -1,1 +1,1 @@
-.. include:: ../AUTHORS
+.. include:: ../../AUTHORS

--- a/docs/about/history.rst
+++ b/docs/about/history.rst
@@ -1,1 +1,1 @@
-.. include:: ../CHANGELOG
+.. include:: ../../CHANGELOG

--- a/docs/about/license.rst
+++ b/docs/about/license.rst
@@ -1,1 +1,1 @@
-.. include:: ../LICENSE
+.. include:: ../../LICENSE


### PR DESCRIPTION
`includes::` are broken in docs/about/ folder, leading to errors like:

```
docs/about/authors.rst:1: SEVERE: Problems with "include" directive path:
InputError: [Errno 2] No such file or directory: 'AUTHORS'.
```

This pull request fixes the includes.
