### PR TITLE
HTML proofer is getting the paths wrong

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ install:
  - pip install tox-travis
  - eval "$(gimme 1.7)"
  - go get github.com/ValeLint/vale
+ - sudo apt-get install libcurl3-devp
 script:
  - tox
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
  - pip install tox-travis
  - eval "$(gimme 1.7)"
  - go get github.com/ValeLint/vale
- - sudo apt-get install libcurl3-devp
+ - sudo apt-get install libcurl3-dev
 script:
  - tox
 env:

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,11 @@ commands =
 changedir = {toxinidir}/docs
 whitelist_externals = htmlproofer
                       gem
-commands =
+
+commands_pre =
     gem install html-proofer
+
+
+commands =
     sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
-    htmlproofer {envtmpdir}/html --alt-ignore '/.*/' --file-ignore '/2013/','/2014'/,'/2015/' --url-ignore '/video/' --allow-hash-href
+    htmlproofer {envtmpdir}/html/conf/australia/2018/about.html --alt-ignore '/.*/' --file-ignore "/2013/,/2014/,/2015/,/blog/" --url-swap ".html:/" --disable_external --url-ignore '/video/' --allow-hash-href

--- a/tox.ini
+++ b/tox.ini
@@ -45,4 +45,4 @@ commands_pre =
 
 commands =
     sphinx-build -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
-    htmlproofer {envtmpdir}/html --alt-ignore '/.*/' --file-ignore --disable-external -file-ignore "/2013/,/2014/,/2015/," --url-ignore '/2015/,/video/' --allow-hash-href
+    htmlproofer {envtmpdir}/html --alt-ignore '/.*/' --file-ignore --disable-external true -file-ignore "/2013/,/2014/,/2015/," --url-ignore '/2015/,/video/' --allow-hash-href

--- a/tox.ini
+++ b/tox.ini
@@ -45,4 +45,4 @@ commands_pre =
 
 commands =
     sphinx-build -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
-    htmlproofer {envtmpdir}/html --alt-ignore '/.*/' --file-ignore --disable-external true -file-ignore "/2013/,/2014/,/2015/," --url-ignore '/2015/,/video/' --allow-hash-href
+    htmlproofer {envtmpdir}/html --alt-ignore '/.*/' --file-ignore --disable-external -file-ignore "/2013/,/2014/,/2015/," --url-ignore '/2015/,/video/' --allow-hash-href

--- a/tox.ini
+++ b/tox.ini
@@ -45,4 +45,4 @@ commands_pre =
 
 commands =
     sphinx-build -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
-    htmlproofer {envtmpdir}/html --alt-ignore '/.*/' --file-ignore -file-ignore "/2013/,/2014/,/2015/," --url-ignore '/video/' --allow-hash-href
+    htmlproofer {envtmpdir}/html --alt-ignore '/.*/' --file-ignore --internal-only -file-ignore "/2013/,/2014/,/2015/," --url-ignore '/2015/,/video/' --allow-hash-href

--- a/tox.ini
+++ b/tox.ini
@@ -45,4 +45,4 @@ commands_pre =
 
 commands =
     sphinx-build -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
-    htmlproofer {envtmpdir}/html --alt-ignore '/.*/' --file-ignore --disable-external -file-ignore "/2013/,/2014/,/2015/," --url-ignore '/2015/,/video/' --allow-hash-href
+    htmlproofer {envtmpdir}/html --alt-ignore '/.*/' --file-ignore -file-ignore "/2013/,/2014/,/2015/," --url-ignore '/2015/,/video/' --allow-hash-href

--- a/tox.ini
+++ b/tox.ini
@@ -45,4 +45,4 @@ commands_pre =
 
 commands =
     sphinx-build -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
-    htmlproofer {envtmpdir}/html --alt-ignore '/.*/' --file-ignore --internal-only -file-ignore "/2013/,/2014/,/2015/," --url-ignore '/2015/,/video/' --allow-hash-href
+    htmlproofer {envtmpdir}/html --alt-ignore '/.*/' --file-ignore --disable-external -file-ignore "/2013/,/2014/,/2015/," --url-ignore '/2015/,/video/' --allow-hash-href

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,6 @@ whitelist_externals = htmlproofer
 commands_pre =
     gem install html-proofer
 
-
 commands =
-    sphinx-build -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
-    htmlproofer {envtmpdir}/html/conf/australia/2018/about.html --alt-ignore '/.*/' --file-ignore "/2013/,/2014/,/2015/,/blog/" --url-swap ".html:/" --disable_external --url-ignore '/video/' --allow-hash-href
+    sphinx-build -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
+    htmlproofer {envtmpdir}/html --alt-ignore '/.*/' --file-ignore -file-ignore "/2013/,/2014/,/2015/," --url-ignore '/video/' --allow-hash-href

--- a/tox.ini
+++ b/tox.ini
@@ -45,4 +45,4 @@ commands_pre =
 
 commands =
     sphinx-build -b dirhtml -d {envtmpdir}/doctrees . {envtmpdir}/html
-    htmlproofer {envtmpdir}/html --alt-ignore '/.*/' --file-ignore -file-ignore "/2013/,/2014/,/2015/," --url-ignore '/2015/,/video/' --allow-hash-href
+    htmlproofer {envtmpdir}/html --alt-ignore '/.*/' --file-ignore "/2013/,/2014/,/2015/," --url-ignore '/2015/,/video/' --allow-hash-href


### PR DESCRIPTION
The link checking we merged in #732 isn't getting the paths right. 

Something is getting confused, perhaps `pathto` in the themes. For example:
```
<li><a href="{{ pathto('conf') }}">Past Events</a></li>
``` 
from a menu, which we serve as `/conf/` is getting link checked as `conf.html` and results in a 404. I was playing around with `html_link_suffix = '/'` in `conf.py` which doesn't fix the problem.

