### PR TITLE
Update Sphinx URL

### DIFF
--- a/docs/writing/documentation-is-part-of-the-product.rst
+++ b/docs/writing/documentation-is-part-of-the-product.rst
@@ -80,4 +80,4 @@ References
 
 .. _`scrum development method`:
    https://en.wikipedia.org/wiki/Scrum_%28development%29
-.. _`Sphinx`: http://sphinx.pocoo.org
+.. _`Sphinx`: http://sphinx-doc.org/


### PR DESCRIPTION
This change updates the old Sphinx URL http://sphinx.pocoo.org/ to the new one: http://sphinx-doc.org/. The old one redirects to the new anyway, but it seems worth having the right one.
