### PR TITLE
Force default file encoding to UTF8 on windows

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,11 @@ import ablog
 import sys
 import os
 
+# Only for windows compatability - Forces default encoding to UTF8, which it may not be on windows
+if os.name == 'nt':
+    reload(sys)
+    sys.setdefaultencoding('UTF8')
+
 
 sys.path.append(os.getcwd())  # noqa
 


### PR DESCRIPTION
Force default file encoding to UTF8 on windows. Otherwise it crashes when opening non-ascii files on windows.