### PR TITLE
Remove Portland schedule link shortcuts

### DIFF
--- a/docs/conf/portland/2018/unconference.rst
+++ b/docs/conf/portland/2018/unconference.rst
@@ -1,10 +1,6 @@
 :template: {{year}}/generic.html
 :banner: _static/2018/assets/headers/writing-day.png
 
-.. _unconference schedule: https://docs.google.com/spreadsheets/d/1Pil6UlHsF8vXFzPZV0cEfqqAT0ns7ZcEKM6iT81ierU/edit?usp=sharing
-
-**Go to the** `unconference schedule`_ **for a list of sessions.**
-
 Unconference
 ============
 
@@ -15,4 +11,4 @@ Schedule
 
 .. FIXME Check unconference schedule
 
-Unconference sessions will be all day Monday and Tuesday when the Job Fair isn't running. Exact timing information is available on our :doc:`/conf/{{shortcode}}/{{year}}/schedule` page. Go to the `unconference schedule`_ for a list of sessions.
+Unconference sessions will be all day Monday and Tuesday when the Job Fair isn't running. Exact timing information is available on our :doc:`/conf/{{shortcode}}/{{year}}/schedule` page.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,8 +5,6 @@
    :author: Write the Docs
    :geo.placename: Worldwide
 
-**Write the Docs Portland is happening now!** Go to the :doc:`schedule <conf/portland/2018/schedule>`, `unconference schedule <https://docs.google.com/spreadsheets/d/1Pil6UlHsF8vXFzPZV0cEfqqAT0ns7ZcEKM6iT81ierU/edit?usp=sharing>`_, or the :doc:`livestream <conf/portland/2018/livestream>`!
-
 Welcome to our community!
 =========================
 


### PR DESCRIPTION
Portland 2018 is over—good job everybody! We don't need the quick schedule links anymore and the unconference session schedule was never particularly accurate, so this PR reverts both of those changes. Cheers!