### PR TITLE
Replace easy_install with pip

### DIFF
--- a/docs/guide/tools/sphinx.rst
+++ b/docs/guide/tools/sphinx.rst
@@ -39,12 +39,11 @@ Sphinx is a python project, so it can be installed like any other python library
 Several Operating Systems (Mac OS X, Major Versions of Linux/BSD) have Python pre-installed,
 so you should just have to run::
 
-    sudo easy_install Sphinx
+    sudo pip install Sphinx
 
 Instructions for installing Python and Sphinx on Windows can be found at the `Sphinx install page`_.
 
 .. note:: Advanced users can install this in a virtualenv if they wish.
-    Also, ``pip install Sphinx`` works fine if you have Pip.
 
 
 Getting Started


### PR DESCRIPTION
Nowadays `easy_install` should not be recommended anymore as the primary Python package manager so I replaced it by `pip`. Although running `sudo pip install` is potentially dangerous, can break the system in hard to debug ways and in general should never be used instead of the system package manager, I understand that you want something _that works_ so I'm leaving it as it is too. Anyway, expanding this section a little bit with some warning would be also desirable IMO.