### PR TITLE
Add WTD.Terms to Vale configuration

### DIFF
--- a/.vale
+++ b/.vale
@@ -5,7 +5,6 @@ MinAlertLevel = warning
 BasedOnStyles = WTD
 
 vale.Redundancy = YES
-#vale.Repetition = YES
 vale.GenderBias = YES
 
 TheEconomist.UnnecessaryWords = YES

--- a/docs/conf/na/2016/news/schedule-welcome-wagon-events.md
+++ b/docs/conf/na/2016/news/schedule-welcome-wagon-events.md
@@ -53,7 +53,7 @@ there's something for everyone in our Welcome Wagon guide.
 Our [events][events] are also going to be great.
 They are:
 
-* A meet up on Sunday before the reception
+* A meetup on Sunday before the reception
 * 15 minute venue tours on Monday before the conference starts
 
 Both events will help to answer any last minute questions you might have,

--- a/vale/WTD/SentenceLength.yml
+++ b/vale/WTD/SentenceLength.yml
@@ -1,6 +1,0 @@
-message: "Sentences should be less than 28 words"
-extends: occurrence
-scope: sentence
-level: suggestion
-max: 28
-token: \b(\w+)\b

--- a/vale/WTD/Terms.yml
+++ b/vale/WTD/Terms.yml
@@ -1,0 +1,5 @@
+extends: substitution
+message: Use '%s' instead of '%s'
+level: error
+swap:
+  'meet[- ]ups?': meetup(s)


### PR DESCRIPTION
This updates the existing Vale configuration to include a simple rule for detecting misuse of "meetup" (as described in the [WTD style guide](https://github.com/writethedocs/www/blob/master/docs/style-guide.rst#meetups)). Line 56 of [`schedule-welcome-wagon-events.md`](https://github.com/writethedocs/www/blob/master/docs/conf/na/2016/news/schedule-welcome-wagon-events.md) was the only issue found.