### PR TITLE
Add Vale to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ install:
  - eval "$(gimme 1.7)"
  - go get github.com/ValeLint/vale
 script:
- - vale docs/
  - tox -e $TOX_ENV
+ - vale docs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,3 @@ install:
  - go get github.com/ValeLint/vale
 script:
  - tox -e $TOX_ENV
- - vale docs/

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_install:
 install:
  - pip install tox
  - eval "$(gimme 1.7)"
- - go get github.com/jdkato/vale
+ - go get github.com/ValeLint/vale
 script:
  - vale docs/
  - tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,13 @@ python:
 sudo: false
 env:
  - TOX_ENV=docs
- - TOX_ENV=branding
+before_install:
+  - export GOPATH=$HOME/golang
+  - export PATH=$PATH:$GOPATH/bin
 install:
  - pip install tox
+ - eval "$(gimme 1.7)"
+ - go get github.com/jdkato/vale
 script:
+ - vale docs/
  - tox -e $TOX_ENV

--- a/.vale
+++ b/.vale
@@ -1,6 +1,12 @@
 StylesPath = style-guide
+MinAlertLevel = error
 
 [*.{md,rst,txt}]
 BasedOnStyles = WTD
-vale.Wordiness = YES
-vale.ComplexWords = YES
+
+vale.Redundancy = YES
+vale.Repetition = YES
+vale.GenderBias = YES
+
+TheEconomist.UnnecessaryWords = YES
+TheEconomist.Hectoring = YES

--- a/.vale
+++ b/.vale
@@ -1,0 +1,6 @@
+StylesPath = style-guide
+
+[*.{md,rst,txt}]
+BasedOnStyles = WTD
+vale.Wordiness = YES
+vale.ComplexWords = YES

--- a/docs/conf/na/2017/east/proposal.md
+++ b/docs/conf/na/2017/east/proposal.md
@@ -1,6 +1,6 @@
 # Write the Docs East: Call for Venue Proposal 2017
 
-It’s time to think about Write the Docs 2017! 
+It’s time to think about Write the Docs 2017!
 We are hoping to split the North American conference into an East and West coast event,
 and we're looking for proposals for the East coast host city.
 This will bring us to 3 total conferences:
@@ -11,7 +11,7 @@ This will bring us to 3 total conferences:
 
 So you want your city to host Write the Docs East? Hurrah! We’re delighted by your interest. Here’s what you need to know, and what we need to know, to consider your proposal.
 
-For 2017, we don't have a set date in mind. 
+For 2017, we don't have a set date in mind.
 The West event will be in May 2017,
 so take this into account in your planning.
 It likely makes sense to do the event in the Fall,
@@ -43,7 +43,7 @@ We need some information about your city, about the venue, and travel. Your prop
         - (Optional, but recommended) Room for an unconference session that can sit up to 50-75 people
         - Green room for speakers to prepare (generally a room that will seat 25 for a workshop is the right size)
         - Location of registration tables
-        - Location of meals and breaks with sufficient seating and tables. 
+        - Location of meals and breaks with sufficient seating and tables.
         - Location of supplemental beverage stations for daylong service.
         - Secure overnight storage for vendor booth supplies and conference registration desk items.
 
@@ -67,10 +67,10 @@ We need some information about your city, about the venue, and travel. Your prop
     - Adjoins or within walking distance to a suitable hotel which can accommodate 250 attendees
     - Excellent Internet connectivity   
     - [Accessible](https://modelviewculture.com/pieces/organizing-more-accessible-tech-events) to as many attendees as possible
-    - Reasonable access to transit for sightseeing 
+    - Reasonable access to transit for sightseeing
 
     We recommend looking at concert venues and other non-traditional event spaces.
-    They tend to have a more interesting vibe, 
+    They tend to have a more interesting vibe,
     and also be cheaper to rent.
     Other options might be universities,
     software company corporate campuses,
@@ -80,7 +80,7 @@ We need some information about your city, about the venue, and travel. Your prop
 
     - Name
     - Location
-    - Transportation options 
+    - Transportation options
     - Attendance capacity
     - Cost of function space, catering, and audio-visual services. Sprints are often hosted by local companies as sponsorship of the event, which is preferable, as it saves the cost of renting a venue.
 
@@ -91,14 +91,14 @@ We need some information about your city, about the venue, and travel. Your prop
     - See catering requirements above.  Eating tables should be separate from work tables if at all possible.
     - Excellent Internet connectivity
 
-4. Hotels. Ideal hotels are a very short walk away. For the hotel, we need at least one option that is affordable (eg. not 4-star), and needs the following info:
+4. Hotels. Ideal hotels are a very short walk away. For the hotel, we need at least one option that is affordable (that is, less than 4-star), and needs the following info:
 
     - Name
     - Location
     - Transportation options (how do people get there from the airport?)
     - Cost of room per night (Generally we don't get a block of rooms because of the liability, we mainly just want to know a general cost)
 
- 
+
 5.  Provide estimates on costs associated with flights, accommodation, meals, ground transportation, etc. for an overview of total cost for attendees.
 
 6. Information about what makes the city a good choice for Write the Docs East and an attractive destination for attendees.

--- a/docs/guide/writing/docs-principles.rst
+++ b/docs/guide/writing/docs-principles.rst
@@ -63,7 +63,7 @@ Publications
 *A "publication" refers to a single, cohesive tool that readers use to consume
 documentation.
 It may be static or interactive — digital or paper. Multiple
-publications may be created from a single source (e.g. web and PDF
+publications may be created from a single source (such as web and PDF
 versions of the same manual). Although rarer, multiple sources may
 be used to create a single publication. More examples of
 publications include: API reference, man page, command line
@@ -119,10 +119,10 @@ the software's contributors. Developers and engineers are the people
 with the best access to in-demand information, and getting them to
 document it will help foster a *culture* of documentation.
 
-As well, documentation *readers* (i.e. users) should have clear avenues
+As well, documentation *readers* (i.e., users) should have clear avenues
 towards involvement in documentation. A good first step is to give
 readers the ability to offer feedback in the form of comments or
-suggestions. Allowing readers to edit documentation directly (e.g. in a
+suggestions. Allowing readers to edit documentation directly (e.g., in a
 wiki) can also be effective but must be weighed against the need and
 capacity for editorial oversight.
 

--- a/docs/organizer-guide/confs/cfp.rst
+++ b/docs/organizer-guide/confs/cfp.rst
@@ -49,7 +49,7 @@ You should have:
 
 How it works:
 
-* We allocate 2 points for every talk at the conference (eg. 30 points for 15 talks).
+* We allocate 2 points for every talk at the conference (e.g., 30 points for 15 talks).
 * You use those points to vote for which talks you want to see.
 * We add up all the points and sort them by highest. This is the initial talk selection.
 * We then argue for & against talks that we *really* want to change positions. This can either be because you know the speaker/topic will be good, two talks cover similar topics and we can only have one, or other reasons.

--- a/docs/origin-story.rst
+++ b/docs/origin-story.rst
@@ -1,17 +1,17 @@
 Origin Story
 ============
 
-The story of how Write the Docs came to be has been told, but it's time to put it up on our own site. 
+The story of how Write the Docs came to be has been told, but it's time to put it up on our own site.
 The first documentation of the emerging documentarian community comes appropriately enough in the form of a `tweet`_ from early 2013:
 
 .. image:: /_static/img/origin-tweet.png
    :width: 75%
 
 What happened next is best told in the words of one of the founders,
-Troy Howard. 
-He wrote it in early 2014, 
-before the second conference. 
-So read it, 
+Troy Howard.
+He wrote it in early 2014,
+before the second conference.
+So read it,
 and ponder just how far we've come since then.
 
 We'll let `Troy <https://twitter.com/thoward37>`_ tell the `story <http://blog.thoward37.me/articles/developer-to-documentarian/>`_ from here.
@@ -45,9 +45,9 @@ has been a vital resource to the Python open source community.
 As a developer, I have always cared about documentation, but I'm not
 sure I ever thought about it *deeply* until I got to know Eric Holscher
 better. Sometime in early 2013, I ran into Eric at a local eatery, and
-we started discussing Read The Docs. He had recently `left his job at
+we started discussing Read the Docs. He had recently `left his job at
 Urban Airship <http://ericholscher.com/blog/2013/jan/10/walk-woods/>`__
-and was able to work on Read The Docs full time. This was going well,
+and was able to work on Read the Docs full time. This was going well,
 but he was concerned about the future of the project. There didn't seem
 to be a sense of community around documentation. Was documentation ever
 going to be given the focus it needed?
@@ -127,4 +127,3 @@ over 1,500 :doc:`meetup </meetups/index>` members that have joined meetup groups
 
 The community keeps growing larger and larger,
 and we're happy to welcome everyone into this wonderful group of documentarians.
-

--- a/style-guide/TheEconomist/Didactic.yml
+++ b/style-guide/TheEconomist/Didactic.yml
@@ -1,0 +1,17 @@
+extends: existence
+message: "'%s' - Do not be too didactic"
+description: "If too many sentences begin with '%s,' readers will think they are reading a textbook."
+link: http://www.economist.com/styleguide/introduction
+scope: text
+level: warning
+ignorecase: false
+tokens:
+  - Compare
+  - Consider
+  - Expect
+  - Imagine
+  - Look at
+  - Note
+  - Prepare for
+  - Remember
+  - Take

--- a/style-guide/TheEconomist/Hectoring.yml
+++ b/style-guide/TheEconomist/Hectoring.yml
@@ -1,0 +1,17 @@
+extends: existence
+message: "'%s' - Do not be hectoring or arrogant"
+description: "Those who disagree with you are not necessarily '%s.'"
+link: http://www.economist.com/styleguide/introduction
+scope: text
+level: error
+ignorecase: true
+tokens:
+  - stupid
+  - idiotic
+  - imbecile
+  - ignorant
+  - insane
+  - absurd
+  - ridiculus
+  - lunatic
+  - asinine

--- a/style-guide/TheEconomist/HorribleWords.yml
+++ b/style-guide/TheEconomist/HorribleWords.yml
@@ -1,0 +1,26 @@
+extends: existence
+message: "'%s' - See section 'Horrible words'"
+description: "Be aware that the use of '%s' may have an emetic effect on some of your readers."
+link: http://www.economist.com/style-guide/horrible-words
+level: warning
+ignorecase: true
+tokens:
+  - carer
+  - chattering classes
+  - facilitate
+  - famously
+  - Governance
+  - grow the business
+  - guesstimate
+  - informed
+  - leverage
+  - likely
+  - looking to
+  - materiel
+  - poster child
+  - prestigious
+  - proactive
+  - rack up
+  - savvy
+  - segue
+  - stakeholder

--- a/style-guide/TheEconomist/OughtShould.yml
+++ b/style-guide/TheEconomist/OughtShould.yml
@@ -1,0 +1,10 @@
+extends: existence
+message: Go easy on the oughts and shoulds
+description: "The aim is not just to tell readers what you think, but to persuade them."
+link: http://www.economist.com/styleguide/introduction
+scope: text
+level: warning
+ignorecase: true
+tokens:
+  - ought
+  - should

--- a/style-guide/TheEconomist/OverusedWords.yml
+++ b/style-guide/TheEconomist/OverusedWords.yml
@@ -1,0 +1,32 @@
+extends: existence
+message: "'%s' is overused"
+description: "Nothing betrays the lazy writer faster than fly-blown phrases used in the belief that they are snappy, trendy or cool."
+link: http://www.economist.com/style-guide/overused-words
+level: warning
+scope: text
+ignorecase: true
+tokens:
+  - address
+  - brits
+  - care for
+  - challenge
+  - commit to
+  - community
+  - environment
+  - famously
+  - focus
+  - historic
+  - homeland
+  - individual
+  - inform
+  - metrosexual
+  - overseas
+  - participate in
+  - process
+  - relationship
+  - resources
+  - skills
+  - supportive
+  - target
+  - transparency
+  - wannabes

--- a/style-guide/TheEconomist/Punctuation.yml
+++ b/style-guide/TheEconomist/Punctuation.yml
@@ -1,0 +1,10 @@
+extends: substitution
+message: Use '%s' instead of '%s'
+level: error
+scope: text
+ignorecase: false
+nonword: true
+swap:
+  e\.g\.: eg
+  i\.e\.: ie
+  \b(?:eg|ie)[^,]: eg, or ie,

--- a/style-guide/TheEconomist/Slang.yml
+++ b/style-guide/TheEconomist/Slang.yml
@@ -1,0 +1,37 @@
+extends: existence
+message: "'%s' - See section 'Journalese and slang'"
+scope: text
+level: warning
+description: "Slang, like metaphors, should be used only occasionally if it is to have effect."
+link: http://www.economist.com/style-guide/journalese-and-slang
+ignorecase: true
+tokens:
+  - ailing
+  - Big Pharma
+  - caring
+  - crisis
+  - Ethics violations
+  - Governance
+  - gravy train
+  - guesstimate
+  - high profile
+  - highly visible
+  - hit the big time
+  - key
+  - major
+  - mandarins
+  - massive
+  - meaningful
+  - oil-rich
+  - perceptions
+  - prestigious
+  - salami tactics
+  - scantily clad
+  - schizophrenic
+  - significant
+  - the bottom line
+  - the green light
+  - the likes of
+  - the thumbs down
+  - the thumbs up
+  - too close to call

--- a/style-guide/TheEconomist/UnexpandedAcronyms.yml
+++ b/style-guide/TheEconomist/UnexpandedAcronyms.yml
@@ -1,0 +1,59 @@
+extends: conditional
+message: "'%s' has no definition"
+level: warning
+scope: text
+description: "Write the words in full on first appearance, unless the abbreviation or acronym is well known."
+link: http://www.economist.com/style-guide/abbreviations
+first: \b([A-Z]{3,5})\b
+second: (?:\b[A-Z][a-z]+ )+\(([A-Z]{3,5})\)
+exceptions:
+  - ABC
+  - ADD
+  - ADHD
+  - AIDS
+  - APA
+  - API
+  - CBS
+  - CIA
+  - CSI
+  - CSS
+  - CST
+  - ESPN
+  - EST
+  - FAQ
+  - FIXME
+  - GNU
+  - HIV
+  - HR
+  - HTML
+  - HTTP
+  - HTTPS
+  - JSON
+  - LAN
+  - MIT
+  - MLA
+  - MLB
+  - MTV
+  - NASA
+  - NATO
+  - NBA
+  - NBC
+  - NCAA
+  - NCAAB
+  - NCAAF
+  - NFL
+  - NHL
+  - NOTE
+  - PDF
+  - PGA
+  - PPV
+  - PST
+  - SGML
+  - SSN
+  - TNT
+  - TODO
+  - URL
+  - USA
+  - USSR
+  - XML
+  - XXX

--- a/style-guide/TheEconomist/UnnecessaryWords.yml
+++ b/style-guide/TheEconomist/UnnecessaryWords.yml
@@ -1,0 +1,34 @@
+extends: existence
+message: "'%s' - See section 'Unnecessary words'"
+level: warning
+scope: text
+description: Some words add nothing but length to your prose.
+link: http://www.economist.com/style-guide/unnecessary-words
+ignorecase: true
+tokens:
+  - any time soon
+  - bought up
+  - cut back
+  - cutbacks
+  - for free
+  - free gift
+  - freed up
+  - hatched up
+  - headed up by
+  - large-scale
+  - meet with
+  - Most especially
+  - Most probably
+  - policymaking process
+  - safe haven
+  - sale events
+  - sent off to bed
+  - so-called
+  - sold off
+  - strike action
+  - The fact that
+  - This time around
+  - top priority
+  - track record
+  - weather conditions
+  - wilderness area

--- a/style-guide/TheEconomist/style.md
+++ b/style-guide/TheEconomist/style.md
@@ -1,0 +1,1 @@
+Based on [The Economist](http://www.economist.com/styleguide/introduction).

--- a/style-guide/WTD/Abbreviations.yml
+++ b/style-guide/WTD/Abbreviations.yml
@@ -2,7 +2,7 @@ type: substitution
 message: Use '%s'
 ignorecase: false
 level: error
-map:
+swap:
   '(?:eg)': e.g.,
   '(?:ie)': i.e.,
   '(?:e\.g\.)\s*': e.g.,

--- a/style-guide/WTD/Abbreviations.yml
+++ b/style-guide/WTD/Abbreviations.yml
@@ -1,4 +1,4 @@
-type: substitution
+extends: substitution
 message: Use '%s'
 ignorecase: false
 level: error

--- a/style-guide/WTD/Abbreviations.yml
+++ b/style-guide/WTD/Abbreviations.yml
@@ -1,0 +1,9 @@
+type: substitution
+message: Use '%s'
+ignorecase: false
+level: error
+map:
+  '(?:eg)': e.g.,
+  '(?:ie)': i.e.,
+  '(?:e\.g\.)\s*': e.g.,
+  '(?:i\.e\.)\s*': i.e.,

--- a/style-guide/WTD/Branding.yml
+++ b/style-guide/WTD/Branding.yml
@@ -1,4 +1,4 @@
-type: substitution
+extends: substitution
 message: Use '%s' instead of '%s'
 level: error
 swap:

--- a/style-guide/WTD/Branding.yml
+++ b/style-guide/WTD/Branding.yml
@@ -1,0 +1,6 @@
+type: substitution
+message: Use '%s' instead of '%s'
+level: error
+map:
+  Write The Docs: Write the Docs
+  Read The Docs: Read the Docs

--- a/style-guide/WTD/Branding.yml
+++ b/style-guide/WTD/Branding.yml
@@ -3,4 +3,5 @@ message: Use '%s' instead of '%s'
 level: error
 swap:
   Write The Docs: Write the Docs
+  write the docs: Write the Docs
   Read The Docs: Read the Docs

--- a/style-guide/WTD/Branding.yml
+++ b/style-guide/WTD/Branding.yml
@@ -1,6 +1,6 @@
 type: substitution
 message: Use '%s' instead of '%s'
 level: error
-map:
+swap:
   Write The Docs: Write the Docs
   Read The Docs: Read the Docs

--- a/style-guide/WTD/SentenceLength.yml
+++ b/style-guide/WTD/SentenceLength.yml
@@ -3,5 +3,4 @@ type: occurrence
 scope: sentence
 level: suggestion
 max: 28
-tokens:
-  - \b(\w+)\b
+token: \b(\w+)\b

--- a/style-guide/WTD/SentenceLength.yml
+++ b/style-guide/WTD/SentenceLength.yml
@@ -1,5 +1,5 @@
 message: "Sentences should be less than 28 words"
-type: occurrence
+extends: occurrence
 scope: sentence
 level: suggestion
 max: 28

--- a/style-guide/WTD/SentenceLength.yml
+++ b/style-guide/WTD/SentenceLength.yml
@@ -1,0 +1,7 @@
+message: "Sentences should be less than 28 words"
+type: occurrence
+scope: sentence
+level: suggestion
+max: 28
+tokens:
+  - \b(\w+)\b

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,11 @@
 [tox]
-envlist = docs,branding
+envlist = docs
 skipsdist = True
 
 [testenv:docs]
 deps = -rrequirements.txt
 changedir = {toxinidir}/docs
+whitelist_externals = vale
 commands =
+    vale .
     sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
-
-[testenv:branding]
-deps = 
-changedir = {toxinidir}/docs
-commands = {toxinidir}/docs/_scripts/test-branding.py


### PR DESCRIPTION
Hi,

This PR adds [Vale](https://github.com/jdkato/vale) to your existing Travis CI setup (and replaces `test-branding.py`). I made a post about Vale [on the WTD forum](http://forum.writethedocs.org/t/vale-a-customizable-syntax-aware-linter-for-prose/632).

I don't necessarily expect this to be merged; I just thought you might be interested in seeing how it could be used (it's also relevant to #58).

---

In terms of the actual linting, I implemented some of the ideas discussed in the [December 2016 newsletter](https://github.com/writethedocs/www/blob/master/docs/blog/newsletter-december-2016.md):

- A suggestion about sentences longer than 28 words;
- a warning about [unnecessary wordiness](https://github.com/jdkato/vale/blob/master/rule/Wordiness.yml);
- a warning about deviating from [plain language](http://www.plainlanguage.gov/howto/wordsuggestions/simplewords.cfm);
- an error about inconsistent use of "e.g." and "i.e."; and
- an error about using "Write The Docs" or "Read The Docs."

The build will only fail on errors (it's [currently failing](https://travis-ci.org/jdkato/www) over the use of "Read The Docs" in `origin-story.rst` and a number of different forms of "e.g." throughout the docs). Obviously, you may want to tweak the individual checks yourselves.

Thanks for taking a look!