### PR TITLE
Refactored community code of conduct

### DIFF
--- a/docs/code-of-conduct.md
+++ b/docs/code-of-conduct.md
@@ -1,62 +1,105 @@
-Code of Conduct
-===============
+# Code of Conduct
 
-Short Version
--------------
-
+## Short Version
 
 **Write the Docs** is dedicated to providing a harassment-free
-experience for everyone, regardless of gender, sexual orientation,
+experience for everyone, regardless of gender identity, sexual orientation,
 disability, physical appearance, body size, race, or religion. We do not
-tolerate harassment of event participants in any form. Sexual language
-and imagery is not appropriate for any event venue, including talks.
-Event participants violating these rules may be sanctioned or expelled
-from the event without a refund at the discretion of the event
-organizers.
+tolerate harassment of community member in any form. Offensive language
+and imagery is not appropriate in any event or online platform.
+Community members, sponsors, and affiliates violating these rules may
+be sanctioned or expelled from events or online platforms without a refund
+at the discretion of the organizers.
 
- 
+## Long Version
 
-Long Version
-------------
+Like the technical community as a whole, Write the Docs is made up of a mixture
+of professionals and volunteers from all over the world, working on every aspect of
+the mission, whether it's in our conferences, meetups, or online platforms.
 
+Diversity is one of our huge strengths, but it can also lead to communication issues
+and unhappiness. To that end, we have a few ground rules that we ask people to adhere
+to. This code applies equally to founders, organizers, sponsors, and affiliates.
 
-### Harassment
+This isn’t an exhaustive list of things that you can’t do. Rather, take it in the spirit
+in which it’s intended - a guide to make it easier to enrich all of us and the technical
+communities in which we participate.
 
-Harassment includes offensive verbal comments related to gender, sexual
-orientation, disability, physical appearance, body size, race, religion,
-sexual images in public spaces, deliberate intimidation, stalking,
-following, harassing photography or recording, sustained disruption of
-talks or other events, inappropriate physical contact, and unwelcome
-sexual attention. Participants asked to stop any harassing behavior are
-expected to comply immediately.
+### The principles
 
-### Exhibitors & Sponsors
+- Be welcoming. We strive to be a community that welcomes and supports people of all
+backgrounds and identities. This includes, but is not limited to members of any race,
+ethnicity, culture, national origin, colour, immigration status, social and economic
+class, educational level, sex, sexual orientation, gender identity and expression, age,
+size, family status, political belief, religion, and mental and physical ability.
 
-Exhibitors in the expo hall, sponsor or vendor booths, or similar
-activities are also subject to the anti-harassment policy. In
-particular, exhibitors should not use sexualized images, activities, or
-other material. Booth staff (including volunteers) should not use
-sexualized clothing/uniforms/costumes, or otherwise create a sexualized
-environment.
+- Be respectful. Not all of us will agree all the time, but disagreement is no excuse
+for poor behavior and poor manners. We might all experience some frustration now and then,
+but we cannot allow that frustration to turn into a personal attack. It’s important to
+remember that a community where people feel uncomfortable or threatened is not a productive
+one. Members of the Write the Docs community should be respectful when dealing with other
+members as well as with people outside the community.
 
-### Participants
+- Be careful in the words that you choose. We are a community of professionals, and we conduct
+ourselves professionally. Be kind to others. Do not insult or put down other participants.
+Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to:
+  - Violent threats or language directed against another person.
+  - Discriminatory jokes and language.
+  - Posting sexually explicit or violent material.
+  - Posting (or threatening to post) other people's personally identifying information ("doxing").
+  - Personal insults, especially those using racist or sexist terms.
+  - Unwelcome sexual attention.
+  - Advocating for, or encouraging, any of the above behavior.
+  - Repeated harassment of others. In general, if someone asks you to stop, then stop.
 
-If a participant engages in harassing behavior, the event organizers may
-take any action they deem appropriate, including warning the offender or
-expulsion from the event with no refund. If you are being harassed,
-notice that someone else is being harassed, or have any other concerns,
-please **contact a member of event staff immediately**. Event staff can
+### Where does the CoC apply
+
+This code of conduct applies to all spaces managed by Write the Docs. This includes:
+
+- Conferences, including social events and peripheral activities
+- Unconferences and sprints
+- Meetups
+- Workshops
+- Presentation materials used in talks or sessions
+- Slack
+- Mailing lists
+- GitHub
+- Twitter hashtag
+- forum.writethedocs.org
+- meetup.com discussion boards
+- Any other forums created by the which the community uses for communication.
+
+In addition, violations of this code outside these spaces may affect a person's
+ability to participate within them.
+
+### Exhibitors & sponsors
+
+When you sponsor a Write the Docs event, we welcome you into our community,
+and we expect you to be respectful to the community you operate within.
+
+All exhibitors in the expo hall, sponsor or vendor booths, or similar
+activities are also subject to the code of conduct. In particular,
+exhibitors should not use sexualized images, activities, or other material.
+Booth staff (including volunteers) must not use sexualized clothing/uniforms/costumes,
+or otherwise create a sexualized environment.
+
+In addition, sponsors for conference, meetups, and online activities should not
+employ aggressive recruiting techniques, invasive marketing behavior, or similar
+actions towards community members. In case of violations, sponsors might be sanctioned
+and expelled from the event or activity with no return of the sponsorship contribution.
+
+### What to do in case of violations
+
+If you believe that someone is violating the code of conduct during one of our events,
+please **contact a member of the event staff immediately**. Event staff can
 be identified by t-shirts/special badges.
 
-Event staff will be happy to help participants contact hotel/venue
-security or local law enforcement, provide escorts, or otherwise assist
-those experiencing harassment to feel safe for the duration of the
-event. We value your attendance.
+If you believe someone is violating the code of conduct in one of our online
+platforms, we ask that you report it by [emailing us](mailto:support@writethedocs.org).
 
-### Venue & Social Events
-
-We expect participants to follow these rules at all related venues and
-social events.
+All reports will be kept confidential. In some cases a public statement might be
+required (for example in a CoC transparency report following conferences), but these
+reports are anonymized and do not include any personally identifying information.
 
 ------------------------------------------------------------------------
 
@@ -79,8 +122,8 @@ social events.
 
 ### License
 
-This Code of Conduct was forked from the example policy from the [Geek
-Feminism wiki, created by the Ada Initiative and other
-volunteers](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy),
-which is under a [Creative Commons
-Zero](http://creativecommons.org/choose/zero/) license.
+This Code of Conduct is inspired by and is based on:
+- Example policy from the [Geek Feminism wiki, created by the Ada Initiative and other volunteers](http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy),
+which is under a [Creative Commons Zero](http://creativecommons.org/choose/zero/) license.
+- Django project [code of conduct](https://www.djangoproject.com/conduct/) and [reporting guidelines](https://www.djangoproject.com/conduct/reporting/), which are
+under a [Creative Commons CCBY Attribution](https://creativecommons.org/licenses/by/3.0/) license.


### PR DESCRIPTION
Expanded and deepened the CoC to reflect more than just events (including online spaces etc). Also added an extra warning for sponsors and exhibitors to refrain from aggressive marketing or recruiting coz that ain't cool. 