### PR TITLE
Add breadcrumbs to the main doc pages.

### DIFF
--- a/docs/_static/css/global-customizations.css
+++ b/docs/_static/css/global-customizations.css
@@ -7,3 +7,7 @@
     border: 2px dotted;
     border-color: red;
 }
+
+.breadcrumbs {
+    margin-bottom: 2em;
+}

--- a/docs/_static/css/global-customizations.css
+++ b/docs/_static/css/global-customizations.css
@@ -8,6 +8,3 @@
     border-color: red;
 }
 
-.breadcrumbs {
-    margin-bottom: 2em;
-}

--- a/docs/_static/css/global-customizations.css
+++ b/docs/_static/css/global-customizations.css
@@ -7,4 +7,3 @@
     border: 2px dotted;
     border-color: red;
 }
-

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -27,6 +27,5 @@
 
 
 {%- block footer %}
-   FOOT
   {% include "footer.html" %}
 {%- endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -14,7 +14,6 @@
                 {% for doc in parents %}
                   <a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;
                 {% endfor %}
-              {{ title }}
             {% endif %}
           </div>
         {% endblock %}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,9 +1,33 @@
 {%- extends "!layout.html" %}
 
-{% block body %}
-  {{ body }}
-{% endblock %}
+{%- block document %}
+  <div class="documentwrapper">
+  {%- if render_sidebar %}
+    <div class="bodywrapper">
+  {%- endif %}
+      <div class="body" role="main">
+          {% block breadcrumbs %}
+          <div class="breadcrumbs">
+            {# Don't show breadcrumbs on root page #}
+            {% if master_doc != pagename %}
+              <a href="{{ pathto(master_doc) }}">{{ _('Home') }}</a> &raquo;
+                {% for doc in parents %}
+                  <a href="{{ doc.link|e }}">{{ doc.title }}</a> &raquo;
+                {% endfor %}
+              {{ title }}
+            {% endif %}
+          </div>
+        {% endblock %}
+        {% block body %} {% endblock %}
+      </div>
+  {%- if render_sidebar %}
+    </div>
+  {%- endif %}
+  </div>
+    {%- endblock %}
+
 
 {%- block footer %}
+   FOOT
   {% include "footer.html" %}
 {%- endblock %}


### PR DESCRIPTION

<img width="504" alt="screenshot 2017-07-26 12 24 18" src="https://user-images.githubusercontent.com/25510/28639532-710e2396-71fd-11e7-9a5b-85f0fa256445.png">

This will help with understanding where you are,
and acts as a basic navigation aid.