### PR TITLE
Removes a sentence from the afternoon intro

### DIFF
--- a/docs/conf/au/2017/schedule.rst
+++ b/docs/conf/au/2017/schedule.rst
@@ -21,8 +21,7 @@ need to contribute.
 Afternoon
 ----------
 
-This is the main event! Hear from lots of interesting folks about all
-things documentation.
+Hear from lots of interesting folks about all things documentation.
 
 .. datatemplate::
    :source: /_data/au-2017-PM.yaml


### PR DESCRIPTION
Removes "This is the main event!" from the afternoon section, because it implies that the doc sprint isn't as important/cool. :)