### PR TITLE
Minor tweaks to site content

### DIFF
--- a/docs/conf/eu/2017/lightning-talks.rst
+++ b/docs/conf/eu/2017/lightning-talks.rst
@@ -7,8 +7,7 @@ Lightning Talks
 
 A lightning talk is a very short talk where you share an idea, concept,
 or a bit of information you find interesting. They’re quick, easy, and a
-great way to practice. (Lovely example
-`*here* <https://www.youtube.com/watch?feature=player_embedded&v=6wcP1aMl7wQ#t=942>`__!)
+great way to practice. (Here is a `*lovely example* <https://www.youtube.com/watch?feature=player_embedded&v=6wcP1aMl7wQ#t=942>`__!)
 
 Planning: What Goes into a Lightning Talk?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/conf/eu/2017/schedule.rst
+++ b/docs/conf/eu/2017/schedule.rst
@@ -50,7 +50,7 @@ Main Stage
    :template: include/schedule.rst
 
 Unconference Room
------------------
+~~~~~~~~~~~~~~~~~
 
 :doc:`/conf/eu/2017/unconference` from 13:00-17:00
 
@@ -77,7 +77,7 @@ Main Stage
    :template: include/schedule.rst
 
 Unconference Room
------------------
+~~~~~~~~~~~~~~~~~
 
 :doc:`/conf/eu/2017/unconference` from 10:00-15:00
 


### PR DESCRIPTION
Fixed headings in the master schedule and a link in the lightning talks.

BTW @ericholscher the site still shows the Portland logo even though I (think I) merged the updated logo. Maybe you can take a look? Thanx