### PR TITLE
Correcting URL end for WtD North England Meetup

### DIFF
--- a/docs/_data/meetups/gbr-leedsbradford.yaml
+++ b/docs/_data/meetups/gbr-leedsbradford.yaml
@@ -2,7 +2,7 @@ region: Europe
 country: United Kingdom
 city: North England
 website: https://www.meetup.com/Write-the-Docs-North/
-meetup: Write-the-Docs-North-England
+meetup: Write-the-Docs-North
 organizers:
   - name: Deborah Barnard
     link: http://twitter.com/starfallweb/


### PR DESCRIPTION
While the `website` listing is correct, I can only get the link working if I change the `meetup` property.