### PR TITLE
Portland copy edits, fixed navbar menu links, minor tweak to Prague page

### DIFF
--- a/docs/_templates/2018/eu/index.html
+++ b/docs/_templates/2018/eu/index.html
@@ -84,7 +84,7 @@
         <img style="height: 150px;" src="{{ pathto('_static/2018/assets/icons/boat-green.svg', 1) }}">
         <h3>Boat Ride</h3>
         <em>September 8</em>
-        <p>If you're in town early, join us for the Boat Ride. Prague features some of the most beautiful architectural and historical monuments along the river, and being on the water is an excellent way to sample the highlights.</p>
+        <p>If you're in town early, join us for the Boat Ride. Prague features beautiful architectural and historical monuments along the river, and being on the water is an excellent way to sample the highlights.</p>
       </div>
       <div class="schedule-item uk-width-1-3@s">
         <img style="height: 150px;" src="{{ pathto('_static/2018/assets/icons/writing-green.svg', 1) }}">
@@ -322,7 +322,7 @@
 
     </div>
   </div><!--- end news block -->
-  
+
   {# include "include/2018/sponsors.html" #}
 
 {% endblock container %}

--- a/docs/_templates/2018/na/menu-desktop.html
+++ b/docs/_templates/2018/na/menu-desktop.html
@@ -8,7 +8,6 @@
                                   <div class="uk-navbar-dropdown">
                                       <ul class="uk-nav uk-navbar-dropdown-nav">
                                           <li><a href="{{ pathto('conf/portland/2018/schedule') }}">Schedule</a></li>
-                                          <li><a href="{{ pathto('conf/portland/2018/speakers') }}">Talks</a></li>
                                           <li><a href="{{ pathto('conf/portland/2018/lightning-talks') }}">Lightning Talks</a></li>
                                           <li><a href="{{ pathto('conf/portland/2018/unconference') }}">Unconference</a></li>
                                           <li><a href="{{ pathto('conf/portland/2018/writing-day') }}">Writing Day</a></li>
@@ -21,11 +20,11 @@
                         <li>
                           <ul class="uk-navbar-nav">
                               <li>
-                                  <a href="{{ pathto('conf/portland/2018/visiting') }}">Visit</a>
+                                  <a href="{{ pathto('conf/portland/2018/visiting') }}">Visiting</a>
                                   <div class="uk-navbar-dropdown">
                                       <ul class="uk-nav uk-navbar-dropdown-nav">
+                                          <li><a href="{{ pathto('conf/portland/2018/visiting') }}">Portland</a></li>
                                           <li><a href="{{ pathto('conf/portland/2018/venue') }}">Venue</a></li>
-                                          <li><a href="{{ pathto('conf/portland/2018/portland') }}">Portland</a></li>
                                       </ul>
                                   </div>
                               </li>
@@ -37,6 +36,7 @@
                                   <a href="{{ pathto('conf/portland/2018/about') }}">About</a>
                                   <div class="uk-navbar-dropdown">
                                       <ul class="uk-nav uk-navbar-dropdown-nav">
+                                          <li><a href="{{ pathto('conf/portland/2018/about') }}">Overview</a></li>
                                           <li><a href="{{ pathto('conf/portland/2018/welcome-wagon') }}">Welcome Wagon</a></li>
                                           <li><a href="{{ pathto('conf/portland/2018/team') }}">Meet the Team</a></li>
                                           <li><a href="{{ pathto('conf') }}">Past Events</a></li>
@@ -53,6 +53,7 @@
                                     <a href="{{ pathto('conf/portland/2018/sponsors') }}">Sponsors</a>
                                     <div class="uk-navbar-dropdown">
                                         <ul class="uk-nav uk-navbar-dropdown-nav">
+                                            <li><a href="{{ pathto('conf/portland/2018/sponsors') }}">Our Sponsors</a></li>
                                             <li><a href="{{ pathto('conf/portland/2018/sponsors/prospectus') }}">Prospectus</a></li>
                                         </ul>
                                     </div>

--- a/docs/_templates/2018/na/menu-mobile.html
+++ b/docs/_templates/2018/na/menu-mobile.html
@@ -5,7 +5,6 @@
                       <a href="{{ pathto('conf/portland/2018/schedule') }}">Program</a>
                       <ul class="uk-nav-sub">
                           <li><a href="{{ pathto('conf/portland/2018/schedule') }}">Schedule</a></li>
-                          <li><a href="{{ pathto('conf/portland/2018/speakers') }}">Talks</a></li>
                           <li><a href="{{ pathto('conf/portland/2018/lightning-talks') }}">Lightning Talks</a></li>
                           <li><a href="{{ pathto('conf/portland/2018/unconference') }}">Unconference</a></li>
                           <li><a href="{{ pathto('conf/portland/2018/writing-day') }}">Writing Day</a></li>
@@ -15,13 +14,14 @@
                   <li class="uk-parent">
                       <a href="{{ pathto('conf/portland/2018/visiting') }}">Visit</a>
                       <ul class="uk-nav-sub">
+                          <li><a href="{{ pathto('conf/portland/2018/visiting') }}">Portland</a></li>
                           <li><a href="{{ pathto('conf/portland/2018/venue') }}">Venue</a></li>
-                          <li><a href="{{ pathto('conf/portland/2018/portland') }}">Portland</a></li>
                       </ul>
                   </li>
                   <li class="uk-parent">
                       <a href="{{ pathto('conf/portland/2018/about') }}">About</a>
                       <ul class="uk-nav-sub">
+                          <li><a href="{{ pathto('conf/portland/2018/about') }}">Overview</a></li>
                           <li><a href="{{ pathto('conf/portland/2018/welcome-wagon') }}">Welcome Wagon</a></li>
                           <li><a href="{{ pathto('conf/portland/2018/team') }}">Meet the Team</a></li>
                           <li><a href="{{ pathto('conf') }}">Past Events</a></li>
@@ -32,6 +32,7 @@
                   <li class="uk-parent">
                       <a href="{{ pathto('conf/portland/2018/sponsors') }}">Sponsors</a>
                       <ul class="uk-nav-sub">
+                          <li><a href="{{ pathto('conf/portland/2018/sponsors') }}">Our Sponsors</a></li>
                           <li><a href="{{ pathto('conf/portland/2018/prospectus') }}">Prospectus</a></li>
                       </ul>
                   </li>

--- a/docs/conf/portland/2018/about.rst
+++ b/docs/conf/portland/2018/about.rst
@@ -2,25 +2,18 @@
 :banner: _static/2018/assets/headers/team.png
 
 
-About the conference
+About the Conference
 ====================
 
-We invite you to join hundreds of other folks for a three-day event to explore
-the art and science of documentation. The Write the Docs Portland
-conference covers any topic related to documentation in the software industry.
-Past talks have also covered such diverse topics as empathy, the history of math
-symbols, and using emoji to keep your users' attention.
+We invite you to join hundreds of other folks for a three-day event to explore the art and science of documentation.
+The Write the Docs Portland conference covers any topic related to documentation in the software industry.
+Past talks have also covered such diverse topics as empathy, the history of math symbols, and using emoji to keep your users' attention.
 
-Write the Docs brings *everyone* who writes the docs together in the same room:
-Writers, Developers, Developer Relations, and Support Staff. We all have things
-to learn, and there's no better way than coming together in the same room and
-getting to know each other.
+Write the Docs brings *everyone* who writes the docs together in the same room: Writers, Developers, Developer Relations, and Support Staff.
+We all have things to learn, and there's no better way than coming together in the same room and getting to know each other.
 
- The main presentation track takes place from **May 7-8 (Monday and Tuesday)
- from 9am to 6pm**. We will return to the historic `Crystal Ballroom
- <http://www.mcmenamins.com/CrystalBallroom>`_,  `centrally located
- <http://goo.gl/maps/D2WrJ>`_ in the heart of Portland. During the main event we
- also run a :doc:`/conf/portland/2018/unconference`, downstairs in Lola's Room.
+The main presentation track takes place from **May 7-8 (Monday and Tuesday) from 9am to 6pm**.
+We will return to the historic `Crystal Ballroom <http://www.mcmenamins.com/CrystalBallroom>`_, `centrally located <http://goo.gl/maps/D2WrJ>`_ in the heart of Portland.
+During the main event we also run an :doc:`/conf/portland/2018/unconference` downstairs in Lola's Room.
 
-You can find out more information about the venue and its accessibility on our
-:doc:`/conf/portland/2018/venue` page.
+You can find out more information about the venue and its accessibility on our :doc:`/conf/portland/2018/venue` page.

--- a/docs/conf/portland/2018/cfp.rst
+++ b/docs/conf/portland/2018/cfp.rst
@@ -1,7 +1,7 @@
 :template: 2018/na/generic.html
 :banner: _static/2018/assets/headers/speakers.jpg
 
-Call for proposals
+Call for Proposals
 ==================
 
 Hello hello, fellow documentarians! It's that time of year again: We’re very excited to announce that we are now accepting talk proposals for our next North American conference, coming up on **May 6-8, 2018, in Portland, Oregon**.

--- a/docs/conf/portland/2018/hike.rst
+++ b/docs/conf/portland/2018/hike.rst
@@ -4,67 +4,48 @@
 Write the Docs Hike
 ===================
 
-One of the organizers, Eric Holscher, knows a ton about hiking in the
-Portland area, and would love to show off a side of Portland visitors
-don't often see.
+Every year we have a conference hike, and at this point it's a fantastic tradition.
+We'll be doing the same hike again this year, because it's the best one easily accessible from downtown Portland.
 
-Every year we have a conference hike, at this point it's a fantastic
-tradition. We'll be doing the same hike again this year, because it's
-the best one easily accessible from downtown Portland.
-
-It's rained on us the past couple years, but I have faith it will be
-beautiful this year! We shall see Mount Hood at the top :)
+It's rained on us the past, but we have faith it will be beautiful this year! We shall see Mount Hood at the top :)
 
 Logistics
 ---------
 
--  Date & Time: Leaves promptly at **Saturday, May 5, 2 PM**. Meet at
-   **1:45**.
--  Start: **Lower Macleay Park** or `Macleay Park
-   Entrance <https://maps.google.com/maps?q=Macleay+Park+Entrance&fb=1&gl=us&hq=Macleay+Park+Entrance&hnear=0x54950b0b7da97427:0x1c36b9e6f6d18591,Portland,+OR&cid=0,0,16280654545704357032&t=m&z=16&iwloc=A>`__.
-   There is a pavilion at the park entrance where we will gather.
--  End: **Oregon Zoo** -- There is a MAX stop here to take us back
-   downtown.
--  `Visual of the
-   hike <https://maps.google.com/maps?saddr=MacLeay+Park+Entrance,+NW+Upshur+St,+Portland,+OR&daddr=45.527373,-122.718589+to:45.5225885,-122.717297+to:oregon+zoo&hl=en&ll=45.52448,-122.717757&spn=0.023933,0.032358&sll=45.522345,-122.712822&sspn=0.023934,0.032358&geocode=FYLStgIdMI6v-CGojI77DIHw4SnVqz2N6QmVVDGojI77DIHw4Q%3BFU2xtgIdg3av-CmRNoxzkQmVVDFxAN8jMh2eKQ%3BFZyetgIdj3uv-CnD2fb_jgmVVDHuWX9DnHsevQ%3BFZpttgIdAoGv-CEm_N2esCDn5ykFuFa4LgqVVDEm_N2esCDn5w&oq=macleay+park&gl=us&dirflg=w&mra=dpe&mrsp=2&sz=15&via=1,2&t=m&z=15>`__
+- Date & Time: Leaves promptly at **Saturday, May 5, 2 PM**. Meet at **1:45**.
+- Start: **Lower Macleay Park** or `Macleay Park Entrance <https://maps.google.com/maps?q=Macleay+Park+Entrance&fb=1&gl=us&hq=Macleay+Park+Entrance&hnear=0x54950b0b7da97427:0x1c36b9e6f6d18591,Portland,+OR&cid=0,0,16280654545704357032&t=m&z=16&iwloc=A>`__. There is a pavilion at the park entrance where we will gather.
+- End: **Oregon Zoo** -- There is a MAX stop here to take us back downtown.
+- `Visual of the hike <https://maps.google.com/maps?saddr=MacLeay+Park+Entrance,+NW+Upshur+St,+Portland,+OR&daddr=45.527373,-122.718589+to:45.5225885,-122.717297+to:oregon+zoo&hl=en&ll=45.52448,-122.717757&spn=0.023933,0.032358&sll=45.522345,-122.712822&sspn=0.023934,0.032358&geocode=FYLStgIdMI6v-CGojI77DIHw4SnVqz2N6QmVVDGojI77DIHw4Q%3BFU2xtgIdg3av-CmRNoxzkQmVVDFxAN8jMh2eKQ%3BFZyetgIdj3uv-CnD2fb_jgmVVDHuWX9DnHsevQ%3BFZpttgIdAoGv-CEm_N2esCDn5ykFuFa4LgqVVDEm_N2esCDn5w&oq=macleay+park&gl=us&dirflg=w&mra=dpe&mrsp=2&sz=15&via=1,2&t=m&z=15>`__
 
-We will be hiking in the amazing `Forest
-Park <http://www.forestparkconservancy.org/>`__, the largest urban
-forested park in the country. It is conveniently located in Northwest
-Portland, not far from the conference venue. It's about a 35 minute walk
-from the venue to the park, or you can `take
-transit <https://www.google.com/maps/dir/Crystal+Ballroom,+1332+W+Burnside+St,+Portland,+OR+97209,+United+States/MacLeay+Park+Entrance,+Northwest+Upshur+Street,+Portland,+OR/@45.5290603,-122.707244,15z/data=!3m1!4b1!4m14!4m13!1m5!1m1!1s0x54950a02e43decb9:0xe289ad93ad758c66!2m2!1d-122.68483!2d45.522785!1m5!1m1!1s0x549509e98d3dabd5:0xe1f0810cfb8e8ca8!2m2!1d-122.712528!2d45.535874!3e3?hl=en>`__
-to make it a bit quicker.
+We will be hiking in the amazing `Forest Park <http://www.forestparkconservancy.org/>`__, the largest urban forested park in the country.
+It is conveniently located in Northwest Portland, not far from the conference venue. It's about a 35 minute walk
+from the venue to the park, or you can `take transit <https://www.google.com/maps/dir/Crystal+Ballroom,+1332+W+Burnside+St,+Portland,+OR+97209,+United+States/MacLeay+Park+Entrance,+Northwest+Upshur+Street,+Portland,+OR/@45.5290603,-122.707244,15z/data=!3m1!4b1!4m14!4m13!1m5!1m1!1s0x54950a02e43decb9:0xe289ad93ad758c66!2m2!1d-122.68483!2d45.522785!1m5!1m1!1s0x549509e98d3dabd5:0xe1f0810cfb8e8ca8!2m2!1d-122.712528!2d45.535874!3e3?hl=en>`__ to make it a bit quicker.
 
 **Note**
 
-The hike does not end where it starts. Take this into consideration with
-your planning. There is an out-and-back option if you choose to just go
-to Pittock Mansion, then return back down.
+The hike does not end where it starts. Take this into consideration when you plan.
+There is an out-and-back option if you choose to just go to Pittock Mansion, then return back down.
 
 What to bring
 ~~~~~~~~~~~~~
 
-May in Portland can be interesting. It will probably be in the 60s, with
-a chance of rain. So, please bring:
+May in Portland can be interesting. It will probably be in the 60s, with a chance of rain. So, please bring:
 
--  Comfortable shoes, that you are comfortable getting a bit muddy.
--  1 Liter of water. There is water available halfway through the hike.
--  A light rain jacket. It won't be cold, but it might drizzle on you.
--  High spirits!
+- Comfortable shoes, that you are comfortable getting a bit muddy.
+- 1 Liter of water. There is water available halfway through the hike.
+- A light rain jacket. It won't be cold, but it might drizzle on you.
+- High spirits!
 
 The hike
 --------
 
-The hike will be around 5 miles long, and have 1000 feet of elevation
-gain. This classifies as a *moderate* hike. We'll be going nice and slow
-so people can appreciate the views and forest.
+The hike will be around 5 miles long, and have 1000 feet of elevation gain.
+This classifies as a *moderate* hike. We'll be going nice and slow so people can appreciate the views and forest.
 
 Meander
 ~~~~~~~
 
-It will follow Balch Creek up from the entrance of `Forest
-Park <http://www.forestparkconservancy.org/>`__.
+The hike will follow Balch Creek up from the entrance of `Forest Park <http://www.forestparkconservancy.org/>`__.
 
 .. figure:: /_static/img/2015/hike/balch.jpg
    :alt: Balch Creek
@@ -74,9 +55,8 @@ Park <http://www.forestparkconservancy.org/>`__.
 Climb
 ~~~~~
 
-Then we will switchback through beautiful forest until we get to Pittock
-Mansion. Pittock affords one of the best views of the city, and
-hopefully Mt. Hood & Mt. St. Helens if it's clear!
+Then we will switchback through beautiful forest until we get to Pittock Mansion.
+Pittock affords one of the best views of the city, and hopefully Mt. Hood & Mt. St. Helens if it's clear!
 
 .. figure:: /_static/img/2015/hike/pittock.jpg
    :alt: The view from Pittock Mansion
@@ -86,17 +66,12 @@ hopefully Mt. Hood & Mt. St. Helens if it's clear!
 Admire
 ~~~~~~
 
-After this we will descend into `Washington
-Park <http://washingtonparkpdx.org/>`__, and the beautiful `Hoyt
-Arboretum <http://www.hoytarboretum.org/>`__. There are a number of
-paths through Hoyt, and we can play that by ear. More than 5,800
-specimens from around the world grow here, including more than 1,100
-species, which are valuable in reforesting damaged habitats.
+After this we will descend into `Washington Park <http://washingtonparkpdx.org/>`__, and the beautiful `Hoyt Arboretum <http://www.hoytarboretum.org/>`__.
+There are a number of paths through Hoyt, and we can play that by ear.
+More than 5,800 specimens from around the world grow here, including more than 1,100 species, which are valuable in reforesting damaged habitats.
 
 Finish
 ~~~~~~
 
-On the other side of Hoyt is the `Oregon
-Zoo <http://www.oregonzoo.org/>`__, where we can take the MAX back to
-downtown. People who wish to stay around in the park or zoo are more
-than welcome.
+On the other side of Hoyt is the `Oregon Zoo <http://www.oregonzoo.org/>`__, where we can take the MAX back to downtown.
+People who wish to stay around in the park or zoo are more than welcome.

--- a/docs/conf/portland/2018/lightning-talks.rst
+++ b/docs/conf/portland/2018/lightning-talks.rst
@@ -6,119 +6,77 @@
 Lightning Talks
 ~~~~~~~~~~~~~~~
 
-A lightning talk is a very short talk where you share an idea, concept,
-or a bit of information you find interesting. They’re quick, easy, and a
-great way to practice. (Lovely example
-`*here* <https://www.youtube.com/watch?feature=player_embedded&v=6wcP1aMl7wQ#t=942>`__!)
+A lightning talk is a very short talk where you share an idea, concept, or a bit of information you find interesting.
+They’re quick, easy, and a great way to practice. (Lovely example `*here* <https://www.youtube.com/watch?feature=player_embedded&v=6wcP1aMl7wQ#t=942>`__!)
 
-Planning: What Goes into a Lightning Talk?
+Planning: What goes into a lightning talk?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A lightning talk should be about **five minutes long**, just long enough
-to give an overview and make people curious about your topic. You can
-talk about anything that’s related to the event’s general theme (in the
-case of Write the Docs, anything even remotely related to
-documentation).
+A lightning talk should be about **five minutes long**, just long enough to give an overview and make people curious about your topic. You can talk about anything that’s related to the event’s general theme (in the case of Write the Docs, anything even remotely related to documentation).
 
 First, you need a **topic**. Your topic might be:
 
--  A concept, process, or tool that you learned recently or are still
-   learning
+- A concept, process, or tool that you learned recently or are still learning
+- An idea for a website or product that would solve a problem you have
+- A retrospective, or what went right/wrong during a project you did or are doing
+- Anything relevant that the audience might be interested in knowing more about
 
--  An idea for a website or product that would solve a problem you have
-
--  A retrospective, or what went right/wrong during a project you did or
-   are doing
-
--  Anything relevant that the audience might be interested in knowing
-   more about
-
-Next, you need an **outline** for the content. Think about the
-**audience**, and the **goal** of your talk. Choose points to make that
-will be understandable by the audience and achieve your presentation
-goal. Remember how quickly five minutes goes by when choosing what to
-include!
+Next, you need an **outline** for the content. Think about the **audience**, and the **goal** of your talk. Choose points to make that will be understandable by the audience and achieve your presentation goal. Remember how quickly five minutes goes by when choosing what to include!
 
 Potential **points of interest** might be:
 
--  What could you use this for or when could you use it? Have you
-   already used it? How?
+- What could you use this for or when could you use it? Have you already used it? How?
+- When wouldn't it not be as useful? What are some contraindications to using it?
+- Resources related to the subject, including books, documentation, and URLs.
+- Are there any projects or companies that are using what you're sharing?
+- Is this something you'd like to collaborate with others on? Feel free to ASK!
+- What are some of the challenges related to using, building, or configuring what you're showing?
 
--  When wouldn't it not be as useful? What are some contraindications to
-   using it?
-
--  Resources related to the subject, including books, documentation, and
-   URLs.
-
--  Are there any projects or companies that are using what you're
-   sharing?
-
--  Is this something you'd like to collaborate with others on? Feel free
-   to ASK!
-
--  What are some of the challenges related to using, building, or
-   configuring what you're showing?
-
-Preparation: Slides are Optional
+Preparation: Slides are optional
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You absolutely don’t need slides. However, if you’d like to make slides,
-use anything that you are comfortable with. Don’t worry if it doesn’t
-look polished, lightning talks don’t need to be! You might use Microsoft
-Word, Keynote, a PDF, or a web site. Even a simple terminal or console
-window where you enter commands can work well for presenting your ideas.
+You absolutely don’t need slides. However, if you’d like to make slides, use anything that you are comfortable with.
+Don’t worry if it doesn’t look polished, lightning talks don’t need to be!
+You might use Microsoft Word, Keynote, a PDF, or a website.
+Even a simple terminal or console window where you enter commands can work well for presenting your ideas.
 
-Keep in mind that the projector will be lower resolution, typically
-1024x768, and that low-contrast slides don't present well. You’ll also
-need to make your terminal or console font very large so that everyone
-can see what you’re typing. If you're running code examples, have them
-written, debugged, and ready to go. Watching someone write code as they
-go can be great in a longer deep-dive type of talk, but it's not very
-well-suited to a lightning talk.
+Keep in mind that the projector will be lower resolution, typically 1024x768, and that low-contrast slides don't present well.
+You’ll also need to make your terminal or console font very large so that everyone can see what you’re typing.
+If you're running code examples, have them written, debugged, and ready to go.
+Watching someone write code as they go can be great in a longer deep-dive type of talk, but it's not very well-suited to a lightning talk.
 
-Live Demos: Proceed at Your Own Risk
+Live Demos: Proceed at your own risk
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-You may have the urge to do a live demonstration of the thing you’re
-talking about. It seems like an easy way to help the audience see your
-vision, and it is… if it works! Following Murphy’s Law, however, we can
-deduce that your live demo will go horribly wrong. A failed demo can
-derail all but the most skilled presenters, but if you choose to do a
-demo and it goes wrong don’t worry! Have a backup story to tell that
-explains what the demo would have shown and revert to it if necessary.
+You may have the urge to do a live demonstration of the thing you’re talking about.
+It seems like an easy way to help the audience see your vision, and it is… if it works!
+Following Murphy’s Law, however, we can deduce that your live demo will go horribly wrong.
+A failed demo can derail all but the most skilled presenters, but if you choose to do a demo and it goes wrong don’t worry!
+Have a backup story to tell that explains what the demo would have shown and revert to it if necessary.
 
-Presenting: Your Own Five Minutes on Stage!
+Presenting: Your own five Minutes on stage!
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Take a deep breath and go for it. You are among friends, and nobody will
-mind if you make mistakes. Almost everyone starts out their public
-speaking career in the tech industry by giving lightning talks, so you
-can assume your audience has been in your shoes before. Throw caution to
-the wind and embrace your five minutes! :)
+Take a deep breath and go for it. You are among friends, and nobody will mind if you make mistakes.
+Almost everyone starts out their public speaking career in the tech industry by giving lightning talks, so you can assume your audience has been in your shoes before. Throw caution to the wind and embrace your five minutes! :)
 
-Be sure to bring everything you need to do your presentation. It’s wise
-to assume that the internet access will fail precisely when you need it.
-Load web pages you need into your browser beforehand. Bring the adapters
-you'd normally need to connect your laptop to a monitor or projector,
-and keep a backup copy of your presentation on a USB memory stick –
-laptops can and do fail, and this will allow you to use someone else’s
-laptop if the need arises.
+Equipment: Be self-sufficient
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Be sure to bring everything you need to do your presentation.
+It’s wise to assume that the internet access will fail precisely when you need it.
+Load web pages you need into your browser beforehand.
+Bring the adapters you'd normally need to connect your laptop to a monitor or projector, and keep a backup copy of your presentation on a USB memory stick – laptops can and do fail, and this will allow you to use someone else’s laptop if the need arises.
 
 Finishing up
 ~~~~~~~~~~~~
 
-If you have your slide presentation or example code available online you
-can let the group know where to find it if you want to share it. Curious
-people may follow up with you if they’d like to collaborate or have
-feedback about your presentation.
+If you have your slide presentation or example code available online you can let the group know where to find it if you want to share it.
+Curious people may follow up with you if they’d like to collaborate or have feedback about your presentation.
 
 License
 ~~~~~~~
 
-Thanks to the lovely Portland Python Users Group for use of this
-content.
+Thanks to the lovely Portland Python Users Group for use of this content.
 
-Lightning Talks: A Guide for Beginners by Michelle Rowley of PDX Python
-is licensed under a `Creative Commons
-Attribution-NonCommercial-ShareAlike 4.0 International
-License <http://creativecommons.org/licenses/by-nc-sa/4.0/>`__.
+Lightning Talks: A Guide for Beginners by Michelle Rowley of PDX Python is licensed under a `Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License <http://creativecommons.org/licenses/by-nc-sa/4.0/>`__.

--- a/docs/conf/portland/2018/sponsors/index.rst
+++ b/docs/conf/portland/2018/sponsors/index.rst
@@ -1,11 +1,10 @@
 :template: 2018/na/generic.html
 
-Sponsor
-=======
+Sponsors
+========
 
-We are seeking corporate partners to help us create the best conference
-possible. Contact us at sponsorship@writethedocs.org for more
-information on sponsoring Write the Docs.
+We are seeking corporate partners to help us create the best conference possible.
+Contact us at sponsorship@writethedocs.org for more information on sponsoring Write the Docs.
 
 Sponsors
 --------

--- a/docs/conf/portland/2018/team.rst
+++ b/docs/conf/portland/2018/team.rst
@@ -1,12 +1,11 @@
 :template: 2018/na/generic.html
 :banner: _static/2018/assets/headers/team.png
 
-Staff
-===========
+Meet the Team
+=============
 
 Our conference is run by a dedicated team consisting mostly of volunteers.
-This page outlines the folks who are helping get things done,
-and what their roles are.
+This page outlines the folks who are helping get things done, and what their roles are.
 
 Folks
 -----
@@ -50,16 +49,15 @@ You can read descriptions of all the roles in our :doc:`/organizer-guide/confs/e
 * **Swag coordinator** - Mikey Ariel
 * **Speaker wrangler** - Kelly O'Brien
 * **Infrastructure chair** - Samuel Wright
-* **Writing Day coordinator** - TBA
+* **Writing Day coordinator** - Shaun McCance
 * **Unconference coordinator** - TBA
 * **Lightning Talk coordinator** - TBA
-* **Workshop coordinator** - TBA
-* **Communication chair** - TBA
+* **Communication chair** - Mikey Ariel
 * **Volunteer coordinator** - TBA
 * **Sponsorship lead** - Eric Holscher
 * **Job Fair coordinator** - TBA
 * **Explore Portland coordinator** - TBA
 * **Welcome Wagon coordinators** - TBA
-* **Social media chair** - TBA
+* **Social media chair** - Mikey Ariel
 * **Hike coordinator** - Eric Holscher
 * **Emcee** - TBA

--- a/docs/conf/portland/2018/unconference.rst
+++ b/docs/conf/portland/2018/unconference.rst
@@ -4,60 +4,37 @@
 Unconference
 ============
 
-Our unconference sessions provided an outlet
-for the community to share ideas and discuss problems at a deeper level
-than we could on just the main stage of the conference.
+Our unconference sessions provided an outlet for the community to share ideas and discuss problems at a deeper level than we could on just the main stage of the conference.
 
-If you've never attended an unconference, expect to interact closely
-with others from the community. Anyone from the community can suggest
-and lead a session on a topic, which could be a presentation, a group
-discussion on a particular problem, or anything in between.
+If you've never attended an unconference, expect to interact closely with others from the community.
+Anyone from the community can suggest and lead a session on a topic, which could be a presentation, a group discussion on a particular problem, or anything in between.
 
-Leading a Session
+Leading a session
 -----------------
 
-There is no stage in an unconference, talks instead focus on community
-interaction. While standard presentations can work, the format lends
-better to discussions within your group.
+There is no stage in an unconference, and talks instead focus on community interaction.
+While standard presentations can work, the format lends better to discussions within your group.
 
-Whether you have a topic in mind, or maybe just a problem you would like to pose
-to the rest of the community, there is no wrong way to lead an unconference
-session. Here are a few ideas of how to structure your session, borrowed from
-`Scott Berkun's post on unconference sessions
-<http://scottberkun.com/2006/how-to-run-a-great-unconference-session/>`__:
+Whether you have a topic in mind, or maybe just a problem you would like to pose to the rest of the community, there is no wrong way to lead an unconference session.
+Here are a few ideas of how to structure your session, borrowed from `Scott Berkun's post on unconference sessions <http://scottberkun.com/2006/how-to-run-a-great-unconference-session/>`__:
 
 -  **Group discussion** - Pick a topic and facilitate a group discussion
--  **The semi-talk** - Use a short presentation to lead into a group
-   discussion on a topic
--  **Show and tell** - Show off your latest project, a new tool, or
-   anything else you are excited about
--  **Presentation** - Because sessions are meant to be small and
-   inclusive, this is a difficult format to lead a session with. You
-   cannot rely on slides, because you will not have a screen to present
-   with. Feel free to present a longer talk, but expect more interaction
-   from others joining the session and break often for questions and
-   discussion
+-  **The semi-talk** - Use a short presentation to lead into a group discussion on a topic
+-  **Show and tell** - Show off your latest project, a new tool, or anything else you are excited about
+-  **Presentation** - Because sessions are meant to be small and inclusive, this is a difficult format to lead a session with. You cannot rely on slides, because you will not have a screen to present with. Feel free to present a longer talk, but expect more interaction from others joining the session and break often for questions and discussion
 
-Schedule a Session
+Scheduling a session
 ------------------
 
-Attendees that wish to lead an unconference session have several options for
-signing up. We will have a board
-with all of the sessions for the unconference track each day, simply post your
-talk topic on the board if you would like to speak.
+Attendees that wish to lead an unconference session have several options for signing up.
+We will have a board with all of the sessions for the unconference track each day, simply post your talk topic on the board if you would like to speak.
 
-The first chance you will get to post your presentation is on Sunday, at
-our Writing Day event and preregistration party.
-If you don't make it to the Writing Day event or preregistration party,
-be sure to find the board when you first arrive at the conference
-to post your topic.
+The first chance you will get to post your presentation is on Sunday, at our Writing Day event and preregistration party.
+If you don't make it to the Writing Day event or preregistration party, be sure to find the board when you first arrive at the conference to post your topic.
 
-We will start promoting the unconference sessions early in the day on
-the days of the conference, so be sure to post your topic early.
+We will start promoting the unconference sessions early in the day on the days of the conference, so be sure to post your topic early.
 
 Sessions
 --------
 
-Unconference sessions will begin after lunch both days, running until
-the end of the day. We will start the unconference sessions off each day
-with some time for focus on one of several topics.
+Unconference sessions will begin after lunch on Monday, and run throughout Monday afternoon and allday Tuesday. We will start the unconference sessions off each day with some time for focus on one of several topics.

--- a/docs/conf/portland/2018/venue.rst
+++ b/docs/conf/portland/2018/venue.rst
@@ -1,19 +1,15 @@
 :template: 2018/na/generic.html
 :banner: _static/2018/assets/headers/venue.png
 
-Venue
------
+About the Venue
+---------------
 
-This year's Portland conference will be held at the `Crystal Ballroom`_.
-It is a beautiful concert venue located in the `middle of downtown`_ Portland.
-It has been a wonderful venue for us the past few years,
-and we expect this to be another wonderful year.
+This year's Portland conference will be held at the `Crystal Ballroom`_. It is a beautiful concert venue located in the `middle of downtown`_ Portland. It has been a wonderful venue for us the past few years, and we expect this to be another wonderful year.
 
 Accessibility
 ~~~~~~~~~~~~~
 
-All conference spaces at the Crystal Ballroom are wheelchair accessible,
-except for the balcony where there are no events.
+All conference spaces at the Crystal Ballroom are wheelchair-accessible, except for the balcony where there are no events.
 
 The venue has:
 
@@ -21,7 +17,7 @@ The venue has:
 * elevators that are open and unlocked during all conference events
 * accessible, clearly labeled restrooms
 
-Low Vision or Hard of Hearing
+Low vision or hard of hearing
 *****************************
 
 Preferred seating will be provided for attendees who request it. Please contact us about any lighting requirements you may have, and we will do our best to meet them.
@@ -31,8 +27,7 @@ All transit in Portland announce stops verbally in English. Most buses have a vi
 Dietary requirements
 ********************
 
-We aim to meet all dietary requirements. Our menu and ingredients are described
-below, although one or two items are still subject to change.
+We aim to meet all dietary requirements. Our menu and ingredients will be posted closer to the conference dates.
 
 Restrooms
 *********
@@ -46,7 +41,7 @@ Quiet room
 
 We will have a clearly marked quiet/lactation room available. This room is intended to be a calm and quiet place for anyone who needs to have a break from the bustle of the conference, and will not be used for socializing.
 
-Other Venues
+Other venues
 ************
 
 We are still working on confirming accessibility at our other conference venues.

--- a/docs/conf/portland/2018/visiting.rst
+++ b/docs/conf/portland/2018/visiting.rst
@@ -6,8 +6,8 @@
 Visiting Portland
 =================
 
-Wondering where to stay and how to get around once you get into Portland? The conference will be held at the `Crystal
-Ballroom <http://www.mcmenamins.com/CrystalBallroom>`__, in downtown Portland, and most conference events will be held within just a few blocks of the Crystal Ballroom.
+Wondering where to stay and how to get around once you get into Portland?
+The conference will be held at the `Crystal Ballroom <http://www.mcmenamins.com/CrystalBallroom>`__, in downtown Portland, and most conference events will be held within just a few blocks of the Crystal Ballroom.
 
 Eating
 ------
@@ -47,11 +47,8 @@ The venue is along Burnside Street at 14th Ave, just east of the I-405 underpass
 
 Streetcars and Buses
 --------------------
+
 Portland has a `separate streetcar network <http://www.portlandstreetcar.org/>`__ which criss-crosses the MAX lines. These, along with Portland's extensive `bus network <http://trimet.org/bus/>`__, ought to suffice.
-
-The streetcar loop lines are also under construction, but only through Saturday 14 May. This means their detours will only matter during the day of the hike. They may be your lifeline during the rest of the conference.
-
-The streetcars run along 10th and 11th Avenues. The closest stops to the venue are also on Couch Street. There is also a Whole Foods Market at NW Couch & 12th Ave. See the `Streetcar Loop detour map <http://news.trimet.org/wordpress/wp-content/uploads/2018/04/Morrison-Yamhill-MAX-Improvements-Streetcar-Service-Map.png>`__ for details.
 
 Taxi Companies
 ~~~~~~~~~~~~~~

--- a/docs/conf/portland/2018/welcome-wagon.rst
+++ b/docs/conf/portland/2018/welcome-wagon.rst
@@ -8,63 +8,45 @@ Hello!
 
 We're your Welcome Wagon, and we're glad you're coming to Write the Docs!
 Feel free to tweet us at `@canncrochet <https://twitter.com/canncrochet>`__ or `@runleonarun <https://twitter.com/runleonarun>`__.
-You can also email
-`Christy <mailto:canncrochet@gmail.com>`__ or
-`Leona <mailto:leona.campbell@jivesoftware.com>`__ if we can help make
-your first time at the conference easier.
-When you get to the conference,
-come :ref:`say hello <say-hello>`.
+You can also email `Christy <mailto:canncrochet@gmail.com>`__ or `Leona <mailto:leona.campbell@jivesoftware.com>`__ if we can help make your first time at the conference easier. When you get to the conference, come :ref:`say hello <say-hello>`.
 
-We've gathered important stuff here that will help you navigate the
-conference like a pro, make you feel more at home, and help you to
-manage the constant flow of information. The Welcome Wagon events warm
-up new attendees and connect them with people, both veterans and other
-first-timers. Strategies and pro tips provide ways you can make the most
-of the conference. The FAQs strive to answer questions before you even
-have them.
+We've gathered important stuff here that will help you navigate the conference like a pro, make you feel more at home, and help you to manage the constant flow of information.
+The Welcome Wagon events warm up new attendees and connect them with people, both veterans and other first-timers.
+Strategies and pro tips provide ways you can make the most of the conference. The FAQs strive to answer questions before you even have them.
 
 Welcome Wagon events
 --------------------
 
-
 **Write the Docs Welcome Wagon Introduction**
 
-*Sunday, May 14th at 18:00 in Lola’s Room*
+*Sunday, May 6th at 18:00 in Lola’s Room*
 
 Join us for an informal Introduction to Write the Docs, to the Welcome Wagon, and to other first-time conference attendees. We’ll pass on some information about the conference specifically for first-timers and give everyone a chance to meet someone new, before we join the opening reception.
 
-
 **Welcome Wagon Tours**
 
-*Sunday, May 14th throughout the day and Monday, May 15th at 8:00 starting in the Crystal Ballroom*
+*Sunday, May 6th throughout the day and Monday, May 7th at 8:15 starting in the Crystal Ballroom*
 
 Come on a short tour of the venue with a veteran Write the Docs attendee so you’ll know where everything is and everything you can take part in.
 
 **Welcome Wagon Check-In**
 
-*Tuesday, May 16th at 8:00 in Lola’s Room*
+*Tuesday, May 8th at 8:15 in Lola’s Room*
 
 Meet back up with the Welcome Wagon and fellow first-timers to check-in about how the conference is going for you. Ask any questions you have, pass on stories from your first day, and let the Welcome Wagon know if there is anything you need to make your second day as successful as your first one.
 
 Pro Tips
 --------
 
--  You don't need to go to every talk. Look through the schedule of
-   events before you arrive or while you are eating or taking a break.
-   Figure out which talks you want to see the most. Spread out your time
-   between talks, unconference sessions, networking, and breaks.
--  Speaking of breaks--conferences are exhilarating, but can also be
-   exhausting. Give your brain a break! Grab a quiet spot in Lola's Room
-   or take a quick walk. Play a board game on your lunch break. Come
-   back invigorated.
--  Starting Monday morning, check the unconference schedule in Lola's
-   Room to see if there are any sessions you are interested in
-   attending. New sessions are added all the time, so check back
-   periodically.
--  Eat! You can use the energy.
--  Are you looking for a job or is there an opening at your company?
-   Check out the job board in Lola's Room.
+-  You don't need to go to every talk. Look through the schedule of events before you arrive or while you are eating or taking a break. Figure out which talks you want to see the most. Spread out your time between talks, unconference sessions, networking, and breaks.
 
+-  Speaking of breaks--conferences are exhilarating, but can also be exhausting. Give your brain a break! Grab a quiet spot in Lola's Room or take a quick walk. Play a board game on your lunch break. Come back invigorated.
+
+-  Starting Monday morning, check the unconference schedule in Lola's Room to see if there are any sessions you are interested in attending. New sessions are added all the time, so check back periodically.
+
+-  Eat! You can use the energy.
+
+-  Are you looking for a job or is there an opening at your company? Check out the job board in Lola's Room.
 
 FAQs
 ----
@@ -72,191 +54,107 @@ FAQs
 .. contents::
    :local:
 
-**Where is everything?**
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-The conference main stage is in the Crystal Ballroom on the third floor
-at 1332 West Burnside Street.
-
-The unconference takes place directly below the Crystal Ballroom, in
-Lola's Room.
-
-If you are joining in the hike on Saturday, you'll meet the other hikers
-at the Macleay Park Entrance at 2960 NW Upshur Street. You can take
-public transportation or a taxi there.
-
-**How should I get around?**
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
--  Portland is a very walk-able town. Most of the events and `the
-   suggested
-   hotels <http://www.writethedocs.org/conf/portland/2018/visiting/>`__ are
-   within walking distance of the conference venue, the Crystal
-   Ballroom.
--  There are good public transportation options and taxi services. Check
-   out the `Visiting Portland section of the Write the Docs
-   website <http://www.writethedocs.org/conf/portland/2018/visiting/>`__ for
-   more info.
-
-**How should I dress?**
-~~~~~~~~~~~~~~~~~~~~~~~
-
--  Portland is a casual-dress town and so is the Write the Docs
-   conference. You'll be meeting business colleagues at this conference,
-   though, so neat and comfortable are good dress guidelines.
--  If you are going on the `Write the Docs hike on
-   Saturday <http://www.writethedocs.org/conf/portland/2018/hike/>`__, be sure
-   to bring appropriate hiking clothes and shoes. This time of year, the
-   Pacific Northwest tends to be muddy or raining with occasional swaths
-   of blue skies. Layering is usually the way to go.
-
-**What will I eat?**
+Where is everything?
 ~~~~~~~~~~~~~~~~~~~~
 
--  Drinks and food are provided for you on conference days, so you can
-   focus on the talks and meeting people and don't have to worry about
-   where to get your morning coffee.
--  Coffee, tea, and water are always available in the Crystal Ballroom.
-   Bring a water bottle to make it easier for you to stay hydrated.
--  Food is provided on Monday and Tuesday in the Crystal Ballroom. There
-   is a light breakfast, a solid lunch, and snacks on each conference
-   day.
--  On Saturday, Sunday, and in the evening on Monday and Tuesday,
-   `explore Portland's amazing food
-   scene <http://www.writethedocs.org/conf/portland/2018/visiting/>`__. Invite
-   someone you just met to join you! If you are invited to dinner, say
-   yes! Making connections over dinner is a great way to get to know
-   more people.
--  If you need grocery items, there is a Whole Foods just down the
-   street from the conference venue at 1210 NW Couch St, Portland, OR 97209.
+The conference main stage is in the Crystal Ballroom on the third floor at 1332 West Burnside Street.
 
-**Where should I sit?**
-~~~~~~~~~~~~~~~~~~~~~~~
+The unconference takes place directly below the Crystal Ballroom, in Lola's Room.
 
--  The Crystal Ballroom will have round tables next to the main stage
-   and rows of seats behind them.
+If you are joining in the hike on Saturday, you'll meet the other hikers at the Macleay Park Entrance at 2960 NW Upshur Street. You can take public transportation or a taxi there.
+
+How should I get around?
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+-  Portland is a very walk-able town. Most of the events and `the suggested hotels <http://www.writethedocs.org/conf/portland/2018/visiting/>`__ are within walking distance of the conference venue, the Crystal Ballroom.
+
+-  There are good public transportation options and taxi services. Check out the `Visiting Portland section of the Write the Docs website <http://www.writethedocs.org/conf/portland/2018/visiting/>`__ for more info.
+
+How should I dress?
+~~~~~~~~~~~~~~~~~~~
+
+-  Portland is a casual-dress town and so is the Write the Docs conference. You'll be meeting business colleagues at this conference, though, so neat and comfortable are good dress guidelines.
+
+-  If you are going on the `Write the Docs hike on Saturday <http://www.writethedocs.org/conf/portland/2018/hike/>`__, be sure
+   to bring appropriate hiking clothes and shoes. This time of year, the Pacific Northwest tends to be muddy or raining with occasional swaths of blue skies. Layering is usually the way to go.
+
+What will I eat?
+~~~~~~~~~~~~~~~~
+
+-  Drinks and food are provided for you on conference days, so you can focus on the talks and meeting people and don't have to worry about where to get your morning coffee.
+-  Coffee, tea, and water are always available in the Crystal Ballroom. Bring a water bottle to make it easier for you to stay hydrated.
+-  Food is provided on Monday and Tuesday in the Crystal Ballroom. There is a light breakfast, a solid lunch, and snacks on each conference day.
+-  On Saturday, Sunday, and in the evening on Monday and Tuesday, `explore Portland's amazing food scene <http://www.writethedocs.org/conf/portland/2018/visiting/>`__. Invite someone you just met to join you! If you are invited to dinner, say yes! Making connections over dinner is a great way to get to know more people.
+-  If you need grocery items, there is a Whole Foods just down the street from the conference venue at 1210 NW Couch St, Portland, OR 97209.
+
+Where should I sit?
+~~~~~~~~~~~~~~~~~~~
+
+-  The Crystal Ballroom will have round tables next to the main stage and rows of seats behind them.
 -  There are no reserved seats; feel free to sit anywhere.
--  If you can, show up early to the conference each morning to grab a
-   seat at one of the round tables. Introducing yourself to your
-   neighbors is one of the easiest way to meet people.
+-  If you can, show up early to the conference each morning to grab a seat at one of the round tables. Introducing yourself to your neighbors is one of the easiest way to meet people.
 
-**What should I do during the talks?**
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+What should I do during the talks?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 :doc:`/conf/portland/2018/speakers/`
 
--  The time between talks is for meeting your colleagues or taking a
-   break. During the talks, listen and take in as much as you can.
--  There is a lot of great information at this conference, but don't
-   worry if you miss something! All talks are videotaped, so you can
-   review them later.
--  If you have a question during a talk, make a note of it and use it as
-   a conversation starter with the speaker.
--  After a talk, feel free to tweet about it with the hashtag
-   #writethedocs. Try not to "watch" the conference through Twitter and
-   other social media, though. You are attending the conference, so live
-   in it as much as you can!
+-  The time between talks is for meeting your colleagues or taking a break. During the talks, listen and take in as much as you can.
+-  There is a lot of great information at this conference, but don't worry if you miss something! All talks are recorded and videos will be published shortly after the conference, so you can review them later.
+-  If you have a question during a talk, make a note of it and use it as a conversation starter with the speaker.
+-  After a talk, feel free to tweet about it with the hashtag #writethedocs. Try not to "watch" the conference through Twitter and other social media, though. You are attending the conference, so live in it as much as you can!
 
-**Unconference in Lola's Room**
-
--  Check the schedule posted in Lola's Room for the table number of the
-   unconference talk you are interested in. Head to that table and have
-   a seat.
--  The session leader will begin when the group has gathered.
--  Feel free to just listen or add your voice to the discussion.
-   Unconference talks are designed to get everyone involved.
-
-**How do I take part in the unconference?**
+How do I take part in the unconference?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  The unconference is a set of informal sessions that take place below
-   the Crystal Ballroom in Lola's Room on Monday and Tuesday afternoons.
-   `Unconference talks focus on exchanges of ideas between
-   participants. <http://www.writethedocs.org/conf/portland/2018/unconference/>`__
--  You can attend unconference sessions, or, if you have an idea for a
-   session, you can lead one.
--  To lead an unconference session, post a summary of your topic on a
-   post-it note in an empty spot on the unconference schedule. Make your
-   way down to Lola's Room a few minutes early to introduce yourself to
-   anyone who is attending your session. Once the group has gathered,
-   introduce your topic and get the discussion going.
+-  Check the schedule posted in Lola's Room for the table number of the unconference talk you are interested in. Head to that table and have a seat.
+-  The session leader will begin when the group has gathered.
+-  Feel free to just listen or add your voice to the discussion. Unconference talks are designed to get everyone involved.
+-  The unconference is a set of informal sessions that take place below the Crystal Ballroom in Lola's Room on Monday and Tuesday afternoons. `Unconference talks focus on exchanges of ideas between participants. <http://www.writethedocs.org/conf/portland/2018/unconference/>`__
+-  You can attend unconference sessions, or, if you have an idea for a session, you can lead one.
+-  To lead an unconference session, post a summary of your topic on a post-it note in an empty spot on the unconference schedule. Make your way down to Lola's Room a few minutes early to introduce yourself to anyone who is attending your session. Once the group has gathered, introduce your topic and get the discussion going.
 
-**What are lightning talks, and should I give one?**
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+What are lightning talks, and should I give one?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  A lightning talk is a five-minute talk where you quickly share a
-   concept or bit of info you find interesting.
--  Lightning talks are a great way to practice public speaking, get
-   people excited about your unconference session, and test interest in
-   a conference proposal idea.
--  Do you have an idea, want to talk about a new tool you are learning,
-   or review a process? Then, yes! Sign up for a lightning talk. There
-   will be a sign-up sheet at registration.
--  If you are interested in giving a lightning talk, be prepared! There
-   is a great guide
-   `here <http://www.writethedocs.org/conf/portland/2018/lightning-talks/?highlight=re>`__.
+-  A lightning talk is a five-minute talk where you quickly share a concept or bit of info you find interesting.
+-  Lightning talks are a great way to practice public speaking, get people excited about your unconference session, and test interest in a conference proposal idea.
+-  Do you have an idea, want to talk about a new tool you are learning, or review a process? Then, yes! Sign up for a lightning talk. There will be a sign-up sheet at registration.
+-  If you are interested in giving a lightning talk, be prepared! There is a great guide `here <http://www.writethedocs.org/conf/portland/2018/lightning-talks/?highlight=re>`__.
 
-**How do I make the most out of this conference?**
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+How do I make the most out of this conference?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Attend the Welcome Wagon events. Make connections with other first-time
-attendees and get advice from seasoned pros.
+Attend the Welcome Wagon events. Make connections with other first-time attendees and get advice from seasoned pros.
 
-The most important part of this conference (and any conference) is the
-people you meet. Set a goal for yourself to meet a few, new people. Here
-are some tips:
+The most important part of this conference (and any conference) is the people you meet. Set a goal for yourself to meet a few, new people. Here are some tips:
 
--  Find out who is attending the conference before you get there. Join
-   the `Write the Docs Slack <http://slack.writethedocs.org/>`__, follow
-   the `Write the Docs on Twitter <https://twitter.com/writethedocs>`__,
-   and review the `list of
-   speakers <http://www.writethedocs.org/conf/portland/2018/speakers/>`__.
--  Figure out which companies will be represented at the conference. If
-   you see a job post you're interested in, you might want to ask them a
-   few questions. This might be a great time to better understand what
-   it's like to work at certain companies.
--  Make a list of a few people you would like to meet, and write down
-   some questions for them. If you can find contact information, email
-   them before the conference and let them know you are looking forward
-   to chatting.
--  Most importantly, remember that you don't have to meet everyone. In
-   fact, you shouldn't. You should plan to make a few, meaningful
-   connections. That is what the Write the Docs conference is about, so
-   go for it! Introduce yourself.
+-  Find out who is attending the conference before you get there. Join the `Write the Docs Slack <http://slack.writethedocs.org/>`__, follow the `Write the Docs on Twitter <https://twitter.com/writethedocs>`__,
+   and review the `list of speakers <http://www.writethedocs.org/conf/portland/2018/speakers/>`__.
+-  Figure out which companies will be represented at the conference. If you see a job post you're interested in, you might want to ask them a few questions. This might be a great time to better understand what it's like to work at certain companies.
+-  Make a list of a few people you would like to meet, and write down some questions for them. If you can find contact information, email them before the conference and let them know you are looking forward to chatting.
+-  Most importantly, remember that you don't have to meet everyone. In fact, you shouldn't. You should plan to make a few, meaningful connections. That is what the Write the Docs conference is about, so go for it! Introduce yourself.
 
-**Sample strategy for my first Write the Docs conference**
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sample strategy for my first Write the Docs conference
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  Join the `Write the Docs Slack <http://slack.writethedocs.org/>`__,
-   and participate in the Welcome Wagon chat room to start making
-   conference connections.
--  Make a list of two people who are attending with some notes about
-   them and questions for them. Either reach out by email before the
-   conference to set up a meeting onsite or find them at the conference.
+-  Join the `Write the Docs Slack <http://slack.writethedocs.org/>`__, and participate in the Welcome Wagon chat room to start making conference connections.
+-  Make a list of two people who are attending with some notes about them and questions for them. Either reach out by email before the conference to set up a meeting onsite or find them at the conference.
 -  Attend the Welcome Wagon events.
 -  Join in the Saturday hike.
 -  Attend the Sunday writing day and volunteer to help on one of the projects being worked on.
--  Check out the talk schedule in advance and make note of the talks you
-   don't want to miss.
--  In the morning, or when you need a break during the day, head down to
-   Lola's Room to check out the unconference schedule. Make note of any
-   unconference talks you want to attend.
--  Check out the lightning talks, and get excited about presenting one
-   at next year's conference.
+-  Check out the talk schedule in advance and make note of the talks you don't want to miss.
+-  In the morning, or when you need a break during the day, head down to Lola's Room to check out the unconference schedule. Make note of any unconference talks you want to attend.
+-  Check out the lightning talks, and get excited about presenting one at next year's conference.
 
-**Sample strategy for a second or higher Write the Docs conference**
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sample strategy for a second or higher Write the Docs conference
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  Attend the Welcome Wagon events and share your conference knowledge.
-   You might learn something new yourself!
--  Reach out to some first-time attendees and tell them about your first
-   conference.
+-  Attend the Welcome Wagon events and share your conference knowledge. You might learn something new yourself!
+-  Reach out to some first-time attendees and tell them about your first conference.
 -  Attend the Sunday writing day with your own project. Ask for help!
--  Check out the talk schedule in advance and make note of the talks you
-   don't want to miss.
--  In the morning, or when you need a break during the day, head down to
-   Lola's Room to check out the unconference schedule. Make note of any
-   unconference talks you want to attend.
+-  Check out the talk schedule in advance and make note of the talks you don't want to miss.
+-  In the morning, or when you need a break during the day, head down to Lola's Room to check out the unconference schedule. Make note of any unconference talks you want to attend.
 -  Sign up for a lightning talk or lead an unconference session.
 
 .. _say-hello:
@@ -265,8 +163,7 @@ Say hello
 ---------
 
 We'd love to say hi when you're at the conference.
-Come find us and ask any questions,
-or just chat about the conference!
+Come find us and ask any questions, or just chat about the conference!
 
 .. container:: crew-images
 
@@ -289,10 +186,7 @@ Thanks
 ------
 
 This document was inspired by other conferences doing great work in this area.
-In particular,
-these two documents were heavily used as a reference:
+In particular, these two documents were heavily used as a reference:
 
 * Double your Audience Microconference Guide
 * http://www.pydanny.com/beginners-guide-pycon-2014.html
-
-

--- a/docs/conf/portland/2018/writing-day.rst
+++ b/docs/conf/portland/2018/writing-day.rst
@@ -3,13 +3,19 @@
 
 .. include:: /include/conf/events/writing-day.rst
 
+Writing Day
+===========
+
+Each year on the first day of the conference we hold a Writing Day, where attendees can gather and collaborate on documentarian projects. The Writing Day concept is based heavily on sprints, which are common in open-source developer conferences. The main premise is to give contributors space and time to meet face-to-face and work on projects together.
+
+Specifically at our conference, we also prioritize on-boarding new contributors to documentation projects, and encourage both newcomers and experienced contributors to meet, network, and share ideas that could be worked on.
+
 Logistics
 ^^^^^^^^^
 
 Please bring a computer or some other mechanism with which to create written words.
 
-We'll be creating and editing content,
-so make sure that you have the tools you need to contribute.
+We'll be creating and editing content, so make sure that you have the tools you need to contribute.
 
 - Date & Time: **Sunday, May 6th, 9am-6pm**,
   with the conference opening reception in the same space until 9.
@@ -19,8 +25,8 @@ so make sure that you have the tools you need to contribute.
   + :ref:`writewrite2018`
   + anything else you fancy
 
-Writing Day Schedule
-^^^^^^^^^^^^^^^^^^^^
+Schedule
+^^^^^^^^
 
 ..
   .. datatemplate::
@@ -30,37 +36,28 @@ Writing Day Schedule
 Documenting a new project?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Check out our `beginners guide
-<http://docs.writethedocs.org/writing/beginners-guide-to-docs/>`_ to writing
-documentation. This should help you get started,
-and give you some ideas for how you can contribute to a project that you love.
+Check out our `beginners guide <http://docs.writethedocs.org/writing/beginners-guide-to-docs/>`_ to writing documentation.
+This should help you get started, and give you some ideas for how you can contribute to a project that you love.
 
 .. _writewrite2018:
 
 Write Write the Docs on Writing Day
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This year we're also running a session where you can help improve your favorite
-website. Yup, you can brainstorm improvements, write helpful content and posts,
-or just magically improve `Write the Docs <http://www.writethedocs.org>`_.
+This year we're also running a session where you can help improve your favorite website.
+Yup, you can brainstorm on improvements, write helpful content and posts, or just magically improve `Write the Docs <http://www.writethedocs.org>`_.
 
-If you're writing text to add to the website, ideally you'll already be familiar
-with GitHub and writing in plain text (markdown or restructured text), but we'll
-be there to help out if you're not.
+If you're writing text to add to the website, ideally you'll already be familiar with GitHub and writing in plain text (markdown or restructured text), but we'll be there to help out if you're not.
 
-If you'd rather brainstorm a content reorganization in Google Docs, improve our
-python scripts or our jinja templates we've got plenty to do there as well.
+If you'd rather brainstorm on content reorganization in Google Docs, improve our Python scripts or our jinja templates, we've got plenty to do there as well.
 
-Here are a few things we'll be working on on writing day, reach out to
-`@plaindocs <https://twitter.com/plaindocs>`_ if you have any questions or more
+Here are a few things we'll be working on on writing day, reach out to `@plaindocs <https://twitter.com/plaindocs>`_ if you have any questions or more
 suggestions.
 
-Brainstorm user oriented architecture
-=======================================
+Brainstorm user-oriented architecture
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The website is currently organised around meetups, conferences, guides, etc –
-find ways to introduce user-oriented labels considering audience. Who is coming
-to the site, why? What are the goals of the site?
+The website is currently organised around meetups, conferences, guides, etc – find ways to introduce user-oriented labels considering audience. Who is coming to the site, why? What are the goals of the site?
 
 - Learn about docs
 - Get involved with the community
@@ -69,28 +66,25 @@ to the site, why? What are the goals of the site?
 - Find a video of a talk that I saw
 
 Improve navigation
-===================
+~~~~~~~~~~~~~~~~~~
 
-Let's discuss information architecture -- can we organize the content better?
-Provide better navigation?
+Let's discuss information architecture -- can we organize the content better? Provide better navigation?
 
 Write articles for the newsletter
-====================================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Summarize content from the Slack channel for the `newsletter </blog/newsletter-may-2018/#looking-ahead>`_.
 
 Help develop the Documentation Guide
-===========================================
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Help reorganize the guide content, or write and edit topics. Check out
-:doc:`/guide/index/` ahead of time and bring your ideas to the table!"
+Help reorganize the guide content, or write and edit topics. Check out :doc:`/guide/index/` ahead of time and bring your ideas to the table!
 
 Fix website issues
-===================
+~~~~~~~~~~~~~~~~~~
 
-We have a list of `issues on GitHub
-<https://github.com/writethedocs/www/issues?q=is%3Aissue+is%3Aopen+label%3Awritingday>`_
-tagged as `writingday` that includes things like
+We have a list of `issues on GitHub <https://github.com/writethedocs/www/issues?q=is%3Aissue+is%3Aopen+label%3Awritingday>`_
+tagged as `writingday` that includes things like:
 
 - fix broken links (we have a lot of these)
 - improve the meetup pages


### PR DESCRIPTION
Fixes part of issue #368 

Includes:

- Source file sweep for all content pages in the Portland conf site (mainly formatting and some date fixes)
- Updated navbar (some links were broken and some items needed to shuffle around)
- Minor tweak to the Prague page (boat ride text was too long)