### PR TITLE
Fix date format in blog post

### DIFF
--- a/docs/blog/newsletter-september-2016.md
+++ b/docs/blog/newsletter-september-2016.md
@@ -1,6 +1,6 @@
 ```eval_rst
 
-.. post:: Sept 1, 2016
+.. post:: Sep 1, 2016
    :tags: newsletter
 
 ```


### PR DESCRIPTION
Before applying this small fix I was not able to run `make livehtml`. On trying, I would receive the following error message: 

```
ValueError: invalid post date in: blog/newsletter-september-2016
```

After making this tiny edit, I was then able to run `make livehtml` successfully. 