### PR TITLE
update number of tips (again) to seven

### DIFF
--- a/docs/_data/2018.portland.speakers.yaml
+++ b/docs/_data/2018.portland.speakers.yaml
@@ -96,17 +96,18 @@
 - abstract: "<p>These core principles have guided me during my (almost) two decades in the business. I'll share some real-world stories to show what kind of results you can expect.</p>
 <p>The tips:<ul>
 <li>Just ask.</li>
-<li>Listen.</li>
-<li>Tell stories.</li>
-<li>Own your stuff.</li>
-<li>Minimum content.</li>
+<li>Listen for intent.</li>
+<li>Create the minimum thing.</li>
+<li>Cultivate ownership, individual and product.</li>
 <li>Be a lifelong learner.</li>
+<li>Opt in.</li>
+<li>Use the power of storytelling.</li>
 <p>There might even be a surprise bonus tip.</p>"
   event: Write the Docs PORTLAND 2018
-  path: conf/portland/2018/videos/eight-essential-tips-for-the-enlightened-tech-writer-ted-hudek
+  path: conf/portland/2018/videos/7-essential-tips-for-the-enlightened-tech-writer-ted-hudek
   series: Write the Docs PORTLAND
   series_slug: portland
-  slug: eight-essential-tips-for-the-enlightened-tech-writer-ted-hudek
+  slug: 7-essential-tips-for-the-enlightened-tech-writer-ted-hudek
   speakers:
   - details: ''
     img_file: ted-hudek.jpg
@@ -114,7 +115,7 @@
     slug: ted-hudek
     twitter: tedhudek
     website: https://threemilesup.wordpress.com/
-  title: Six Essential Tips for the Enlightened Tech Writer
+  title: 7 Essential Tips for the Enlightened Tech Writer
   year: 2018
 - abstract: "<p>Thorough and optimal technical documentation often requires not just\
     \ an API reference of endpoints and parameters, or long contextual instructions,\

--- a/docs/_data/na-2018-day-2.yaml
+++ b/docs/_data/na-2018-day-2.yaml
@@ -25,7 +25,7 @@
   Session: Snack break
   Time: '10:50'
 - Duration: '30'
-  Session: "Six Essential Tips for the Enlightened Tech Writer \u2013 Ted Hudek"
+  Session: "7 Essential Tips for the Enlightened Tech Writer \u2013 Ted Hudek"
   Slug: ted-hudek
   Time: '11:10'
 - Duration: '10'

--- a/docs/conf/portland/2018/news/announcing-speakers.rst
+++ b/docs/conf/portland/2018/news/announcing-speakers.rst
@@ -30,7 +30,7 @@ Every year, we look to bring a wide range of voices to the Write the Docs stage.
 * Neal Kaplan – `Where do I start? The art and practice of documentation triage <http://www.writethedocs.org/conf/portland/2018/speakers/#speaker-portland-2018-neal-kaplan>`_
 * Sarah Day – `Starting from Scratch: Finding and Hiring Junior Writers <http://www.writethedocs.org/conf/portland/2018/speakers/#speaker-portland-2018-sarah-day>`_
 * Steve Stegelin – `Graphic Content Warning: The Pros, Cons, and Alternatives to Screenshots <http://www.writethedocs.org/conf/portland/2018/speakers/#speaker-portland-2018-steve-stegelin>`_
-* Ted Hudek – `Six Essential Tips for the Enlightened Tech Writer <http://www.writethedocs.org/conf/portland/2018/speakers/#speaker-portland-2018-ted-hudek>`_
+* Ted Hudek – `7 Essential Tips for the Enlightened Tech Writer <http://www.writethedocs.org/conf/portland/2018/speakers/#speaker-portland-2018-ted-hudek>`_
 * Thursday Bram – `What They Don't Tell You About Creating New Style Guides <http://www.writethedocs.org/conf/portland/2018/speakers/#speaker-portland-2018-thursday-bram>`_
 
 You can head over to the `Speakers page <http://www.writethedocs.org/conf/portland/2018/speakers/>`_ to see the full abstracts. We hope there’s something there for everyone to enjoy, and also something that will stretch your horizons a bit.


### PR DESCRIPTION
Hi folks, apologies for the last minute update! This matches the title I'll use in the talk.

One thing to double-check before you accept is this line:

`path: conf/portland/2018/videos/7-essential-tips-for-the-enlightened-tech-writer-ted-hudek`

I didn't see that file in the repo, but hopefully changing that filename won't mess anything up.

Thanks and see you soon!
