### PR TITLE
No breakfast or lunch included in cincinnati 2018 tickets

### DIFF
--- a/docs/conf/cincinnati/2018/tickets.rst
+++ b/docs/conf/cincinnati/2018/tickets.rst
@@ -12,7 +12,7 @@ Tickets
 Each ticket includes:
 
 * Entry to all conference events and activities
-* Breakfast, snacks, and lunch on all conference days
+* Snacks and drinks on all conference days
 * Welcome Reception and Social Event with light snacks and free drinks
 * Wifi throughout the event
 * Meeting lots of fantastic people in a spacious, inviting venue


### PR DESCRIPTION
We decided not to include breakfast or lunch initially to keep costs down. We might add some meals if we have extra sponsor money.