### PR TITLE
grammar (is/are)

### DIFF
--- a/docs/organizer-guide/newsletter/editorial-guidelines.rst
+++ b/docs/organizer-guide/newsletter/editorial-guidelines.rst
@@ -6,7 +6,7 @@ Editorial Guidelines
 
 Working from Slack conversations is a little tricky, but our goal is to distill the discussion into a few key takeaways that are useful to our readers. It's more important that our stories are clear and practical, than that we've recounted the conversation in its entirety.
 
-The other thing to keep in mind is that, while we are paraphrasing from conversations we (probably) didn't participate in, we want to be on guard against the temptation to editorialize. Try not to let your personal opinions sneak into your articles too much. And if there's two (or more) sides that come up in a discussion, we want to cover all of them as even-handedly as possible.
+The other thing to keep in mind is that, while we are paraphrasing from conversations we (probably) didn't participate in, we want to be on guard against the temptation to editorialize. Try not to let your personal opinions sneak into your articles too much. And if there are two (or more) sides that come up in a discussion, we want to cover all of them as even-handedly as possible.
 
 One last big picture thing, before we hit a few nuts-and-bolts points: Remember that the newsletter is governed by the `WTD Code of Conduct <http://www.writethedocs.org/code-of-conduct/>`_ just like any other part of the community. (In fact, even more strenuously since it's coming from the organization directly.) So if you run across anything that's even minorly dicey, with regards to the CoC, omit it from your story.
 


### PR DESCRIPTION
Very minor grammar correction.

Effectively: 'there are sides' instead of 'there is sides'.