### PR TITLE
Add docs like code part to the guide

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -200,7 +200,7 @@ def rstjinja(app, docname, source):
     """
     if getattr(app.builder, 'implementation', None) or app.builder.format != 'html':
         return
-    if docname.startswith('conf/'):
+    if docname.startswith('conf/') or docname.startswith('guide/'):
         src = source[0]
         rendered = app.builder.templates.render_string(src, app.config.html_context)
         source[0] = rendered
@@ -210,6 +210,7 @@ def add_jinja_filters(app):
     if getattr(app.builder, 'implementation', None) or app.builder.format != 'html':
         return
     app.builder.templates.environment.filters['slugify'] = slugify
+
 
 def setup(app):
     app.connect('html-page-context', on_page_context)

--- a/docs/guide/docs-like-code.rst
+++ b/docs/guide/docs-like-code.rst
@@ -1,0 +1,33 @@
+Docs like Code
+============
+
+*Docs like Code* refers to a philosophy that you should be writing documentation with the same tools you use to write code.
+This means following the same workflows and integrating into development teams.
+
+Generally a *Docs like Code* approach gives you the following benefits:
+
+* Writers integrate better with development teams
+* Developers will write a first draft of documentation
+* You can block merging of new features if they don't include documentation
+    
+Videos
+------
+
+Write the Docs has had a number of talks that touch on this topic over the years.
+In Portland 2015,
+`Riona MacNamara`_ talked about how adopting *Docs like Code* has completely transformed how Google does documentation.
+At our 2016 US conference,
+we had a `panel`_ with folks from Rackspace,
+Microsoft,
+Balsamiq,
+and Twitter,
+all talking about how they are adopting these practices.
+Our 2016 EU conference had talks from `Margaret Eker and Jennifer Roundeau`_ and `Rachel Whitten`_ give talks as well.
+
+The *Docs like Code* concepts are widely practiced in the software industry,
+and are gaining adoption in the writing community.
+
+.. _Riona MacNamara: https://www.youtube.com/watch?v=EnB8GtPuauw
+.. _panel: https://www.youtube.com/watch?v=Y2TGwUPb8R4
+.. _Margaret Eker and Jennifer Roundeau: https://www.youtube.com/watch?v=JvRd7MmAxPw
+.. _Rachel Whitten: https://www.youtube.com/watch?v=dHdBsNxtKeI

--- a/docs/guide/docs-like-code.rst
+++ b/docs/guide/docs-like-code.rst
@@ -13,20 +13,28 @@ Generally a *docs like Code* approach gives you the following benefits:
 * Writers integrate better with development teams
 * Developers will often write a first draft of documentation
 * You can block merging of new features if they don't include documentation, which incentivizes developers to 
+
+There is a lot more to building a proper *Docs like Code* workflow.
+There are a couple books we recommend that you check out:
+
+* Docs like Code - Anne Gentle
+* Modern Technical Writing - Andrew Etter
     
-Videos
-------
+*Docs like Code* at Write the Docs
+----------------------------------
 
 Write the Docs has had a number of talks that touch on this topic over the years.
-In Portland 2015,
+At our 2015 NA conference,
 `Riona MacNamara`_ talked about how adopting *Docs like Code* has completely transformed how Google does documentation.
-At our 2016 US conference,
+At our 2016 NA conference,
 we had a `panel`_ with folks from Rackspace,
 Microsoft,
 Balsamiq,
 and Twitter,
 all talking about how they are adopting these practices.
-Our 2016 EU conference had talks from `Margaret Eker and Jennifer Roundeau`_ and `Rachel Whitten`_ give talks as well.
+Our 2016 EU conference had a talk from `Margaret Eker and Jennifer Roundeau`_ from Rackspace & Capital One,
+it was a great overview of *Docs as Code*.
+We also had `Rachel Whitten`_ from Pantheon give a talk on their implementation of these approaches.
 
 The *Docs like Code* concepts are widely practiced in the software industry,
 and are gaining adoption in the writing community.

--- a/docs/guide/docs-like-code.rst
+++ b/docs/guide/docs-like-code.rst
@@ -1,14 +1,18 @@
 Docs like Code
 ============
 
+:author: `Eric Holscher <https://ericholscher.com>`_
+
 *Docs like Code* refers to a philosophy that you should be writing documentation with the same tools you use to write code.
 This means following the same workflows and integrating into development teams.
+It enables a culture where writers and developers both feel ownership of documentation,
+and work together to make it as good as possible.
 
-Generally a *Docs like Code* approach gives you the following benefits:
+Generally a *docs like Code* approach gives you the following benefits:
 
 * Writers integrate better with development teams
-* Developers will write a first draft of documentation
-* You can block merging of new features if they don't include documentation
+* Developers will often write a first draft of documentation
+* You can block merging of new features if they don't include documentation, which incentivizes developers to 
     
 Videos
 ------

--- a/docs/guide/docs-like-code.rst
+++ b/docs/guide/docs-like-code.rst
@@ -24,17 +24,19 @@ There are a couple books we recommend that you check out:
 ----------------------------------
 
 Write the Docs has had a number of talks that touch on this topic over the years.
-At our 2015 NA conference,
-`Riona MacNamara`_ talked about how adopting *Docs like Code* has completely transformed how Google does documentation.
-At our 2016 NA conference,
-we had a `panel`_ with folks from Rackspace,
-Microsoft,
-Balsamiq,
-and Twitter,
-all talking about how they are adopting these practices.
-Our 2016 EU conference had a talk from `Margaret Eker and Jennifer Roundeau`_ from Rackspace & Capital One,
-it was a great overview of *Docs as Code*.
-We also had `Rachel Whitten`_ from Pantheon give a talk on their implementation of these approaches.
+
+**2015 North America**
+
+* `Riona MacNamara`_ talked about how adopting *Docs like Code* has completely transformed how Google does documentation.
+
+**2016 North America**
+
+* We had a `panel`_ with folks from Rackspace, Microsoft, Balsamiq, and Twitter, all talking about how they are adopting these practices.
+
+**2016 Europe**
+
+* `Margaret Eker and Jennifer Roundeau`_ from Rackspace & Capital One, it was a great overview of *Docs as Code*.
+* `Rachel Whitten`_ from Pantheon give a talk on their implementation of these approaches.
 
 The *Docs like Code* concepts are widely practiced in the software industry,
 and are gaining adoption in the writing community.

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -33,8 +33,8 @@ Writing Great Documentation
 
 * :doc:`writing/docs-principles`
 * Structuring your Documentation
+* :doc:`docs-like-code`
 * Style Guides
-* :ref:`interesting-approaches`
 
 Documentation Culture at your Company
 -------------------------------------


### PR DESCRIPTION
The plan is to link this from a Foreword I'm doing in the Docs like Code book, since we've covered so much of this content. Up for more ideas of what might be good to link.