### PR TITLE
Add full text and number of entries to Atom feed

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,7 +31,8 @@ blog_authors = {
     'kelly': ("Kelly O'Brien", 'https://twitter.com/OBrienEditorial'),
 }
 blog_default_author = 'Team'
-
+blog_feed_fulltext = True
+blog_feed_length = '10'
 blog_locations = {
     'PDX': ('Portland, Oregon', 'http://www.portlandhikersfieldguide.org/'),
 }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ blog_authors = {
 }
 blog_default_author = 'Team'
 blog_feed_fulltext = True
-blog_feed_length = '10'
+blog_feed_length = 10
 blog_locations = {
     'PDX': ('Portland, Oregon', 'http://www.portlandhikersfieldguide.org/'),
 }


### PR DESCRIPTION
Fixes #328. Adds [`blog_feed_fulltext`](http://ablog.readthedocs.io/manual/ablog-configuration-options/#confval-blog_feed_fulltext) for full text entries, and [`blog_feed_length`](http://ablog.readthedocs.io/manual/ablog-configuration-options/#confval-blog_feed_length) to limit the feed to 10 items.