### PR TITLE
Importing content from Docness: "conventions"

### DIFF
--- a/docs/_themes/kr/static/wtd.css
+++ b/docs/_themes/kr/static/wtd.css
@@ -114,6 +114,29 @@ ul, ol {
 
 blockquote {
   margin: 0 0 0 20px;
+  padding: 8px;
+  border-style: 1px solid #cccccc;
+  background-color: #fafafa;
+}
+blockquote > div {
+
+}
+blockquote > div:before,
+blockquote > div:after {
+  line-height: 1em;
+  font-weight: bold;
+  font-size: 2em;
+  color: #cccccc;
+}
+blockquote > div:before {
+  content: open-quote;
+  margin-right: 4px;
+  float: left;
+}
+blockquote > div:after {
+  content: close-quote;
+  margin-left: 4px;
+  float: right;
 }
 
 dl dd {

--- a/docs/writing/conventions/documentation-language.rst
+++ b/docs/writing/conventions/documentation-language.rst
@@ -1,0 +1,145 @@
+#############################
+Choose documentation language
+#############################
+
+Recommendation:
+
+* Analyze documentation usage
+* Choose a language for the documentation
+* If the language choice isn't obvious, write the choice and the reason in the
+  documentation
+
+Keep in mind that the language of the documentation is related to documentation
+usage: who does read it? Who does write it?
+
+
+********************************************
+English is standard for software development
+********************************************
+
+**English is recommended for technical documentations related to software**,
+because it's the standard in software industry. Programming languages and code
+are written in english. So should be their documentation.
+
+
+**********************************************
+Guidelines for non english-speaking developers
+**********************************************
+
+A common scenario in countries where english is not a natural language:
+
+* a team develops software
+* some team members don't speak english, or at least not well enough to be
+  efficient with english.
+
+So english doesn't sound natural to this team... Let's consider other points
+of interest, so that you can base your choice on pragmatic values.
+
+How much is english a useful skill to develop software?
+=======================================================
+
+Since most software documentations, articles, tutorials are written in english,
+learning english is truly useful. For developers, english language is valuable.
+
+So the question is: in the context of the project, can the team learn english?
+If the answer is "yes", then english remains a good choice.
+Some helpers:
+
+* do team members actually are interested in learning english?
+* compare estimated learning cost to estimated benefits of english skill.
+
+Notice that, if some developers speak english, they can help others while
+doing code review or pair programming.
+
+How many foreign-speaking developers contribute to the software?
+================================================================
+
+Think about collaboration and maintenance. May external developers contribute
+to the project? Which languages could be used for communications?
+
+The documentation language should be one in the list of possibilities.
+
+Notice that, as a universal communication language, english has chances to be
+in the list. The more "international" or "open" is your project, the more
+english is a good choice.
+
+How much would be a translation?
+================================
+
+Whatever the language choice, you may have to translate the documentation one
+day. So, if you are not sure about the suitable language, consider the cost of
+translation.
+
+If the cost is low, you may try a language now, and wonder about languages
+later, when necessary. Just make sure you defined "when necessary".
+
+As an example, if your documentation is about 200 words, you'd better
+write it now and translate it later, if necessary, rather than learn english
+then write the docs. But, the question should be asked again if the
+documentation reaches 5.000 words.
+
+
+******************
+Multiple languages
+******************
+
+If only you have to
+===================
+
+Support multiple languages if only you have to.
+
+One use case where you have to support multiple languages is a end-user
+documentation of an international service:
+
+* you provide a service or product in multiple languages.
+* users speak several languages.
+* you provide support for this product in multiple languages.
+* so the end-user documentation is written in multiple languages.
+
+Then here is an example where multiple languages are not required... You
+provide a service to developers. Since your service is world-famous, users
+speak various languages. But your interface is user-friendly and most
+developers are used to english... so you don't have to localize the end-user
+documentation.
+
+If only you can
+===============
+
+Support multiple languages if only you can.
+
+Keep in mind that supporting several languages means lot of work: translations,
+coordination of translation teams, maintenance.
+
+As an example, if you often release original documentation, you have to
+translate often, or translations would be obsolete. And obsolete (i.e. wrong
+or incomplete) documentation is generally more harmful than untranslated one.
+
+Sometimes, you can't support multiple languages yourself, but commmunity can.
+As an example, `the PHP documentation`_ is available in several languages.
+The original documentation is english, then translated in several languages. In
+that case, the community is big enough to support the translation process.
+In fact, here, original documentation and its translations are managed as
+distinct products.
+
+As separated documentations
+===========================
+
+When you have to support multiple languages, you'd better create distinct
+products (documentations) which are linked, instead of a big product which
+contains it all.
+
+Several reasons:
+
+* separate maintenance: if a documentation is broken, it doesn't block others.
+* separate contributors: original authors create the reference, then
+  translators translate. You shouldn't block the release of original content
+  because a translation is missing.
+
+
+**********
+References
+**********
+
+.. target-notes::
+
+.. _`the PHP documentation`: http://php.net/docs.php

--- a/docs/writing/conventions/documentation-style-guide.rst
+++ b/docs/writing/conventions/documentation-style-guide.rst
@@ -1,0 +1,28 @@
+###############################
+Adopt documentation style guide
+###############################
+
+Readability counts. Many programming languages and frameworks provide coding
+standards, conventions or best practices to increase code readbility.
+It makes collaboration and maintenance easier.
+
+**Adopt style guide for your documentation.**
+Then, in contributor guide, add an hyperlink to the style guide reference.
+
+As an example, for Sphinx users `documentation-style-guide-sphinx`_ and
+`rst2rst`_ are **in-development** projects to explain and apply style guide
+for reStructuredText documents. Have a look at `rst2rst test fixtures`_ for
+some commented examples.
+
+
+**********
+References
+**********
+
+.. target-notes::
+
+.. _`documentation-style-guide-sphinx`:
+   http://documentation-style-guide-sphinx.readthedocs.org
+.. _`rst2rst`: https://github.com/benoitbryon/rst2rst
+.. _`rst2rst test fixtures`:
+   https://github.com/benoitbryon/rst2rst/tree/master/rst2rst/tests/fixtures

--- a/docs/writing/conventions/feedback-over-conventions.rst
+++ b/docs/writing/conventions/feedback-over-conventions.rst
@@ -1,0 +1,96 @@
+#########################
+Feedback over conventions
+#########################
+
+**Associate feedback to conventions**.
+And even better, whenever you can, replace conventions by feedback.
+
+
+**********************
+Example: code coverage
+**********************
+
+Let's start with a story about code coverage...
+
+The team we work in states about code coverage in documentation:
+
+  Developers make sure that their tests cover most code.
+
+**Good motivation: we have a convention.**
+
+But that is not enough. When a developer checks code coverage, how can he tell
+whether the result is good or bad?
+
+Let's setup a recipe to get feedback about the convention:
+
+  Run ``make coverage``.
+  As a result, you get global code coverage ratio.
+  If this ratio is greater than 80%, it's good, else it's bad.
+
+**It's getting better: we can get feedback on demand.**
+
+Still, it is not enough. It belongs to each developer to respect the
+convention, i.e. developers can ignore it. With time, developers may forget
+it. New developers won't see it... Soon, the convention becomes unused, and the
+documentation becomes obsolete. How can we make the convention restrictive?
+
+Let's plug some code coverage tool in our continuous integration service. So
+that we automatically get feedback:
+
+* we receive a notification (or see a big red light) when the rule is broken
+  (code coverage is less than 80%).
+* we can do basic accountancy, using coverage history: does it increase or
+  decrease? When did it break? Which commits broke the rule?
+
+**Great! Everybody automatically gets feedback.**
+
+Now the whole team owns the convention: if one fails, the team has to perform
+something or get a big noisy red alert. So, the convention is visible, it is
+concrete, obvious. Nobody can ignore it. 
+
+Then, we can safely remove the convention from the documentation. The team no
+longer needs to maintain the convention in documentation: it's live! The
+convention will be maintained (and self-documented) as scripts and
+configuration applied to continuous integration service.
+
+Let's compare it to `the fable of the chicken and the pig`_:
+
+* by writing down conventions, you get involved.
+* by replacing conventions by feedback, you get committed.
+
+
+****************
+Classic patterns
+****************
+
+Here is a list of frequently encountered use cases, where you can get feedback
+instead of writing down conventions:
+
+* "No test, no commit".
+  Use commit hooks or a continuous integration service to get feedback when
+  tests get broken.
+
+* Coding standards.
+  Plug a "coding standards reviewer" into a continuous integration service.
+
+  As an example, for Python code, make your build fail if `flake8`_ reports
+  errors.
+
+* "No TODO in PROD". Write a test or a commit hook that fail if "TODO" string
+  is found in code.
+
+* "No debug in PROD". Write a test or a commit hook... where "debug"
+  definition depends on your language.
+  
+  As an example, for Python, check for "pdb" and "print".
+
+
+**********
+References
+**********
+
+.. target-notes::
+
+.. _`the fable of the chicken and the pig`:
+   https://en.wikipedia.org/wiki/The_Chicken_and_the_Pig
+.. _`flake8`: http://pypi.python.org/pypi/flake8/

--- a/docs/writing/conventions/index.rst
+++ b/docs/writing/conventions/index.rst
@@ -1,0 +1,15 @@
+###################
+Declare conventions
+###################
+
+The project's documentation is a good place for a team to store and share
+conventions.
+
+Here are some recommandations about conventions.
+
+
+.. toctree::
+
+   feedback-over-conventions
+   documentation-language
+   documentation-style-guide

--- a/docs/writing/index.rst
+++ b/docs/writing/index.rst
@@ -11,3 +11,4 @@ This section contains recommendations about writing documentation. What to do, a
    mindshare
    what-not/index
    doctests
+   conventions/index


### PR DESCRIPTION
To continue (progressive) migration from https://github.com/benoitbryon/docness to writethedocs, here are some pages about conventions.

My primary intention is to actually move content from docness to writethedocs.
I'm aware that, then, we will certainly have to review, discuss, organize the content.
