### PR TITLE
Upgraded sphinxcontrib-testbuild to bugfix version 0.1.2.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ dependencies:
 develop: virtualenv dependencies
 
 
+update:
+	$(PIP) install -U -r $(PIP_REQUIREMENTS) --use-mirrors
+
+
 docs/_static:
 	mkdir -p docs/_static
 

--- a/etc/pip/requirements.txt
+++ b/etc/pip/requirements.txt
@@ -12,4 +12,4 @@ nose==1.2.1
 python-termstyle==0.1.10
 rednose==0.3.3
 wsgiref==0.1.2
-sphinxcontrib-testbuild==0.1.1
+sphinxcontrib-testbuild==0.1.2


### PR DESCRIPTION
Version 0.1.2 of sphinxcontrib-testbuild is a bugfix release.
See https://github.com/benoitbryon/sphinxcontrib-testbuild/issues/1
