### PR TITLE
Refs #4: CC BY 3.0 license

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+# Authors name/mail mapping. See ``git help shortlog``.
+# This feature is used by ``make authors``.
+
+Troy Howard <thoward37@gmail.com> <troy@appfog.com>
+
+

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,6 +1,19 @@
 Authors and contributors
 ========================
 
-* Eric Holscher
-* Chris McDonald
+Copyright holders
+-----------------
+
+* Eric Holscher <eric@ericholscher.com>
+* Troy Howard <thoward37@gmail.com> <troy@appfog.com>
+
+Contributors
+------------
+
+By alphabetical order...
+
 * Benoît Bryon <benoit@marmelune.net>
+* Chris McDonald <xwraithanx@gmail.com>
+* Eric Holscher <eric@ericholscher.com>
+* Rich Morin <rdm@cfcl.com>
+* Troy Howard <thoward37@gmail.com> <troy@appfog.com>

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,8 @@
 License
 =======
 
-License haven't been chosen yet.
+Copyright (c) 2013 by Eric Holscher, Troy Howard. See :doc:`authors`.
+
+This work is made available under the terms of the Creative Commons
+Attribution 3.0 Unported (CC BY 3.0) license:
+http://creativecommons.org/licenses/by/3.0/

--- a/LICENSE
+++ b/LICENSE
@@ -3,6 +3,7 @@ License
 
 Copyright (c) 2013 by Eric Holscher, Troy Howard. See :doc:`authors`.
 
-This work is made available under the terms of the Creative Commons
-Attribution 3.0 Unported (CC BY 3.0) license:
-http://creativecommons.org/licenses/by/3.0/
+This work is licensed under the Creative Commons Attribution 3.0 Unported
+License (CC BY 3.0). To view a copy of this license, visit
+http://creativecommons.org/licenses/by/3.0/ or send a letter to Creative
+Commons, 444 Castro Street, Suite 900, Mountain View, California, 94041, USA.

--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,7 @@ distclean: clean
 
 maintainer-clean:
 	rm -rf $(ROOT_DIR)/bin/ $(ROOT_DIR)/lib/
+
+
+authors:
+	git log --pretty="* %aN <%aE>" | sort | uniq

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,21 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'Write the Docs'
-copyright = u'2013, Eric Holscher, Troy Howard'
+copyright = """
+<a rel="license"
+   href="http://creativecommons.org/licenses/by/3.0/"
+   style="float:right;height:3em;line-height:3em;padding:10px 0 0 1em;">
+    <img alt="Creative Commons License" style="border-width:0"
+         src="http://i.creativecommons.org/l/by/3.0/88x31.png" />
+</a>
+2013, Eric Holscher, Troy Howard.
+<br />
+This work is licensed under a
+<br />
+<a rel="license" href="http://creativecommons.org/licenses/by/3.0/">
+    Creative Commons Attribution 3.0 Unported License
+</a>
+"""
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
As proposed in #4, here is a creative commons unported 3.0 license:
- setup LICENSE
- setup copyright in docs/conf.py
- updated AUTHORS (introduced a `make authors` helper)
