### PR TITLE
Tweaked the updated CoC and created a blog post

### DIFF
--- a/docs/blog/new-community-coc.rst
+++ b/docs/blog/new-community-coc.rst
@@ -1,0 +1,19 @@
+.. post:: Feb 22, 2017
+   :tags: community, code of conduct, announcements
+
+New and Improved Community Code of Conduct
+==========================================
+
+Greetings documentarians! As you know, Write the Docs is an incredibly diverse, friendly, and inclusive community. We continually encourage and support safe spaces in our events and online platforms.
+
+To that effect, we recently refactored and expanded our :doc:`/code-of-conduct` to accommodate for the increased interaction that our community members have with each other and with folks outside our community when communicating on behalf of Write the Docs.
+
+This updated code of conduct aims not only to deliver a more accurate definition of the principles which we believe in, but also to establish which spaces are considered official community spaces, what might be considered a violation, and what to do in case you need to report a violation.
+
+In addition to the expanded code of conduct, we included a :doc:`/code-of-conduct-reporting` with guidelines on how to submit a report and what to expect after submitting a report.
+
+And lastly, we refactored our :doc:`/code-of-conduct-response` to cover handling reports in all of our community spaces, and to make sure that we follow a consistent and transparent approach in handling these reports.
+
+Please take a moment to review the :doc:`/code-of-conduct`. As with any of our community documentation, we welcome feedback and contributions. We'd also like to thank the `Django Project Code of Conduct <https://www.djangoproject.com/conduct/>`_ for inspiring a large portion of our updated code of conduct.
+
+And remember - Be excellent to each other!

--- a/docs/code-of-conduct-reporting.rst
+++ b/docs/code-of-conduct-reporting.rst
@@ -1,0 +1,41 @@
+Code of Conduct Reporting Guide
+===============================
+
+In any Write the Docs space (events or online), if you believe someone is violating the :doc:`/code-of-conduct`, we ask that you report it to the staff by emailing conduct@writethedocs.org. All reports will be kept confidential. In some cases we may determine that a public statement will need to be made. If that's the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
+
+If you believe anyone is in physical danger, please notify appropriate law enforcement first. If you are unsure which law enforcement agency is appropriate, please include this in your report and we will attempt to notify them.
+
+If the violation occurs at an event (such as conference, meetup), get in touch with one of the event staff right away, in any of the following ways:
+
+* In person
+* By phone
+* By email
+
+What to include in the report
+-----------------------------
+
+* Your contact information (so we can get in touch with you if we need to follow up)
+* Names of any individuals involved (real names, nicknames, or pseudonyms). If there were other witnesses besides you, please try to include them as well.
+* When and where the incident occurred. Please be as specific as possible.
+* Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or a public chat logger) please include a link.
+* Any extra context you believe existed for the incident.
+* Whether you believe this incident is ongoing.
+* Any other information you believe we should have.
+
+What happens after you file a report
+------------------------------------
+
+The Write the Docs community team aims to follow the process outlined in :doc:`/code-of-conduct-response`.
+
+We promise to acknowledge receipt of any reports within 24 hours or sooner, and a resolution (or update in case a resolution is delayed) within 7 days.
+
+Note: If the violation is determined to be an ongoing incident or a threat to physical safety, the staff's immediate priority will be to protect everyone involved. This means we may delay an "official" response until we believe that the situation has ended and that everyone is physically safe.
+
+Once we determine the final needed action, we'll contact the original reporter to let them know what action we'll be taking, if any. Please understand that while we take into account feedback from the reporter on the appropriateness of our response, we cannot guarantee we can or will act on it.
+
+Finally, the staff may choose to make a public report of the incident if it was reported outside one of our conferences. All conferences will be followed by a CoC transparency report.
+
+Appealing
+---------
+
+Only permanent resolutions (such as bans) may be appealed. To appeal a decision, contact the WTD staff at conduct@writethedocs.org with your appeal and they will review the case.

--- a/docs/code-of-conduct-response.rst
+++ b/docs/code-of-conduct-response.rst
@@ -1,43 +1,64 @@
 
-Write the Docs Code of Conduct - Reporting Guide
-================================================
+Code of Conduct Response Playbook
+=================================
 
-.. _report: conduct@writethedocs.org
+This document aims to help organizers and moderators of Write the Docs spaces to handle reports of :doc:`code-of-conduct` violations.
 
-In general, in any Write the Docs space (conferences, meetup, Slack, forum), if you believe someone is violating the code of conduct we ask that you report it to the staff by emailing report_. All reports will be kept confidential. In some cases we may determine that a public statement will need to be made. If that's the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
+CoC violations at conferences
+-----------------------------
 
-If you believe anyone is in physical danger, please notify appropriate law enforcement first. If you are unsure what law enforcement agency is appropriate, please include this in your report and we will attempt to notify them.
+Presentations
+~~~~~~~~~~~~~
+Presentations or similar events should not be stopped for one-time gaffes or minor problems, although a member of conference staff should speak to the presenter afterward. However, staff should take immediate action to politely and calmly stop any presentation or event that repeatedly or seriously violates the anti-harassment policy. For example, simply say "I'm sorry, this presentation cannot be continued at the present time" with no further explanation.
 
-If the violation occurs at an event (conference, meetup), get in touch with one of the event staff right away, in any of the following ways:
+In-person reports
+~~~~~~~~~~~~~~~~~
 
-* In person
-* By phone
-* By email
+When taking a report from someone experiencing harassment you should record what they say and reassure them they are being taken seriously, but avoid making specific promises about what actions the organizers will take.
 
-In your report please include:
+Ask for any other information if the reporter has not volunteered it (such as time, place) but do not pressure them provide it if they are reluctant. Even if the report lacks important details such as the identity of the person taking the harassing actions, it should still be recorded and passed along to the appropriate staff member(s).
 
-* Your contact information (so we can get in touch with you if we need to follow up)
-* Names of any individuals involved (real names, nicknames, or pseudonyms). If there were other witnesses besides you, please try to include them as well.
-* When and where the incident occurred. Please be as specific as possible.
-* Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or a public chat logger) please include a link.
-* Any extra context you believe existed for the incident.
-* Whether you believe this incident is ongoing.
-* Any other information you believe we should have.
+If the reporter desires it, arrange for an escort by conference staff or a trusted person, contact a friend, and contact local law enforcement. Do not pressure the reporter to take any action if they do not want to do it. Respect the reporter's privacy by not sharing unnecessary details with others, especially individuals who were not involved with the situation or non-staff members.
 
-What happens after you file a report
-------------------------------------
+After resolving the issue, a CoC report should be written and submitted to conduct@writethedocs.org as soon as possible, so that the information can be logged and included in transparency reports. The report should be written according to the :doc:`/code-of-conduct-reporting`.
 
-You will receive an email from the WTD staff acknowledging receipt. We promise to acknowledge receipt within 24 hours, and will aim for much quicker than that.
+Warnings
+~~~~~~~~
 
-The staff will meet immediately to review the incident and determine the following:
+Any member of conference staff can issue a verbal warning to a participant that their behavior violates the conference Code of Conduct.
+
+Expulsion
+~~~~~~~~~
+
+A participant may be expelled by the decision of conference staff and at their discretion. Here are some general guidelines for when a participant should be expelled:
+
+* A third offense that resulted in a warning from staff
+* Continuing to harass after any "No" or "Stop" instruction
+* A pattern of harassing behavior, with or without warnings
+* A single serious offense (e.g., punching or groping someone)
+* A single obviously intentional offense (e.g., taking up-skirt photos)
+
+In addition, hotel/venue security and local authorities should be contacted when appropriate. Please contact one of the representatives listed in the conference brochure or posted on signs in the conference venues.
+
+CoC violations in community spaces
+----------------------------------
+
+In case someone reports a code of conduct violation outside conferences or meetups, in one of the Write the Docs online spaces, or otherwise by email,
+
+Initial receipt
+~~~~~~~~~~~~~~~
+
+Reports must be acknowledged as received within 24 hours or sooner.
+
+The staff must to review the incident and determine the following:
 
 * What happened.
 * Whether this event constitutes a code of conduct violation.
 * Who the bad actor was.
-* Whether this is an ongoing situation, or if there is a threat to anyone's physical safety.
-* If this is determined to be an ongoing incident or a threat to physical safety, the staff's immediate priority will be to protect everyone involved. This means we may delay an "official" response until we believe that the situation has ended and that everyone is physically safe.
+* Whether this is an ongoing situation
+* If there is a threat to anyone's physical safety.
 
-After the staff has a complete account of the events they will make a decision as to how to response. Responses may include:
+After the staff has a complete account of the events they need to make a decision as to how to resolve the case. Resolutions might include:
 
 * Nothing (if we determine no violation occurred).
 * A private reprimand from the staff to the individual(s) involved.
@@ -46,13 +67,10 @@ After the staff has a complete account of the events they will make a decision a
 * A permanent or temporary ban from some or all WTD spaces (Slack, the forum, meetups).
 * A request for a public or private apology.
 
-We'll respond within one week to the person who filed the report with either a resolution or an explanation of why the situation is not yet resolved.
+A response must be sent within one week to the person who filed the report with either a resolution or an explanation of why the situation is not yet resolved.
 
-Once we've determined our final action, we'll contact the original reporter to let them know what action we'll be taking, if any. We'll take into account feedback from the reporter on the appropriateness of our response, but we don't guarantee we'll act on it.
+Public statements
+~~~~~~~~~~~~~~~~~
+As a general rule, conference staff should not make any public statements about the behavior of individual people during or after the conference. After each conference, a CoC transparency report will be published with anonymized information about any violations that might have occured.
 
-Finally, the staff may choose to make a public report of the incident.
-
-Appealing
----------
-
-Only permanent resolutions (such as bans) may be appealed. To appeal a decision, contact the WTD staff at report_ with your appeal and they will review the case.
+This report should be handled with care not to divulge personally identifying information about victims, reporters, and violators, and should serve as a means to ensure that attendees will be comfortable reporting harrasment and that our community will be kept accountable for supporting and encouraging safe spaces.

--- a/docs/code-of-conduct.rst
+++ b/docs/code-of-conduct.rst
@@ -4,19 +4,16 @@ Code of Conduct
 
 Write the Docs is a global community of documentarians who share information, discuss ideas, and work together to improve the art and science of documentation.
 
-Diversity is one of our huge strengths. To support a welcoming environment for all, regardless of individual differences, we have a few ground rules that we ask people to adhere to when they're participating within this community and its projects. These rules apply equally to founders, mentors, admins, and those seeking conversation, discussion, help, and guidance -- in short, to all participants.
+Diversity is one of our huge strengths, but it can also lead to communication issues. To support a welcoming environment for all, regardless of individual differences, we have a few ground rules that we ask people to adhere to when they participate in this community activities. These rules apply equally to founders, organizers, moderators, sponsors, and affiliates -- in short, to all participants.
 
-This isn't an exhaustive list of things that you must do, or can't do. Rather, take it in the spirit in which it's intended. It's a guide to make it easier to enrich all of us -- the technical community and the conferences, meetups, and other forums we hope to guide new participants to.
+This isn't an exhaustive list of things that you must do, or can't do. Rather, take it in the spirit in which it's intended. It's a guide to make it easier to enrich all of us and the technical communities in which we participat, and which we represent.
 
-This code of conduct applies to all spaces associated with the Write the Docs community, whether virtual or face-to-face. This includes Slack, the discussion forum, social media, conferences, meetups, and anywhere else Write the Docs might show up. In addition, violations of this code outside these spaces may affect a person's ability to participate within them. 
+The principles
+~~~~~~~~~~~~~~
 
-* **Be friendly and patient.**
+* **Be friendly and welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to, members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
 
-* **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to, members of any race, ethnicity, culture, national origin, colour, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
-
-* **Be considerate.** Your words and your work will be used by other people, and you in turn will depend on the words and the work of others. Any decision you take will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
-
-* **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the Write the Docs community should be respectful when dealing with others inside and outside the Write the Docs community.
+* **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It’s important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the Write the Docs community should be respectful when dealing with other members as well as with people outside the community.
 
 * **Be careful in the words that you choose.** We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants, individually or as a group. Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to:
 
@@ -29,6 +26,45 @@ This code of conduct applies to all spaces associated with the Write the Docs co
   * Advocating for, or encouraging, any of the above behavior.
   * Repeated harassment of others. In general, if someone asks you to stop, then stop.
 
-* **When we disagree, try to understand why.** Disagreements, both social and technical, happen all the time and Write the Docs is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we’re different. The strength of Write the Docs comes from its varied community -- people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. And don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+Where does the code of conduct apply
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This code of conduct is copied largely from the [Django Project](https://www.djangoproject.com/conduct/), which in turn credits the original text of the Speak Up! project, inspired in its turn by the Fedora Project, as well as the Python Mentorship Project and many others. We are all dwarves sitting on the shoulders of giants.
+This code of conduct applies to all spaces managed by Write the Docs. This includes:
+
+* Conferences (including social events and peripheral activities)
+* Unconferences and sprints
+* Meetups
+* Workshops
+* Presentation materials used in talks or sessions
+* Slack
+* Mailing lists
+* GitHub
+* Twitter hashtag
+* forum.writethedocs.org
+* meetup.com discussion boards
+* Any other forums created by the which the community uses for communication.
+
+In addition, violations of this code outside these spaces may affect a person's ability to participate within them.
+
+Sponsors, affiliates, and exhibitors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you sponsor a Write the Docs event, we welcome you as a member of our community, and we expect you to be respectful to the community you operate within.
+
+All exhibitors in the expo hall, sponsor or vendor booths, or similar activities are also subject to the code of conduct. In particular, exhibitors should not use sexualized images, activities, or other material. Booth staff (including volunteers) must not use sexualized clothing/uniforms/costumes, or otherwise create a sexualized environment.
+
+In addition, sponsors and affiliates of conference, meetups, and online activities should not employ aggressive recruiting techniques, invasive marketing behavior, or similar actions towards community members. In case of violations, sponsors might be sanctioned and expelled from the event or activity with no return of the sponsorship contribution.
+
+What to in case of violations
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you believe that someone is violating the code of conduct during one of our events, please contact a member of the event staff immediately. Event staff can be identified by t-shirts/special badges.
+
+If you believe someone is violating the code of conduct in one of our online platforms, we ask that you report it by emailing conduct@writethedocs.org. To help us respond in the best way to the situation, please follow the :doc:`/code-of-conduct-reporting`. The code of conduct representatives employ the :doc:`/code-of-conduct-response` to handle reports.
+
+All reports will be kept confidential. In some cases a public statement might be required (for example in a CoC transparency report following conferences), but these reports are anonymized and do not include any personally identifying information.
+
+Thanks
+~~~~~~
+
+This code of conduct is largely based on the `Django Project Code of Conduct <https://www.djangoproject.com/conduct/>`_, which in turn credits the original text of the Speak Up! project, inspired in its turn by the Fedora Project, as well as the Python Mentorship Project and many others.


### PR DESCRIPTION
Following the updates to the CoC made in PR #134, I performed further refinements to the CoC and reporting guide, and I also brought back the response doc and rebranded it as a playbook for staff.

Also, I drafted a blog post announcing this, which can go out as soon as this PR is reviewed and merged. 

Tagging the folks who were in the original CoC PR but of course others are welcome to review.