### PR TITLE
Proof of concept for RSS feeds for meetup events

### DIFF
--- a/docs/_scripts/event_feeds.py
+++ b/docs/_scripts/event_feeds.py
@@ -1,0 +1,49 @@
+import yaml
+import feedparser
+import glob
+import io
+from pprint import pprint
+
+def load_yaml(path):
+    with io.open(path, encoding='utf-8') as fp:
+        return yaml.safe_load(fp)
+
+def load_meetups():
+    result = []
+    for yaml_file in glob.glob('../_data/meetups/*.yaml'):
+        meetup = load_yaml(yaml_file)
+        if not 'website' in meetup:
+            raise SphinxError('Meetup needs a website')
+        result.append(meetup['website']+'events/rss')
+    return result
+
+# Function to fetch the rss feed and return the parsed RSS
+def parseRSS( rss_url ):
+    return feedparser.parse( rss_url )
+
+# Function grabs the rss feed headlines (titles) and returns them as a list
+def getHeadlines( rss_url ):
+    headlines = []
+
+    feed = parseRSS( rss_url )
+    for newsitem in feed['items']:
+        headlines.append(newsitem['title'])
+
+    return headlines
+
+# A list to hold all headlines
+allheadlines = []
+
+# List of RSS feeds that we will fetch and combine
+newsurls = load_meetups()
+
+#pprint(newsurls)
+
+# Iterate over the feed urls
+for url in newsurls:
+    # Call getHeadlines() and combine the returned headlines with allheadlines
+    allheadlines.extend( getHeadlines( url ) )
+
+# Iterate over the allheadlines list and print each headline
+for hl in allheadlines:
+    print(hl)


### PR DESCRIPTION
Some *rough and ready* python gleaned from the internet to get events from meetup.com . We could certainly do this better with the API.

Currently spits out something like this

```
History of the New Relic Documentation Site, Part One
Writing Inclusively About Technology Topics
Hackup
Hackup
Hackup
Hackup
Hackup
Hackup
ATX Write the Docs monthly meeting
ATX Write the Docs monthly meeting
ATX Write the Docs monthly meeting
ATX Write the Docs monthly meeting
ATX Write the Docs monthly meeting
ATX Write the Docs monthly meeting
Finding the right work to do: Lessons learnt from a year at a startup
September theme - tbc
First Write The Docs Montreal Meetup!
```

We'd need to tweak the code to grab more info than the headlines, and throw it into a template.

Decoupled from `conf.py` so we can run it as a cron with CI. FAO @rosewms 