### PR TITLE
fix amw slug to match slug in speaker list

### DIFF
--- a/docs/_data/cin-2018-day-1.yaml
+++ b/docs/_data/cin-2018-day-1.yaml
@@ -58,7 +58,7 @@
   Time: '15:25'
 - Duration: '30'
   Session: "Open Source DocOps \u2013 Adam Wood"
-  Slug: adam-wood
+  Slug: adam-michael-wood
   Time: '15:45'
 - Duration: '10'
   Session: Switch Speakers


### PR DESCRIPTION
I noticed that clicking on my talk from the schedule page doesn't link to the on page anchor for the talk. This should fix that.