### PR TITLE
Dont break on make clean

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -168,7 +168,7 @@ changes:
 	@echo
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
-linkcheck:
+linkcheck: html
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \


### PR DESCRIPTION
Adding the dependency stops linkcheck crashing. 