### PR TITLE
Add organizer and other meta data to meetup listing page

### DIFF
--- a/docs/_data/meetups/aus.yaml
+++ b/docs/_data/meetups/aus.yaml
@@ -1,3 +1,6 @@
 region: Oceania
 country: Australia
 website: http://www.meetup.com/Write-the-Docs-Australia/
+meetup: Write-the-Docs-Australia
+organizers:
+  - name: Swapnil Ogale

--- a/docs/_data/meetups/aus.yaml
+++ b/docs/_data/meetups/aus.yaml
@@ -4,3 +4,4 @@ website: http://www.meetup.com/Write-the-Docs-Australia/
 meetup: Write-the-Docs-Australia
 organizers:
   - name: Swapnil Ogale
+    link: http://twitter.com/swapnilogale/

--- a/docs/_data/meetups/bel-brussels.yaml
+++ b/docs/_data/meetups/bel-brussels.yaml
@@ -1,4 +1,4 @@
 region: Europe
 country: Belgium
 city: Brussels
-website: https://www.meetup.com/Write-The-Docs-Brussels
+meetup: Write-The-Docs-Brussels

--- a/docs/_data/meetups/can-fredericton.yaml
+++ b/docs/_data/meetups/can-fredericton.yaml
@@ -3,3 +3,4 @@ country: Canada
 state: NB
 city: Fredericton
 website: https://www.meetup.com/Write-The-Docs-YFC-Fredericton/
+meetup: Write-The-Docs-YFC-Fredericton

--- a/docs/_data/meetups/can-fredericton.yaml
+++ b/docs/_data/meetups/can-fredericton.yaml
@@ -4,3 +4,8 @@ state: NB
 city: Fredericton
 website: https://www.meetup.com/Write-The-Docs-YFC-Fredericton/
 meetup: Write-The-Docs-YFC-Fredericton
+organizers:
+  - name: Krista McGrath
+    link: https://www.meetup.com/Write-The-Docs-YFC-Fredericton/members/229691400/
+  - name: Bethany Tompkins
+    link: https://www.meetup.com/Write-The-Docs-YFC-Fredericton/members/230308291/

--- a/docs/_data/meetups/can-ottawa.yaml
+++ b/docs/_data/meetups/can-ottawa.yaml
@@ -3,3 +3,4 @@ country: Canada
 state: Ontario
 city: Ottawa
 website: http://www.meetup.com/Write-The-Docs-YOW-Ottawa/
+meetup: Write-The-Docs-YOW-Ottawa

--- a/docs/_data/meetups/esp-barcelona.yaml
+++ b/docs/_data/meetups/esp-barcelona.yaml
@@ -2,3 +2,4 @@ region: Europe
 country: Spain
 city: Barcelona
 website: http://www.meetup.com/Write-the-Docs-Barcelona/
+meetup: Write-the-Docs-Barcelona

--- a/docs/_data/meetups/gbr-cambridge.yaml
+++ b/docs/_data/meetups/gbr-cambridge.yaml
@@ -2,3 +2,6 @@ region: Europe
 country: United Kingdom
 city: Cambridge
 website: https://www.meetup.com/Write-The-Docs-Cambridge/
+meetup: Write-The-Docs-Cambridge
+organizers:
+  - name: Diana Logan

--- a/docs/_data/meetups/gbr-cambridge.yaml
+++ b/docs/_data/meetups/gbr-cambridge.yaml
@@ -5,4 +5,4 @@ website: https://www.meetup.com/Write-The-Docs-Cambridge/
 meetup: Write-The-Docs-Cambridge
 organizers:
   - name: Diana Logan
-    link: https://www.meetup.com/Write-The-Docs-Cambridge/members/225612123/<Paste>
+    link: https://www.meetup.com/Write-The-Docs-Cambridge/members/225612123/

--- a/docs/_data/meetups/gbr-cambridge.yaml
+++ b/docs/_data/meetups/gbr-cambridge.yaml
@@ -5,3 +5,4 @@ website: https://www.meetup.com/Write-The-Docs-Cambridge/
 meetup: Write-The-Docs-Cambridge
 organizers:
   - name: Diana Logan
+    link: https://www.meetup.com/Write-The-Docs-Cambridge/members/225612123/<Paste>

--- a/docs/_data/meetups/gbr-leedsbradford.yaml
+++ b/docs/_data/meetups/gbr-leedsbradford.yaml
@@ -2,3 +2,7 @@ region: Europe
 country: United Kingdom
 city: Leeds-Bradford
 website: https://www.meetup.com/Write-the-Docs-Leeds-Bradford/
+meetup: Write-the-Docs-Leeds-Bradford
+organizers:
+  - name: Deborah Barnard
+  - name: Sam Wright

--- a/docs/_data/meetups/gbr-leedsbradford.yaml
+++ b/docs/_data/meetups/gbr-leedsbradford.yaml
@@ -5,4 +5,6 @@ website: https://www.meetup.com/Write-the-Docs-Leeds-Bradford/
 meetup: Write-the-Docs-Leeds-Bradford
 organizers:
   - name: Deborah Barnard
+    link: http://twitter.com/starfallweb/
   - name: Sam Wright
+    link: http://twitter.com/plaindocs/

--- a/docs/_data/meetups/gbr-london.yaml
+++ b/docs/_data/meetups/gbr-london.yaml
@@ -5,4 +5,6 @@ website: http://www.meetup.com/Write-The-Docs-London/
 meetup: Write-The-Docs-London
 organizers:
   - name: Kristof Van Tomme
+    link: http://twitter.com/kvantomme/
   - name: Kelly O'Brien
+    link: http://twitter.com/OBrienEditorial/

--- a/docs/_data/meetups/gbr-london.yaml
+++ b/docs/_data/meetups/gbr-london.yaml
@@ -2,3 +2,7 @@ region: Europe
 country: United Kingdom
 city: London
 website: http://www.meetup.com/Write-The-Docs-London/
+meetup: Write-The-Docs-London
+organizers:
+  - name: Kristof Van Tomme
+  - name: Kelly O'Brien

--- a/docs/_data/meetups/ger-berlin.yaml
+++ b/docs/_data/meetups/ger-berlin.yaml
@@ -2,5 +2,9 @@ region: Europe
 country: Germany
 city: Berlin
 website: http://www.meetup.com/Write-The-Docs-Berlin/
-notes: |
-  Organised by [@plaindocs](https://twitter.com/plaindocs), [@chrischinch](https://twitter.com/chrischinch).
+meetup: Write-The-Docs-Berlin
+organizers:
+  - name: Sam Wright
+    link: https://twitter.com/plaindocs
+  - name: '@chrischinch'
+    link: https://twitter.com/chrischinch

--- a/docs/_data/meetups/ger-hamburg.yaml
+++ b/docs/_data/meetups/ger-hamburg.yaml
@@ -2,3 +2,4 @@ region: Europe
 country: Germany
 city: Hamburg
 website: https://www.meetup.com/Write-the-Docs-Hamburg/
+meetup: Write-the-Docs-Hamburg

--- a/docs/_data/meetups/ger-karlsruhe.yaml
+++ b/docs/_data/meetups/ger-karlsruhe.yaml
@@ -2,3 +2,4 @@ region: Europe
 country: Germany
 city: Karlsruhe
 website: https://www.meetup.com/Write-the-Docs-Karlsruhe/
+meetup: Write-the-Docs-Karlsruhe

--- a/docs/_data/meetups/ger-munich.yaml
+++ b/docs/_data/meetups/ger-munich.yaml
@@ -2,3 +2,4 @@ region: Europe
 country: Germany
 city: Munich
 website: https://www.meetup.com/Write-the-Docs-Munich/
+meetup: Write-the-Docs-Munich

--- a/docs/_data/meetups/ger-rhineland.yaml
+++ b/docs/_data/meetups/ger-rhineland.yaml
@@ -2,3 +2,4 @@ region: Europe
 country: Germany
 city: Cologne
 website: https://www.meetup.com/WTD-Rhineland/
+meetup: WTD-Rhineland

--- a/docs/_data/meetups/gre-athens.yaml
+++ b/docs/_data/meetups/gre-athens.yaml
@@ -2,3 +2,6 @@ region: Europe
 country: Greece
 city: Athens
 website: https://www.meetup.com/meetup-group-tvpdMPBG
+meetup: meetup-group-tvpdMPBG
+organizers:
+  - name: Swapnil Ogale

--- a/docs/_data/meetups/hun-budapest.yaml
+++ b/docs/_data/meetups/hun-budapest.yaml
@@ -2,3 +2,4 @@ region: Europe
 country: Hungary
 city: Budapest
 website: https://www.meetup.com/Budapest-Technical-content-creators/
+meetup: Budapest-Technical-content-creators

--- a/docs/_data/meetups/irl-galway.yaml
+++ b/docs/_data/meetups/irl-galway.yaml
@@ -2,3 +2,6 @@ region: Europe
 country: Ireland
 city: Galway
 website: http://www.meetup.com/Write-The-Docs-Ireland/
+meetup: Write-The-Docs-Ireland
+organizers:
+  - name: Lynda O'Leary

--- a/docs/_data/meetups/irl-galway.yaml
+++ b/docs/_data/meetups/irl-galway.yaml
@@ -5,3 +5,4 @@ website: http://www.meetup.com/Write-The-Docs-Ireland/
 meetup: Write-The-Docs-Ireland
 organizers:
   - name: Lynda O'Leary
+    link: http://twitter.com/olearylynda/

--- a/docs/_data/meetups/isr-herzliya.yaml
+++ b/docs/_data/meetups/isr-herzliya.yaml
@@ -2,3 +2,4 @@ region: Asia
 country: Israel
 city: Herzliya
 website: https://www.meetup.com/Write-The-Docs-Herzliya/
+meetup: Write-The-Docs-Herzliya

--- a/docs/_data/meetups/jap-kobe.yaml
+++ b/docs/_data/meetups/jap-kobe.yaml
@@ -2,3 +2,6 @@ region: Asia
 country: Japan
 city: Kobe
 website: https://www.meetup.com/Write-the-Docs-Kobe/
+meetup: Write-the-Docs-Kobe
+organizers:
+  - name: Yuki Fujiwara

--- a/docs/_data/meetups/jap-kobe.yaml
+++ b/docs/_data/meetups/jap-kobe.yaml
@@ -5,3 +5,4 @@ website: https://www.meetup.com/Write-the-Docs-Kobe/
 meetup: Write-the-Docs-Kobe
 organizers:
   - name: Yuki Fujiwara
+    link: http://twitter.com/sky_y/

--- a/docs/_data/meetups/kor-seoul.yaml
+++ b/docs/_data/meetups/kor-seoul.yaml
@@ -2,3 +2,4 @@ region: Asia
 country: Korea
 city: Seoul
 website: http://www.meetup.com/write-the-docs-seoul/
+meetup: write-the-docs-seoul

--- a/docs/_data/meetups/ned-amsterdam.yaml
+++ b/docs/_data/meetups/ned-amsterdam.yaml
@@ -5,4 +5,6 @@ website: https://www.meetup.com/Write-The-Docs-Amsterdam/
 meetup: Write-The-Docs-Amsterdam
 organizers:
   - name: Kristof Van Tomme
+    link: http://twitter.com/kvantomme/
   - name: Laura Vass
+    link: https://www.meetup.com/Write-The-Docs-Amsterdam/members/183302865/

--- a/docs/_data/meetups/ned-amsterdam.yaml
+++ b/docs/_data/meetups/ned-amsterdam.yaml
@@ -2,3 +2,7 @@ region: Europe
 country: Netherlands
 city: Amsterdam
 website: https://www.meetup.com/Write-The-Docs-Amsterdam/
+meetup: Write-The-Docs-Amsterdam
+organizers:
+  - name: Kristof Van Tomme
+  - name: Laura Vass

--- a/docs/_data/meetups/rus-moscow.yaml
+++ b/docs/_data/meetups/rus-moscow.yaml
@@ -2,3 +2,4 @@ region: Europe
 country: Russian Federation
 city: Moscow
 website: https://www.meetup.com/Write-the-Docs-Moscow/
+meetup: Write-the-Docs-Moscow

--- a/docs/_data/meetups/rus-novosibirsk.yaml
+++ b/docs/_data/meetups/rus-novosibirsk.yaml
@@ -2,3 +2,6 @@ region: Asia
 country: Russian Federation
 city: Novosibirsk
 website: https://www.meetup.com/Write-the-Docs-Siberia/
+meetup: Write-the-Docs-Siberia
+organizers:
+  - name: Nick Volynkin

--- a/docs/_data/meetups/rus-novosibirsk.yaml
+++ b/docs/_data/meetups/rus-novosibirsk.yaml
@@ -5,3 +5,4 @@ website: https://www.meetup.com/Write-the-Docs-Siberia/
 meetup: Write-the-Docs-Siberia
 organizers:
   - name: Nick Volynkin
+    link: https://www.meetup.com/Write-the-Docs-Siberia/members/229048004/

--- a/docs/_data/meetups/rus-stpetersburg.yaml
+++ b/docs/_data/meetups/rus-stpetersburg.yaml
@@ -5,3 +5,4 @@ website: https://www.meetup.com/Write-the-Docs-SPb/
 meetup: Write-the-Docs-SPb
 organizers:
   - name: Nick Volynkin
+    link: https://www.meetup.com/Write-the-Docs-SPb/members/229048004/

--- a/docs/_data/meetups/rus-stpetersburg.yaml
+++ b/docs/_data/meetups/rus-stpetersburg.yaml
@@ -2,3 +2,6 @@ region: Europe
 country: Russian Federation
 city: St. Petersburg
 website: https://www.meetup.com/Write-the-Docs-SPb/
+meetup: Write-the-Docs-SPb
+organizers:
+  - name: Nick Volynkin

--- a/docs/_data/meetups/usa-annarbor.yaml
+++ b/docs/_data/meetups/usa-annarbor.yaml
@@ -6,5 +6,8 @@ website: https://www.meetup.com/Write-the-Docs-A2
 meetup: Write-the-Docs-A2
 organizers:
   - name: Cory Williamson-Cardneau
+    link: http://twitter.com/cory_will/
   - name: Susan Ostreicher
+    link: https://www.meetup.com/Write-the-Docs-A2/members/12822567/
   - name: Kristina Birk
+    link: https://www.meetup.com/Write-the-Docs-A2/members/225907998/

--- a/docs/_data/meetups/usa-annarbor.yaml
+++ b/docs/_data/meetups/usa-annarbor.yaml
@@ -3,3 +3,8 @@ country: USA
 state: Michigan
 city: Ann Arbor
 website: https://www.meetup.com/Write-the-Docs-A2
+meetup: Write-the-Docs-A2
+organizers:
+  - name: Cory Williamson-Cardneau
+  - name: Susan Ostreicher
+  - name: Kristina Birk

--- a/docs/_data/meetups/usa-austin.yaml
+++ b/docs/_data/meetups/usa-austin.yaml
@@ -3,3 +3,8 @@ country: USA
 state: Texas
 city: Austin
 website: http://www.meetup.com/WriteTheDocs-ATX-Meetup/
+meetup: WriteTheDocs-ATX-Meetup
+organizers:
+  - name: Becky Todd
+  - name: Margaret Eker
+  - name: Uwana Idaiddi

--- a/docs/_data/meetups/usa-austin.yaml
+++ b/docs/_data/meetups/usa-austin.yaml
@@ -6,5 +6,7 @@ website: http://www.meetup.com/WriteTheDocs-ATX-Meetup/
 meetup: WriteTheDocs-ATX-Meetup
 organizers:
   - name: Becky Todd
+    link: http://twitter.com/infodevdc/
   - name: Margaret Eker
   - name: Uwana Idaiddi
+    link: https://www.meetup.com/WriteTheDocs-ATX-Meetup/members/229384230/

--- a/docs/_data/meetups/usa-boise.yaml
+++ b/docs/_data/meetups/usa-boise.yaml
@@ -3,3 +3,7 @@ country: USA
 state: Idaho
 city: Boise
 website: http://www.meetup.com/Write-the-Docs-Boise/
+meetup: Write-the-Docs-Boise
+organizers:
+  - name: Monica Campbell
+  - name: Bryan Davis

--- a/docs/_data/meetups/usa-boise.yaml
+++ b/docs/_data/meetups/usa-boise.yaml
@@ -6,4 +6,6 @@ website: http://www.meetup.com/Write-the-Docs-Boise/
 meetup: Write-the-Docs-Boise
 organizers:
   - name: Monica Campbell
+    link: https://www.meetup.com/Write-the-Docs-Boise/members/201528892/
   - name: Bryan Davis
+    link: https://www.meetup.com/Write-the-Docs-Boise/members/106936812/

--- a/docs/_data/meetups/usa-boston.yaml
+++ b/docs/_data/meetups/usa-boston.yaml
@@ -3,3 +3,6 @@ country: USA
 state: Massachusetts
 city: Boston
 website: http://www.meetup.com/Write-the-Docs-BOS/
+meetup: Write-the-Docs-BOS
+organizers:
+  - name: Phillip Borenstein

--- a/docs/_data/meetups/usa-boston.yaml
+++ b/docs/_data/meetups/usa-boston.yaml
@@ -6,3 +6,4 @@ website: http://www.meetup.com/Write-the-Docs-BOS/
 meetup: Write-the-Docs-BOS
 organizers:
   - name: Phillip Borenstein
+    link: http://twitter.com/pborenstein/

--- a/docs/_data/meetups/usa-boulder.yaml
+++ b/docs/_data/meetups/usa-boulder.yaml
@@ -6,4 +6,6 @@ website: http://www.meetup.com/Boulder-Denver-WriteTheDocs-Meetup/
 meetup: Boulder-Denver-WriteTheDocs-Meetup
 organizers:
   - name: Bri Hillmer
+    link: http://twitter.com/writebriwrite/
   - name: MaryBeth Alexander
+    link: https://www.meetup.com/Write-the-Docs-Boulder-Denver/members/130670172/

--- a/docs/_data/meetups/usa-boulder.yaml
+++ b/docs/_data/meetups/usa-boulder.yaml
@@ -3,3 +3,7 @@ country: USA
 state: Colorado
 city: Boulder/Denver
 website: http://www.meetup.com/Boulder-Denver-WriteTheDocs-Meetup/
+meetup: Boulder-Denver-WriteTheDocs-Meetup
+organizers:
+  - name: Bri Hillmer
+  - name: MaryBeth Alexander

--- a/docs/_data/meetups/usa-houston.yaml
+++ b/docs/_data/meetups/usa-houston.yaml
@@ -6,3 +6,8 @@ website: https://www.meetup.com/Write-the-Docs-Houston/
 meetup: Write-the-Docs-Houston
 organizers:
   - name: Michaele Cerf
+    link: https://www.meetup.com/Write-the-Docs-Houston/members/12205633/
+  - name: Emily Zinsitz
+    link: http://twitter.com/ezinsitz/
+  - name: Jennifer Platt
+    link: https://www.meetup.com/Write-the-Docs-Houston/members/199395851/

--- a/docs/_data/meetups/usa-houston.yaml
+++ b/docs/_data/meetups/usa-houston.yaml
@@ -3,3 +3,6 @@ country: USA
 state: Texas
 city: Houston
 website: https://www.meetup.com/Write-the-Docs-Houston/
+meetup: Write-the-Docs-Houston
+organizers:
+  - name: Michaele Cerf

--- a/docs/_data/meetups/usa-losAngeles.yaml
+++ b/docs/_data/meetups/usa-losAngeles.yaml
@@ -6,5 +6,8 @@ website: https://www.meetup.com/Write-the-Docs-Los-Angeles/
 meetup: Write-the-Docs-Los-Angeles
 organizers:
   - name: Andrea Kao
+    link: https://www.meetup.com/Write-the-Docs-LA/members/59612492/
   - name: Marcy Harbut
+    link: https://www.meetup.com/Write-the-Docs-LA/members/3055706://www.meetup.com/Write-the-Docs-LA/members/3055706/
   - name: Frank Solomon
+    link: https://www.meetup.com/Write-the-Docs-LA/members/13251974/

--- a/docs/_data/meetups/usa-losAngeles.yaml
+++ b/docs/_data/meetups/usa-losAngeles.yaml
@@ -3,3 +3,8 @@ country: USA
 state: California
 city: Los Angeles
 website: https://www.meetup.com/Write-the-Docs-Los-Angeles/
+meetup: Write-the-Docs-Los-Angeles
+organizers:
+  - name: Andrea Kao
+  - name: Marcy Harbut
+  - name: Frank Solomon

--- a/docs/_data/meetups/usa-nyc.yaml
+++ b/docs/_data/meetups/usa-nyc.yaml
@@ -4,5 +4,7 @@ state: New York
 city: New York City
 page: ./nyc/
 website: https://www.meetup.com/WriteTheDocsNYC/
-notes: |
-  Organised by [@WriteTheDocsNYC](https://twitter.com/WriteTheDocsNYC)
+meetup: WriteTheDocsNYC
+twitter: WriteTheDocsNYC
+organizers:
+  - name: Ricardo Feliciano

--- a/docs/_data/meetups/usa-nyc.yaml
+++ b/docs/_data/meetups/usa-nyc.yaml
@@ -8,3 +8,4 @@ meetup: WriteTheDocsNYC
 twitter: WriteTheDocsNYC
 organizers:
   - name: Ricardo Feliciano
+    link: http://twitter.com/FelicianoTech/

--- a/docs/_data/meetups/usa-portland.yaml
+++ b/docs/_data/meetups/usa-portland.yaml
@@ -3,5 +3,8 @@ country: USA
 state: Oregon
 city: Portland
 website: https://www.meetup.com/Write-The-Docs-PDX/
-notes: |
-  Organised by [@WriteTheDocsPDX](https://twitter.com/WriteTheDocsPDX)
+meetup: Write-The-Docs-PDX
+twitter: WriteTheDocsPDX
+organizers:
+  - name: Mo Nishiyama
+  - name: Kristen McKee

--- a/docs/_data/meetups/usa-portland.yaml
+++ b/docs/_data/meetups/usa-portland.yaml
@@ -7,4 +7,6 @@ meetup: Write-The-Docs-PDX
 twitter: WriteTheDocsPDX
 organizers:
   - name: Mo Nishiyama
+    link: https://twitter.com/synthcat
   - name: Kristen McKee
+    link: https://www.meetup.com/Write-The-Docs-PDX/members/234053635/

--- a/docs/_data/meetups/usa-saltLakeCity.yaml
+++ b/docs/_data/meetups/usa-saltLakeCity.yaml
@@ -3,3 +3,7 @@ country: USA
 state: Utah
 city: Salt Lake City
 website: https://www.meetup.com/Write-the-Docs-SLC/
+meetup: Write-the-Docs-SLC
+organizers:
+  - name: Ashley Newton
+  - name: Kyle Rollins

--- a/docs/_data/meetups/usa-saltLakeCity.yaml
+++ b/docs/_data/meetups/usa-saltLakeCity.yaml
@@ -6,4 +6,6 @@ website: https://www.meetup.com/Write-the-Docs-SLC/
 meetup: Write-the-Docs-SLC
 organizers:
   - name: Ashley Newton
+    link: https://www.meetup.com/Write-the-Docs-SLC/members/161200662/
   - name: Kyle Rollins
+    link: https://www.meetup.com/Write-the-Docs-SLC/members/233152735/

--- a/docs/_data/meetups/usa-sanDiego.yaml
+++ b/docs/_data/meetups/usa-sanDiego.yaml
@@ -3,3 +3,4 @@ country: USA
 state: California
 city: San Diego
 website: https://www.meetup.com/Write-the-Docs-San-Diego/
+meetup: Write-the-Docs-San-Diego

--- a/docs/_data/meetups/usa-sanfrancisco.yaml
+++ b/docs/_data/meetups/usa-sanfrancisco.yaml
@@ -3,3 +3,8 @@ country: USA
 state: California
 city: San Francisco
 website: http://www.meetup.com/Write-the-Docs/
+meetup: Write-the-Docs
+organizers:
+  - name: Laura Stewart
+  - name: Juan Lara
+  - name: Liz Harris

--- a/docs/_data/meetups/usa-sanfrancisco.yaml
+++ b/docs/_data/meetups/usa-sanfrancisco.yaml
@@ -6,5 +6,8 @@ website: http://www.meetup.com/Write-the-Docs/
 meetup: Write-the-Docs
 organizers:
   - name: Laura Stewart
+    link: https://www.meetup.com/Write-the-Docs-SF/members/194427202/
   - name: Juan Lara
+    link: http://twitter.com/JRLtechwriting/
   - name: Liz Harris
+    link: https://www.meetup.com/Write-the-Docs-SF/members/204444209/

--- a/docs/_data/meetups/usa-seattle.yaml
+++ b/docs/_data/meetups/usa-seattle.yaml
@@ -6,5 +6,8 @@ website: http://www.meetup.com/Write-The-Docs-Seattle/
 meetup: Write-The-Docs-Seattle
 organizers:
   - name: Lois Patterson
+    link: https://www.linkedin.com/in/loispatterson
   - name: Becky Yoose
+    link: http://twitter.com/yo_bj/
   - name: Rose Williams
+    link: http://twitter.com/zelwms/

--- a/docs/_data/meetups/usa-seattle.yaml
+++ b/docs/_data/meetups/usa-seattle.yaml
@@ -3,3 +3,8 @@ country: USA
 state: Washington
 city: Seattle
 website: http://www.meetup.com/Write-The-Docs-Seattle/
+meetup: Write-The-Docs-Seattle
+organizers:
+  - name: Lois Patterson
+  - name: Becky Yoose
+  - name: Rose Williams

--- a/docs/_ext/meetups.py
+++ b/docs/_ext/meetups.py
@@ -45,8 +45,10 @@ def load_meetups_by_region():
             'website',
             'twitter',
         ]])
-        if 'website' not in meetup:
-            raise ExtensionError('Meetup needs a website')
+        if 'meetup' not in meetup:
+            raise ExtensionError('Meetup missing `meetup` key: file={0}'.format(
+                yaml_file
+            ))
         result[meetup['region']].append(meetup)
     for _, meetups in list(result.items()):
         meetups.sort(key=lambda m: m.get('city', m['country']))

--- a/docs/_ext/meetups.py
+++ b/docs/_ext/meetups.py
@@ -39,6 +39,12 @@ def load_meetups_by_region():
     result = collections.defaultdict(list)
     for yaml_file in glob.glob('_data/meetups/*.yaml'):
         meetup = load_yaml(yaml_file)
+        # Conditionally show the meetup meta data block
+        meetup['has_meta'] = any([(key in meetup) for key in [
+            'organizers',
+            'website',
+            'twitter',
+        ]])
         if 'website' not in meetup:
             raise ExtensionError('Meetup needs a website')
         result[meetup['region']].append(meetup)

--- a/docs/_templates/include/meetups/listing.jinja
+++ b/docs/_templates/include/meetups/listing.jinja
@@ -2,7 +2,8 @@
     <dl class="meetup-listing">
         {% for meetup in meetups %}
         <dt class="meetup-listing-detail">
-            <a href="{% if meetup['page'] %}{{ meetup['page'] }}{% else %}{{ meetup['website'] }}{% endif %}">
+
+            <a href="{% if meetup['page'] %}{{ meetup['page'] }}{% else %}http://www.meetup.com/{{ meetup['meetup'] }}/{% endif %}">
                 {% if meetup['city'] %}{{ meetup['city'] }}, {% endif -%}
                 {% if meetup['state'] %}{{ meetup|state_abbr }}, {% endif -%}
                 {{ meetup['country'] -}}
@@ -11,10 +12,10 @@
         {% if meetup.has_meta %}
         <dd>
           <dl class="meetup-listing-meta">
-            {# Alternative meetup link #}
-            {% if meetup['page'] and meetup['website'] %}
+            {# Alternative meetup link, we are already using the page as the site link #}
+            {% if meetup['page'] %}
               <div>
-                More information on <a href="{{ meetup['website'] }}">Meetup</a>
+                More information on <a href="http://meetup.com/{{ meetup['meetup'] }}/">Meetup</a>
               </div>
             {% endif %}
 

--- a/docs/_templates/include/meetups/listing.jinja
+++ b/docs/_templates/include/meetups/listing.jinja
@@ -1,16 +1,48 @@
 .. raw:: html
-    <ul>
+    <dl class="meetup-listing">
         {% for meetup in meetups %}
-        <li>
+        <dt class="meetup-listing-detail">
             <a href="{% if meetup['page'] %}{{ meetup['page'] }}{% else %}{{ meetup['website'] }}{% endif %}">
-                {% if meetup['city'] %}{{ meetup['city'] }},{% endif %}
-                {% if meetup['state'] %}{{ meetup|state_abbr }},{% endif %}
-                {{ meetup['country'] }}
+                {% if meetup['city'] %}{{ meetup['city'] }}, {% endif -%}
+                {% if meetup['state'] %}{{ meetup|state_abbr }}, {% endif -%}
+                {{ meetup['country'] -}}
             </a>
-            {% if meetup['page'] and meetup['website'] %}(<a href="{{ meetup['website'] }}">meetup.com</a>){% endif %}
-            {% if meetup['notes'] %}
-            - {{ meetup['notes']|markdown|replace('<p>', '')|replace('</p>', '') }}
+        </dt>
+        {% if meetup.has_meta %}
+        <dd>
+          <dl class="meetup-listing-meta">
+            {# Alternative meetup link #}
+            {% if meetup['page'] and meetup['website'] %}
+              <div>
+                More information on <a href="{{ meetup['website'] }}">Meetup</a>
+              </div>
             {% endif %}
-        </li>
+
+            {# Organizer listing #}
+            {% if 'organizers' in meetup %}
+              <div>
+                Organized by
+                {% for organizer in meetup['organizers'] -%}
+                  {% if loop.last and not loop.first %} and {% endif -%}
+                  {%- if 'link' in organizer -%}
+                    <a href="{{ organizer.link }}">{{ organizer.name }}</a>
+                  {%- else -%}
+                    {{ organizer.name }}
+                  {%- endif -%}
+                  {%- if not loop.last and loop.length > 2 -%}, {% endif -%}
+                {%- endfor %}
+              </div>
+            {% endif %}
+
+            {# On twitter #}
+            {% if meetup['twitter'] %}
+              <div>
+                <a href="https://twitter.com/{{ meetup['twitter'] }}">@{{ meetup['twitter'] }}</a>
+              </div>
+            {% endif %}
+
+          </dl>
+        </dd>
+        {% endif %}
         {% endfor %}
-    </ul>
+    </dl>

--- a/docs/meetups/index.rst
+++ b/docs/meetups/index.rst
@@ -52,4 +52,3 @@ Know of a meetup not shown here? `Add it to the list <https://github.com/writeth
 
    nyc
    philly
-


### PR DESCRIPTION
Organizer information is not complete and doesn't necessarily seem to match up
to Meetup data. We could automate this by hitting the Meetup API during build
and grabbing all of the organizer information.

Refs #54