### PR TITLE
Issue 71, link to short form CoC

### DIFF
--- a/docs/organizer-guide/meetups/sustainable-meetups.rst
+++ b/docs/organizer-guide/meetups/sustainable-meetups.rst
@@ -15,7 +15,8 @@ Minimal Viable Meetup checklist
 * Alternatively, consider hosting a regular informal ‘docs and drinks’ to keep the momentum going with your attendees – these can involve either alcohol or coffee. 
 * Bring in at least two main organizers for your meetup (including yourself). This helps shoulder the burden of organizing and stops you burning out. 
 * Check your scheduling won’t clash with an overlapping meetup that might attract away your attendees. 
-* Even if you haven’t had a meetup in a while, just pick yourself back up and schedule another one when you can. 
+* Even if you haven’t had a meetup in a while, just pick yourself back up and schedule another one when you can.
+* At each meetup, highlight the Write the Docs Code of Conduct. We have a `short form CoC available for meetups <../../../code-of-conduct-shortform-meetups>`_.
 
 Nice-to-haves 
 -------------


### PR DESCRIPTION
The short form CoC was merged into this page: https://github.com/mjang/www-1/blob/master/docs/code-of-conduct-shortform-meetups.rst

This PR links to that page