### PR TITLE
Fix blog_baseurl

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ extensions = [
     'ablog',
     'sphinxcontrib.datatemplates',
 ]
-blog_baseurl = 'http://www.writethedocs.org/blog/'
+blog_baseurl = 'http://www.writethedocs.org/'
 blog_path = 'blog/archive'
 blog_authors = {
     'Team': ('Write the Docs Team', 'http://www.writethedocs.org/team/'),


### PR DESCRIPTION
The [`blog_baseurl` doc](http://ablog.readthedocs.io/manual/ablog-configuration-options/#confval-blog_baseurl) says:

> Base URL for the website, required for generating feeds.

The extra `blog/` in the current config is adding extra path segments to the URLs in the feed, and as far as I can tell that is the only place it is affecting.

I haven't generated the site locally, so someone else please test. Until this is fixed, the URLs for items in the feeds are broken.