### PR TITLE
update IBM style guide link

### DIFF
--- a/docs/guide/writing/style-guides.md
+++ b/docs/guide/writing/style-guides.md
@@ -36,7 +36,7 @@ Here are some good general resources -- perhaps someone in your company is alrea
 - [Techprose techwriting guidelines (PDF)](http://www.techprose.com/assets/techwriting_guidelines.pdf)
 - [Microsoft manual of style](https://ptgmedia.pearsoncmg.com/images/9780735648715/samplepages/9780735648715.pdf)
 - [Oxford manual of style](https://www.ox.ac.uk/sites/files/oxford/media_wysiwyg/University%20of%20Oxford%20Style%20Guide.pdf)
-- [IBM style guide](https://www.redbooks.ibm.com/Redbooks.nsf/ibmpressisbn/9780132101301?Open)
+- [IBM style guide](https://www.ibm.com/developerworks/library/styleguidelines/)
 - [Handbook of Technical Writing](http://www.macmillanlearning.com/Catalog/product/handbookoftechnicalwriting-eleventhedition-alred)
 
 If you belong to an open-source community or NGO, you can consider the following resources:


### PR DESCRIPTION
(addresses #465 )

In regards to the IBM link, I also found a link to a [PDF](http://ptgmedia.pearsoncmg.com/images/9780132101301/samplepages/0132101300.pdf).

In regards to the Pebble Road and Pressly links, I did some googling ...
- [This](https://www.pebbleroad.com/articles) seems to be the extent of all Pebble Road articles that are currently available to the public.
- [Pressly](https://www.pressly.com/) appears to have been acquired by another entity. Not sure what this means for its previously existing blog posts.

What are your thoughts? Should we just remove those latter two links? And should we notify Ivan Walsh? 🤔 
