### PR TITLE
Delink non talks

### DIFF
--- a/docs/_templates/include/schedule.rst
+++ b/docs/_templates/include/schedule.rst
@@ -1,5 +1,31 @@
 .. raw:: html
 
+{% set dont_link = ['Lunch',
+                    'Snack break',
+                    'Switch Speakers',
+                    'Doors Open, Breakfast Served',
+                    'Introduction & State of the Docs',
+                    'Lightning Talks',
+                    'Day 1 wraps up',
+                    'Closing & Group Photo',
+                    'Day 2 wraps up',
+                    'Writing Day Introduction - Introduction to Sprints & Project Introductions',
+                    'Team up and start working',
+                    'Lunch Break',
+                    'End of Writing Day, Beginning of Reception',
+                    'End of Reception',
+                    'Introduction to Write the Docs',
+                    'Workshop begins: Learn how to Git',
+                    'Workshop ends: Learn how to Git. Lunch Break',
+                    'Workshop begins: Structuring and writing documentation',
+                    'Workshop ends: Structuring and writing documentation',
+                    '5 Min Switch Speakers',
+                    'Group Photo',
+                    'Closing Announcements',
+                    'Snacks & milling about and chatting with other attendees',
+                    'Write the Docs meetup social and conference after-party',
+                    ] %}
+
 {% for talk in data %}
 
       <div class="row">
@@ -9,9 +35,17 @@
         <div class="col-xs-10>
           <p class=">
 
-`{{ talk.Session }} <../speakers#{{ talk.Session|slugify }}>`_
+          {% if talk.Session in dont_link %}
+
+          {{ talk.Session}}
+
+          {% else %}
+
+`{{ talk.Session }} </conf/na/2016/speakers/#speaker-{{ talk.slug }}>`_
 
 .. raw:: html
+
+          {% endif %}
 
           </p>
         </div>

--- a/docs/conf/na/2017/schedule.rst
+++ b/docs/conf/na/2017/schedule.rst
@@ -25,7 +25,8 @@ Burnside St**.
 
 During the day, we'll hold our :doc:`Writing Day documentation
 sprints </conf/na/2017/writing-day>`, followed by the conference
-reception in the evening. It also includes two half-day :doc:`workshops </conf/na/2017/workshops>`.
+reception in the evening. We also have two half-day :doc:`workshops </conf/na/2017/workshops>`
+running in parallel with the writing day.
 
 We encourage everyone to drop by on Sunday evening for the conference
 reception. You'll have a chance to get acquainted with each other over
@@ -57,7 +58,7 @@ The main conference will take place at the **Crystal Ballroom located at 1332 W
 Burnside St**.
 
 This is the main event! Hear from lots of interesting folks about all
-things documentation. 
+things documentation.
 
 Main Stage
 ~~~~~~~~~~


### PR DESCRIPTION
This is an interim fix for broken links.

We should probably look at tweaking the json / template so we can include arbitrary links for workshops and writing day.

IF link use that - if not use speaker link type thing.