### PR TITLE
Adding Prague 2019 landing page.

### DIFF
--- a/docs/_data/config-prague-2019.yaml
+++ b/docs/_data/config-prague-2019.yaml
@@ -1,0 +1,108 @@
+name: Prague
+
+shortcode: prague # prague australia?
+templatecode: eu # HACK
+year: 2019
+city: Prague
+local_area: Czech Republic
+area: Europe
+area_adj: European
+tz: CEST
+email: prague@writethedocs.org
+color: coral
+
+photos:
+  default: _static/2019/assets/headers/prague-group.png
+
+tickets:
+  community:
+    price: €500
+  corporate:
+    price: €250
+  independent:
+    price: €150
+  student:
+    price: €75
+
+sponsorship:
+  first_draft:
+    price: €500
+  second_draft:
+    price: €1000
+  publisher:
+    price: €3000
+  patron:
+    price: €6000
+  keystone:
+    price: €12000
+  job_fair:
+    price: €800
+    half: €400
+  lanyard:
+    price: TBD
+  writing_day:
+    price: TBD
+
+date: # how do we handle these? human readable would be nice.
+  main: "**September 15-17, 2019, in Prague, Czechia**"
+  short: Sep 15-17, 2019
+  tickets_live: "March 2019"
+  month: September
+  day_one:
+    event: Boat Ride
+    date: September 14
+    summary: If you're in town early, join us for the Boat Ride. Prague features beautiful architectural and historical monuments along the river, and being on the water is an excellent way to sample the highlights.
+    icon: boat
+    dotw: Saturday
+  day_two:
+    event: Writing Day
+    date: September 15
+    summary: Join us for the Writing Day and Welcome Reception. The first official day of the conference is full of chances to interact with other documentarians.
+    icon: writing
+    dotw: Sunday
+  day_three:
+    event: Main Conference
+    date: September 16-17
+    summary: The main days of the conference. We will be running our main track in the ballroom, and the Unconference.
+    icon: conference
+    dotw: Monday
+  day_four:
+    date: September 17
+    dotw: Tuesday
+
+about:
+  summary:
+    "The main presentation track takes place from **September 15-17 (Monday and Tuesday) from 10:00 to 18:00**.
+    During the main event we also run an :doc:`/conf/prague/2019/unconference`.
+
+    You can find out more information about the venue and its accessibility on our :doc:`/conf/prague/2019/venue` page."
+  venue:
+    "Auto Klub, Opletalova 29, Prague"
+  attendees: 300
+  mainroom:
+    Main Ballroom
+  unconfroom:
+    Unconference Room, across from the Main Ballroom
+  photos: https://www.flickr.com/photos/writethedocs/sets/72157695294209550
+  videos: https://www.writethedocs.org/videos/prague/2019/
+
+cfp:
+  url: https://goo.gl/forms/M6YjhBgmCEwOwrzP2
+  ends: Thursday, May 31st
+  notification: Friday, June 15th
+
+job_fair:
+  location: Unconference Room, across from the Main Ballroom
+
+flaghassponsors: True
+flagcfp: False
+flagticketsonsale: False
+flagspeakersannounced: False
+flaghasschedule: False
+flagwelcomewagon: False
+flaglivestreaming: False
+flagvideos: false
+
+flaghashike: False
+flaghasboat: True
+flaglanding: True

--- a/docs/_data/config-prague-2019.yaml
+++ b/docs/_data/config-prague-2019.yaml
@@ -83,7 +83,6 @@ about:
     Main Ballroom
   unconfroom:
     Unconference Room, across from the Main Ballroom
-  videos: https://www.writethedocs.org/videos/prague/2019/
 
 cfp:
   url: https://goo.gl/forms/M6YjhBgmCEwOwrzP2

--- a/docs/_data/config-prague-2019.yaml
+++ b/docs/_data/config-prague-2019.yaml
@@ -4,7 +4,7 @@ shortcode: prague # prague australia?
 templatecode: eu # HACK
 year: 2019
 city: Prague
-local_area: Czech Republic
+local_area: Czechia
 area: Europe
 area_adj: European
 tz: CEST

--- a/docs/_data/config-prague-2019.yaml
+++ b/docs/_data/config-prague-2019.yaml
@@ -16,25 +16,25 @@ photos:
 
 tickets:
   community:
-    price: €500
+    price: €600
   corporate:
-    price: €250
+    price: €300
   independent:
-    price: €150
+    price: €175
   student:
     price: €75
 
 sponsorship:
   first_draft:
-    price: €500
+    price: €750
   second_draft:
-    price: €1000
+    price: €1500
   publisher:
-    price: €3000
+    price: €3500
   patron:
-    price: €6000
+    price: €7500
   keystone:
-    price: €12000
+    price: €13000
   job_fair:
     price: €800
     half: €400

--- a/docs/_data/config-prague-2019.yaml
+++ b/docs/_data/config-prague-2019.yaml
@@ -65,10 +65,7 @@ date: # how do we handle these? human readable would be nice.
     date: September 16-17
     summary: The main days of the conference. We will be running our main track in the ballroom, and the Unconference.
     icon: conference
-    dotw: Monday
-  day_four:
-    date: September 17
-    dotw: Tuesday
+    dotw: Monday/Tuesday
 
 about:
   summary:

--- a/docs/_data/config-prague-2019.yaml
+++ b/docs/_data/config-prague-2019.yaml
@@ -83,7 +83,6 @@ about:
     Main Ballroom
   unconfroom:
     Unconference Room, across from the Main Ballroom
-  photos: https://www.flickr.com/photos/writethedocs/sets/72157695294209550
   videos: https://www.writethedocs.org/videos/prague/2019/
 
 cfp:

--- a/docs/conf/prague/2019/about.rst
+++ b/docs/conf/prague/2019/about.rst
@@ -1,0 +1,14 @@
+:template: {{year}}/generic.html
+:banner: _static/{{year}}/assets/headers/team.png
+
+About the Conference
+====================
+
+We invite you to join hundreds of other folks for a three-day event to explore the art and science of documentation.
+The Write the Docs conference covers any topic related to documentation in the software industry.
+Past talks have also covered such diverse topics as empathy, the history of math symbols, and using emoji to keep your users' attention.
+
+Write the Docs brings *everyone* who writes the docs together in the same room: Writers, Developers, Developer Relations, Customer Support, and more.
+We all have things to learn, and there's no better way than coming together in the same room and getting to know each other.
+
+{{about.summary}}

--- a/docs/conf/prague/2019/badge-flair.rst
+++ b/docs/conf/prague/2019/badge-flair.rst
@@ -1,0 +1,6 @@
+:template: {{year}}/generic.html
+
+Badge Flair Contest
+===================
+
+{% include "conf/events/badge-flair.rst" %}

--- a/docs/conf/prague/2019/cfp.rst
+++ b/docs/conf/prague/2019/cfp.rst
@@ -1,0 +1,97 @@
+:template: {{year}}/generic.html
+:banner: _static/2019/assets/headers/speakers.jpg
+
+Call for Proposals
+==================
+
+Hello hello, fellow documentarians!
+
+It's that time of year again: We’re very excited to announce that we are now accepting talk proposals for our next {{ area_adj }} conference, coming up on {{date.main}}.
+
+Every year, Write the Docs invites people from all across our community to come up on stage to share their insights and experience. Whether you’ve worked on documentation for decades or you’ve just started this year, we want to hear from
+you! Read on to learn more about the goals of the conference and what we look for in talk proposals.
+
+In the meantime, mark your calendars:
+
+**The deadline for submitting proposals is Midnight {{TZ}} on {{cfp.ends}}.**
+
+We'll let you know if your proposal has been accepted by {{cfp.notification}}.
+
+Conference goals
+----------------
+
+Write the Docs conferences are our chance to get together in-person to explore and celebrate the craft of documentation in a positive, inclusive environment.
+
+Between the talks on stage, the discussions in the unconference, the collaboration on the writing day and the conversations in the hallway, 100% of the content for our conferences comes from our community! Whether your job title is writer, developer, product manager, support advocate, librarian, or one of a hundred others, your perspective on what makes good docs is what this conference is all about.
+
+Our goal is to give documentarians a chance to connect and learn from each other. You'll have the chance to compare notes on what's happening in the industry, dig into questions of convention and good practice, and generally nerd out about all the things we love about documentation.
+
+What we’re looking for
+----------------------
+
+**Mix of topics and perspectives**
+
+The focus of Write the Docs is software documentation, but we actively seek talks that address a wide range of related subjects,
+at various levels of expertise. Documentation perspectives from other fields are welcome! Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+
+**Diverse group of speakers**
+
+We welcome talks from first-time speakers, from industry experts, and from everyone in between. Whatever your background and experience, we prefer hearing about new approaches than about tried-and-tested technology. We especially welcome talks from underrepresented groups within the tech community.
+
+**Practicality and positivity**
+
+We prefer talks backed by experience and experimentation to talks about theory, and we definitely don't like talks that bad-mouth technologies or approaches. Don't tell us why you hate something – tell us how you overcame the problems it was causing.
+
+**Process over tooling**
+
+We tend to avoid talks about specific tools, which often turn into marketing pitches or tutorials. We would much rather hear about process, culture, data, people, or the metaphysical side effects of spending your life thinking about docs.
+
+**Audience awareness**
+
+When crafting talk proposals, remember that you're going to be talking to a mix of levels of expertise, skill sets, and professions. Your talk doesn't have to be relevant to everyone, but it should be relevant to most people and shouldn't
+make too many assumptions about what people already know.
+
+Take a look at the abstracts for accepted talks from the last couple of conferences for some ideas:
+
+* `Portland 2019 <http://www.writethedocs.org/conf/portland/2019/speakers/>`_
+* `Portland 2017 <http://www.writethedocs.org/conf/na/2017/speakers/>`_
+* `Prague 2017 <http://www.writethedocs.org/conf/eu/2017/speakers/>`_
+* `Portland 2016 <http://www.writethedocs.org/conf/na/2016/speakers/>`_
+* `Prague 2016 <http://www.writethedocs.org/conf/eu/2016/speakers/>`_
+
+Need help?
+-----------
+
+If you need a hand preparing your talk proposal, there are lots of good places to start:
+
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <http://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `http://slack.writethedocs.org/ <http://slack.writethedocs.org/>`_.)
+
+Presentation format
+-------------------
+
+Presentations will be scheduled in 30-minute blocks. We won't be doing Q&A after the talks, but we ask that speakers be available at the front of the stage for a few minutes of the break after their talk to answer questions.
+
+Speaker benefits & logistics
+----------------------------
+
+If you are selected to speak at Write the Docs, we will waive your attendance fee. We regret that we are not able to cover the cost of travel or lodging for all speakers at this time. By not covering travel costs for our speakers, we are able to keep ticket prices low and to make the conference accessible to the largest number of participants possible.
+
+If your proposal is accepted but you are unable to attend due to travel costs, please let us know and we will do our best to help make it happen.
+
+**You’ll hear from us with our proposal decisions by {{cfp.notification}}.**
+
+Questions?
+----------
+
+If you have any questions, please email us at `{{email}} <mailto:{{email}}>`_ and let us know.
+
+Submit your proposal
+--------------------------
+
+.. raw:: html
+
+	<iframe src="{{cfp.url}}?embedded=true" width="760" height="850" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+
+You can also view `our CFP <{{cfp.url}}>`_ in its own page.

--- a/docs/conf/prague/2019/convince-your-manager.rst
+++ b/docs/conf/prague/2019/convince-your-manager.rst
@@ -1,0 +1,65 @@
+:template: {{year}}/generic.html
+
+Convince Your Manager
+=====================
+
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
+Feel free to adapt and share with your manager to show them the many benefits of attending!
+
+Sample email
+-------------
+
+Remember to change the things in `[brackets]`!
+
+----
+
+  FROM: [your name]
+
+  TO: [your employer or manager's name]
+
+  SUBJECT: Professional Development: Documentation Community Conference
+
+  I'd like to attend Write the Docs {{city}}, which takes place {{ date.main }}. This three-day event explores the art and science of documentation, and covers a diverse range of topics related to documentation in the software industry.
+
+  Write the Docs conferences bring together everyone who writes the docs – Tech Writers, Developers, Developer Relations, Customer Support – making the events an ideal networking opportunity.
+  Each conference successfully combines a number of different event formats to deliver engaging, practical, and timely content.
+
+  There is a single track of talks, a parallel unconference event, and a community writing day. The `sessions from last year </conf/eu/{{year-1}}/speakers/>`_ will give you a good idea of the kinds of topics covered, many of which are relevant to my work.
+
+  Costs:
+
+  * Conference ticket (includes breakfast and lunch) - {{tickets.corporate.price}}
+  * Travel – [fill in with estimate]
+  * Accommodation – – [fill in with estimate]
+
+  Benefits:
+
+  * Discovering solutions to problems I'm facing at work
+  * Exposure to the latest ideas, techniques, and tools for software docs
+  * Opportunity to learn from the best doc teams in the industry
+  * Building professional connections with other documentarians
+
+  Thanks in advance,
+  [your name]
+
+----
+
+Resources
+---------
+
+When discussing how to pitch the conference, a few generally helpful tips emerged:
+
+* Highlight a few specific talks that relate to ongoing projects at work. (This one's dependent on pitching after the talk line up has been announced).
+* If your company is looking to hire another documentarian, the job fair and networking at the event are an excellent resource.
+* Don't forget that one of the benefits to your attendance is that it raises the visibility of your company in the community. If your team wants a reputation for caring about their docs, having people at Write the Docs is a great way to do that.
+
+In addition, it can be useful to share some info about previous conferences. You can find the websites for previous events on :doc:`/conf/index/`, and a quick list of last year's talks down below.
+But perhaps more useful might be some of the info in our :doc:`press-kit/`, which includes community testimonials, photos, and more.
+
+List of talks from 2017
+-----------------------
+
+.. datatemplate::
+   :source: /_data/2017.{{templatecode}}.speakers.yaml
+   :template: 2017/simple-talk-list.rst

--- a/docs/conf/prague/2019/convince-your-manager.rst
+++ b/docs/conf/prague/2019/convince-your-manager.rst
@@ -57,9 +57,9 @@ When discussing how to pitch the conference, a few generally helpful tips emerge
 In addition, it can be useful to share some info about previous conferences. You can find the websites for previous events on :doc:`/conf/index/`, and a quick list of last year's talks down below.
 But perhaps more useful might be some of the info in our :doc:`press-kit/`, which includes community testimonials, photos, and more.
 
-List of talks from 2017
------------------------
+List of talks from {{year-1}}
+-----------------------------
 
 .. datatemplate::
-   :source: /_data/2017.{{templatecode}}.speakers.yaml
-   :template: 2017/simple-talk-list.rst
+   :source: /_data/{{year-1}}.{{shortcode}}.speakers.yaml
+   :template: {{year-1}}/speakers-simple-list.rst

--- a/docs/conf/prague/2019/index.rst
+++ b/docs/conf/prague/2019/index.rst
@@ -1,0 +1,25 @@
+:template: {{year}}/index.html
+:banner: _static/2019/assets/images/backgrounds/{{ shortcode }}-green.jpg
+:orphan:
+
+.. raw:: html
+
+  <div class="news-block">
+    <div class="uk-container">
+
+      <h2>Updates from the team</h2>
+      <section>
+      <div class="content">
+
+.. postlist:: 10
+   :date: %B %d, %Y
+   :format: {title} - {date}
+   :list-style: none
+   :tags: {{ shortcode }}-{{ year }}
+
+.. raw:: html
+
+      </div>
+      </section>
+    </div>
+  </div><!--- end news block -->

--- a/docs/conf/prague/2019/job-fair.rst
+++ b/docs/conf/prague/2019/job-fair.rst
@@ -1,0 +1,11 @@
+:template: {{year}}/generic.html
+
+Job Fair
+========
+
+{% include "conf/events/job-fair.rst" %}
+
+Schedule
+--------
+
+Scheduling information is available on our :doc:`/conf/{{shortcode}}/{{year}}/schedule` page.

--- a/docs/conf/prague/2019/lightning-talks.rst
+++ b/docs/conf/prague/2019/lightning-talks.rst
@@ -1,0 +1,8 @@
+:template: {{year}}/generic.html
+
+Lightning Talks
+===============
+
+.. _speaker-lightning-talks-2019/eu:
+
+{% include "conf/events/lightning-talks.rst" %}

--- a/docs/conf/prague/2019/mailing-list.rst
+++ b/docs/conf/prague/2019/mailing-list.rst
@@ -1,0 +1,35 @@
+:template: {{year}}/generic.html
+
+Join our mailing list
+=====================
+
+.. raw:: html
+
+    <!-- Begin MailChimp Signup Form -->
+    <link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
+    <div id="mc_embed_signup">
+    <form action="//writethedocs.us6.list-manage.com/subscribe/post?u=94377ea46d8b176a11a325d03&amp;id=dcf0ed349b" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+        <div id="mc_embed_signup_scroll">
+    <div class="mc-field-group">
+        <label for="mce-EMAIL">Email Address  <span class="asterisk">*</span>
+    </label>
+        <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+    </div>
+    <div class="mc-field-group input-group">
+        <strong>What types of updates would you like? </strong>
+        <ul><li><input type="checkbox" value="1" name="group[14633][1]" id="mce-group[14633]-14633-0" checked><label for="mce-group[14633]-14633-0">Monthly Community Newsletter</label></li>
+        <li><input type="checkbox" value="2" name="group[14633][2]" id="mce-group[14633]-14633-1" checked><label for="mce-group[14633]-14633-1">North American Conference Announcements</label></li>
+        <li><input type="checkbox" value="4" name="group[14633][4]" id="mce-group[14633]-14633-2"><label for="mce-group[14633]-14633-2">European Conference Announcements</label></li>
+    </ul>
+    </div>
+        <div id="mce-responses" class="clear">
+            <div class="response" id="mce-error-response" style="display:none"></div>
+            <div class="response" id="mce-success-response" style="display:none"></div>
+        </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+        <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_94377ea46d8b176a11a325d03_dcf0ed349b" tabindex="-1" value=""></div>
+        <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+        </div>
+    </form>
+    </div>
+    <script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
+    <!--End mc_embed_signup-->

--- a/docs/conf/prague/2019/news/index.rst
+++ b/docs/conf/prague/2019/news/index.rst
@@ -1,0 +1,13 @@
+:template: {{year}}/generic.html
+
+News
+====
+
+Updates from the team.
+More here as it happens!
+
+ .. postlist:: 3
+   :date: %A, %B %d, %Y
+   :format: {title} - {date}
+   :list-style: none
+   :tags: prague-2019

--- a/docs/conf/prague/2019/news/prague-19-dates.rst
+++ b/docs/conf/prague/2019/news/prague-19-dates.rst
@@ -1,0 +1,13 @@
+:template: {{year}}/generic.html
+
+.. post:: December 10, 2018
+   :tags: prague-2019
+
+Announcing Prague Conference Dates
+==================================
+
+Today we are announcing the dates for `Write the Docs Prague 2019 <http://www.writethedocs.org/conf/prague/2019/>`_.
+This year's Prague conference will be held {{ date.main }}.
+We will return to the the Auto Klub, Opletalova 29, Prague 1 right next to the train station in the Prague city center.
+
+We expect to open both ticket sales and the Call for Proposals in March 2019.

--- a/docs/conf/prague/2019/outing.rst
+++ b/docs/conf/prague/2019/outing.rst
@@ -1,0 +1,24 @@
+:template: {{year}}/generic.html
+
+{% if shortcode == 'prague'%}
+:banner: _static/2019/assets/headers/group.png
+
+Write the Docs Boat Ride
+========================
+
+{% include "conf/prague/boat.rst" %}
+
+{% elif shortcode == 'portland'%}
+
+:banner: _static/2019/assets/headers/hike.png
+
+Write the Docs Hike
+===================
+
+{% include "conf/portland/hike.rst" %}
+
+{% else %}
+
+We don't have an outing yet.
+
+{% endif %}

--- a/docs/conf/prague/2019/press-kit.rst
+++ b/docs/conf/prague/2019/press-kit.rst
@@ -1,0 +1,62 @@
+:template: {{year}}/generic.html
+
+Press Kit
+=========
+
+We love that you're supporting Write the Docs by writing about the conference, sharing news about it on social media, telling people you're planning to attend.
+We're trying to make it as easy as possible for you to do any of the above, so here are some sample tweets, useful information, and handy images you can use.
+
+Sample tweets
+-------------
+
+Use these unedited, or tweak them as needed!
+
+
+.. raw:: html
+
+  <ul>
+    <li>I&#39;m attending Write the Docs {{date.main }} to discuss all things documentation. <br><a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="I&#39;m attending Write the Docs {{date.main }} to discuss all things documentation." data-url="http://www.writethedocs.org/conf/{{shortcode}}/{{year}}/" data-hashtags="writethedocs" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></li>
+    <li>Join writers, programmers, librarians, scientists, developer advocates. and support humans at #writethedocs in {{ date.main }} to discuss all things documentation. <br><a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="Join writers, programmers, librarians, scientists, developer advocates. and support humans at #writethedocs in {{ date.main }} to discuss all things documentation." data-url="http://www.writethedocs.org/conf/{{shortcode}}/{{year}}/" data-hashtags="writethedocs" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></li>
+  </ul>
+
+Good things people have said about us
+-------------------------------------
+
+.. raw:: html
+
+  <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">I&#39;m finding myself really sad that today isn&#39;t a <a href="https://twitter.com/hashtag/writethedocs?src=hash&amp;ref_src=twsrc%5Etfw">#writethedocs</a> day today too. I mean yes, today I can literally write the docs, but still.</p>&mdash; Diana Potter (@drpotter) <a href="https://twitter.com/drpotter/status/601133512205291520?ref_src=twsrc%5Etfw">May 20, 2015</a></blockquote>
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+  <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr"><a href="https://twitter.com/hashtag/writethedocs?src=hash&amp;ref_src=twsrc%5Etfw">#writethedocs</a> ended yesterday. It was such a great conference! <a href="https://t.co/uhyEIYrbTV">https://t.co/uhyEIYrbTV</a></p>&mdash; 🌟 Aleen vs. the Forces of Evil 🌟 (@Aleen) <a href="https://twitter.com/Aleen/status/601111911791534081?ref_src=twsrc%5Etfw">May 20, 2015</a></blockquote>
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+  <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">On my way home from another great <a href="https://twitter.com/hashtag/writethedocs?src=hash&amp;ref_src=twsrc%5Etfw">#writethedocs</a>. Already working on ways to apply what I learned. If you care about docs, be here next time!</p>&mdash; Daniel D. Beck (@ddbeck) <a href="https://twitter.com/ddbeck/status/601042665744957440?ref_src=twsrc%5Etfw">May 20, 2015</a></blockquote>
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+Useful numbers
+---------------
+
+We have some stats about attendees, membership, and website hits over on the following blog posts:
+
+- :doc:`/blog/write-the-docs-2017-stats/`
+- :doc:`/blog/write-the-docs-2016-year-in-review/`
+
+
+Images and logos
+-------------------
+
+We're working on getting our new logos and images up here, in the meantime you can use any of the Creative Commons licensed images from our `Flickr gallery <https://www.flickr.com/photos/writethedocs/>`_ or take a look at the `logo and other assets stylesheet <https://github.com/writethedocs/resources/blob/master/conf/2019/STYLE-SHEET-2019.pdf>`_.
+
+In particular, we encourage you to use these three photos in your tweets and blog posts, which we think are expecially representative of Write the Docs Portland.
+
+.. raw:: html
+
+  <a data-flickr-embed="true"  href="https://www.flickr.com/photos/writethedocs/34495135662/in/album-72157683817839465/" title="All quiet"><img src="https://farm5.staticflickr.com/4162/34495135662_664eaf3870_k.jpg" width="1024" height="683" alt="All quiet"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+
+  <hr>
+
+  <a data-flickr-embed="true"  href="https://www.flickr.com/photos/writethedocs/33849416753/in/album-72157683817839465/" title="Settling in to work"><img src="https://farm5.staticflickr.com/4194/33849416753_acf46120e6_b.jpg" width="1024" height="683" alt="Settling in to work"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+
+  <hr>
+
+  <a data-flickr-embed="true"  href="https://www.flickr.com/photos/writethedocs/33856825394/in/album-72157683817839465/" title="Group shot!"><img src="https://farm5.staticflickr.com/4193/33856825394_27fe2d0b6b_b.jpg" width="1024" height="393" alt="Group shot!"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>

--- a/docs/conf/prague/2019/schedule.rst
+++ b/docs/conf/prague/2019/schedule.rst
@@ -1,0 +1,182 @@
+:template: {{year}}/generic.html
+
+Schedule
+========
+
+Write the Docs is more than a conference.
+Each year we organize a wide range of events so that people can come together, collaborate, and learn from each other in different ways.
+
+.. contents::
+    :local:
+    :depth: 1
+    :backlinks: none
+
+{{date.day_one.dotw}}, {{date.day_one.date}}
+--------------------------------------------------
+
+{% if flaghashike %}
+
+Hike
+~~~~
+
+The only event scheduled on Saturday is the :doc:`annual hike to Pittock Mansion </conf/{{shortcode}}/{{year}}/outing>`.
+If you get into town early, join us on the hike and take the chance to explore Portland in all of its glory.
+
+* **Where**: Lower Macleay Park or Macleay Park Entrance.
+* **When**: 13:45
+* **Details**: :doc:`Annual hike to Pittock Mansion </conf/{{shortcode}}/{{year}}/outing>`
+
+{% endif %}
+
+{% if flaghasboat %}
+
+Boat Ride
+~~~~~~~~~
+
+The only event scheduled on Saturday is the :doc:`Prague Boat Ride </conf/{{shortcode}}/{{year}}/outing>`.
+If you get into town early, join us and experience Prague from the water.
+
+Further details will be announced later.
+
+{% endif %}
+
+
+{{date.day_two.dotw}}, {{date.day_two.date}}
+----------------------------------------
+
+The Writing Day and Welcome Reception will be held at the **{{about.venue}}**.
+
+*Breakfast and lunch will be provided, as well as snacks and drinks all day.*
+
+.. contents::
+    :local:
+    :backlinks: none
+
+Writing Day
+~~~~~~~~~~~
+
+* **Where**: {{about.venue}}, {{about.mainroom}}
+* **When**: **9:00-17:00**
+* **Details**: :doc:`Writing Day documentation sprints </conf/{{shortcode}}/{{year}}/writing-day>`
+
+{% if flaghasschedule %}
+
+.. datatemplate::
+   :source: /_data/{{templatecode}}-{{year}}-day-0.yaml
+   :template: include/schedule2019.rst
+   :include_context:
+
+{% else %}
+  A detailed schedule will be announced soon.
+{% endif %}
+
+Reception
+~~~~~~~~~
+
+We encourage everyone to drop by on Sunday evening for the conference reception.
+You'll have a chance to get acquainted with each other over some drinks and snacks.
+We'll also help groups organize dinner plans, so you can continue your conversations over more substantial food as well.
+
+* **Where**: {{about.venue}}, {{about.mainroom}}
+* **When**: **17:00-20:00**
+
+Monday, September 10
+--------------------
+
+.. contents::
+   :local:
+   :backlinks: none
+
+This is the main event! Hear from lots of interesting folks about all things documentation.
+We will have talks all day on the main stage, and a unconference session running in parallel in the afternoon.
+
+*Breakfast and lunch will be provided, as well as snacks and drinks all day.*
+
+Conference Talks
+~~~~~~~~~~~~~~~~
+
+* **Where**: {{about.venue}}, {{about.mainroom}}
+* **When**: **10:00-18:00**
+* **Details**: :doc:`/conf/{{shortcode}}/{{year}}/speakers`
+
+
+{% if flaghasschedule %}
+
+.. datatemplate::
+   :source: /_data/{{templatecode}}-{{year}}-day-1.yaml
+   :template: include/schedule2019.rst
+   :include_context:
+
+{% else %}
+  A detailed schedule will be announced soon.
+{% endif %}
+
+Unconference
+~~~~~~~~~~~~
+
+The unconference sessions run in parallel to the main conference talks.
+
+* **Where**: {{about.venue}}, {{about.unconfroom}}
+* **When**: **10:40-18:00**
+* **Details**: :doc:`/conf/{{shortcode}}/{{year}}/unconference`
+
+Monday Night Social
+~~~~~~~~~~~~~~~~~~~
+
+The official Write the Docs social!
+
+This event is for **conference attendees only**. Please bring your badge to be let into the venue.
+There will be light snacks and drinks available on the conference while our tab lasts.
+
+* **Where**: `Hoffa Bar, Senovážné Náměstí 22, Prague 1 <https://goo.gl/maps/b1egvQhoDxt>`_
+* **When**: **20:00-23:00**
+* **Details**: Drinks and snacks are included while our tab lasts. If you want a sit-down dinner we recommend to grab it before, as we will only have light snacks and finger food at the event. The bar is located on the ground floor and is accessible to wheelchairs.
+
+Tuesday, September 11
+---------------------
+
+.. contents::
+   :local:
+   :backlinks: none
+
+And the conference goes on!
+
+*Breakfast and lunch will be provided, as well as snacks and drinks all day.*
+
+Conference Talks
+~~~~~~~~~~~~~~~~
+
+* **Where**: {{about.venue}}, {{about.mainroom}}
+* **When**: **10:00-16:30**
+* **Details**: :doc:`/conf/{{shortcode}}/{{year}}/speakers`
+
+{% if flaghasschedule %}
+
+.. datatemplate::
+   :source: /_data/{{templatecode}}-{{year}}-day-2.yaml
+   :template: include/schedule2019.rst
+   :include_context:
+
+{% else %}
+  A detailed schedule will be announced soon.
+{% endif %}
+
+.. _{{shortcode}}-{{year}}-job-fair:
+
+Job Fair
+~~~~~~~~
+
+New in 2019! We'll be holding a job fair on Tuesday morning!
+
+* **Where**: {{about.venue}}, {{about.unconfroom}}
+* **When**: **10:30-11:50**
+* **Details**: :doc:`/conf/{{shortcode}}/{{year}}/job-fair`
+
+Unconference
+~~~~~~~~~~~~
+
+The unconference sessions run in parallel to the main conference talks.
+
+* **Where**: {{about.venue}}, {{about.unconfroom}}
+* **When**: **12:10-15:30**
+* **Details**: :doc:`/conf/{{shortcode}}/{{year}}/unconference`

--- a/docs/conf/prague/2019/schedule.rst
+++ b/docs/conf/prague/2019/schedule.rst
@@ -166,7 +166,7 @@ Conference Talks
 Job Fair
 ~~~~~~~~
 
-New in 2019! We'll be holding a job fair on Tuesday morning!
+We'll be holding a job fair on Tuesday morning!
 
 * **Where**: {{about.venue}}, {{about.unconfroom}}
 * **When**: **10:30-11:50**

--- a/docs/conf/prague/2019/speakers.rst
+++ b/docs/conf/prague/2019/speakers.rst
@@ -1,0 +1,16 @@
+:template: {{year}}/generic.html
+:banner: _static/2019/assets/headers/speakers.jpg
+
+Conference Speakers
+===================
+
+{% if flagspeakersannounced %}
+
+.. datatemplate::
+   :source: /_data/{{year}}.{{shortcode}}.speakers.yaml
+   :template: {{year}}/speakers.rst
+   :include_context:
+
+{% else %}
+  Nothing to see yet.
+{% endif %}

--- a/docs/conf/prague/2019/speaking-tips.rst
+++ b/docs/conf/prague/2019/speaking-tips.rst
@@ -1,0 +1,7 @@
+:template: {{year}}/generic.html
+:banner: _static/2019/assets/headers/writing-day.png
+
+Speaking Tips
+=================
+
+{% include "conf/speaking-tips.rst" %}

--- a/docs/conf/prague/2019/sponsors/index.rst
+++ b/docs/conf/prague/2019/sponsors/index.rst
@@ -1,0 +1,9 @@
+:template: {{year}}/generic.html
+
+Sponsors
+========
+
+We are seeking corporate partners to help us create the best conference possible.
+Please see our :doc:`/conf/{{shortcode}}/{{year}}/sponsors/prospectus`.
+
+Contact us at sponsorship@writethedocs.org for more information on sponsoring Write the Docs.

--- a/docs/conf/prague/2019/sponsors/prospectus.rst
+++ b/docs/conf/prague/2019/sponsors/prospectus.rst
@@ -1,0 +1,287 @@
+:template: {{year}}/generic.html
+:banner: _static/2019/assets/headers/group.png
+
+Sponsorship Prospectus
+######################
+
+.. raw:: pdf
+
+   PageBreak
+
+.. contents::
+   :local:
+   :depth: 1
+   :backlinks: none
+
+**New this year**: our `Job Fair`_.
+
+Concept
+=======
+
+Write the Docs (http://www.writethedocs.org/) is a
+**three day conference** focusing on documentation systems, tech writing
+theory, and information delivery.
+
+Writing and maintaining documentation involves a multidisciplinary
+community of technical writers, designers, librarians, typesetters, developers,
+support teams, marketers and many others. This group of people can be
+collectively referred to as “documentarians”.
+
+**Write the Docs** creates a time and a place for this community to
+share information, discuss ideas, and work together to improve the art
+and science of documentation.
+
+For too long, people who care about documentation have felt alone in the
+world, not able to connect with their community. Write the Docs is a
+magical experience for many of our attendees, allowing them to feel like
+they have found their place. We believe this is the most
+important thing that our event can do, and we aim to provide that
+experience again this year, and make it better than ever.
+
+Demographics
+============
+
+We hold two conferences yearly, one in Portland, USA in May, and one in
+Prague, Europe in September. Attendence is approximately 400 in the
+USA and 250 in Europe, and we expect both conferences to sell out.
+
+Our audience is made up of:
+
+- Technical Writers (50%)
+- Developers (15%)
+- Support Staff (15%)
+- Managers (10%)
+- Community Contributors, Enthusiasts & Other Folks (10%)
+
+Why Sponsor
+===========
+
+By supporting a Write the Docs event, your company will gain not only visibility
+and credibility with front-line documentarians, but also valuable
+insights that will help you get the most out of your own documentation efforts.
+If you're hiring for docs positions, Write the Docs is also an excellent
+opportunity to meet top-notch talent.
+
+Our conferences are run by teams of volunteers, and we work hard to keep ticket
+prices affordable for a broad range of attendees. Your sponsorship makes it
+possible for all sorts of documentarians to attend our events, whether they're a
+freelancer, a student or out of work. Becoming a sponsor demonstrates your
+commitment to and support of good documentation, and the people who build it.
+
+.. raw:: pdf
+
+   PageBreak
+
+Sponsorship Packages
+====================
+
+The following options are suggested sponsorship levels. We are happy to discuss
+adjustments and custom packages.
+
+First Draft
+-----------
+
+The **First Draft** package is only available to startups (under 15 employees),
+non-profits,
+and open source organizations.
+
+- One (1) ticket_
+- Small logo & link on the Write the Docs website
+- Name included in welcome announcement in email newsletters and social media
+- Display 1 promotional (“Swag”) item on the conference swag table (provided by sponsor)
+- **NOTE**: A table at the job fair is now included in this sponsorship
+
+
+
+The **First Draft** package costs {{sponsorship.first_draft.price}}.
+You can buy it directly on our ticket website.
+
+Second Draft
+------------
+
+The **Second Draft** package is great for companies looking to hire or promote a product.
+
+- Two (2) tickets_
+- Medium logo & link on the Write the Docs website
+- Name included in welcome announcement in email newsletters and social media
+- Display 1 promotional (“Swag”) item on the conference swag table (provided by sponsor)
+- One featured job posting in our Newsletter (2,500 subscribers)
+- **NOTE**: A table at the job fair is now included in this sponsorship
+
+The **Second Draft** package costs **{{sponsorship.second_draft.price}}**.
+
+Publisher
+---------
+
+The **Publisher** package is great for sending a team and getting to know the community.
+
+- Five (5) tickets_
+- Large logo & link on the Write the Docs website
+- Name included in welcome announcement in email newsletters and social media
+- Display 2 promotional (“Swag”) item on the conference swag table (provided by sponsor)
+- Two featured job postings in our Newsletter (2,500 subscribers)
+- A table at the job fair
+
+The **Publisher** package costs **{{sponsorship.publisher.price}}**.
+
+.. raw:: pdf
+
+   PageBreak
+
+Patron
+------
+
+Limit 2 (**One remaining**)
+
+The **Patron** package highlights your company as a force in the industry and community:
+
+- Ten (10) tickets_
+- Small table in the main conference hall
+- Small logo included on videos
+- Full size logo & link on the Write the Docs website
+- Name included in welcome announcement in email newsletters and social media
+- Display 3 promotional (“Swag”) item on the conference swag table (provided by sponsor)
+- Three featured job postings in our Newsletter (2,500 subscribers)
+- A featured table at the job fair
+
+The **Patron** package costs **{{sponsorship.patron.price}}**.
+
+Keystone
+--------
+
+Limit 1 (**Sold Out**)
+
+The **Keystone** package highlights you as our main community partner:
+
+- Fifteen (15) tickets_
+- Large table in the main conference hall
+- Dedicated table for staff
+- Large logo included on videos
+- Full size logo & link on the Write the Docs website
+- Name included in welcome announcement in email newsletters and social media
+- Display unlimited promotional (“Swag”) item on the conference swag table (provided by sponsor)
+- Five featured job postings in our Newsletter (2,500 subscribers)
+- A featured table at the job fair
+
+The **Keystone** package costs **{{sponsorship.keystone.price}}**.
+
+.. raw:: pdf
+
+   PageBreak
+
+Other Sponsorship Opportunities
+===============================
+
+The following a la carte offerings are available either independently or
+combined with one of the previous packages to increase visibility at the event.
+
+Job Fair
+--------
+
+Our job fair is a wonderful place to connect with the talented Write the Docs attendees.
+We'll have over {{about.attendees}} people in attendance for our conference,
+and many of those people will come to our job fair to look for new roles and positions.
+
+It is included in all sponsorship packages this year.
+
+- **Logistics**: The Job Fair will be Tuesday morning in {{job_fair.location}}. You can see the timing details on the :ref:`schedule <{{shortcode}}-{{year}}-job-fair>`.
+
+- **Layout**: Every participant will have a table and two chairs reserved for them. Giveaways/flyers are welcome, please make sure everything fits on your table.
+
+Note that the `Code of Conduct </code-of-conduct/>`_ and :ref:`coc-sponsors` apply to the Job Fair as well as to the rest of the conference.
+
+Lanyard
+-------
+
+Provide your branded lanyards for our badges. This makes your company name visible to each and every attendee at the conference!
+
+**{{sponsorship.lanyard.price}}**
+
+- **Logistics**: Sponsor is responsible for shipping lanyards to organizers at least two weeks before the event starts.
+
+Writing Day
+-----------
+
+Sponsor the Writing Day on Sunday, where we get together to help improve the documentation of many projects.
+This is great for any company that is looking for contributors to their open source projects.
+
+**{{sponsorship.writing_day.price}}**
+
+- **Logistics**: The Writing Day runs 10-5 on Sunday.
+
+
+.. raw:: pdf
+
+  PageBreak
+
+Inquiries
+=========
+
+Please direct all inquiries to our sponsorship team at:
+
+- sponsorship@writethedocs.org
+
+Payment
+=======
+
+We expect all invoices to be paid **within 21 days of invoice receipt**, as many
+of our expenses must be paid up front.
+
+.. _ticket: https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}/
+.. _tickets: https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}/
+
+Run of Show
+===========
+
+A quick overview of the spaces:
+
+* The *Main Ballroom* is where talks and most sponsorship activity happens. 
+* The *Unconference Room* is across from the main ballroom. This is where the Unconference & Job Fair happens.
+
+An overview of the conference schedule:
+
+* The Writing Day is on Sunday, in the main ballroom. You are welcome to run a documentation sprint here if your documentation is open source.
+* The main conference & sponsorship days are on Monday & Tuesday in the main ballroom.
+* The Job Fair happens Tuesday morning.
+
+The :doc:`/conf/{{ shortcode }}/{{ year }}/schedule` contains the most up to date information about the timing of events.
+
+How do I get the most out of my sponsorship?
+--------------------------------------------
+
+Come prepared to engage with our community, and to learn just as much as you teach. Engage with our event as attendees as well as sponsors. Send technical staff who can chat with people on the interesting things your company is doing, and get value from the vast amount of insight in the room. We do have some decision makers in the room, but soft sells will work better than hard sales in the environment we strive for.
+
+Who is my primary contact?
+--------------------------
+
+Eric Holscher <eric@writethedocs.org> will be your primary contact, but our team is available at <sponsorship@writethedocs.org>. If you have a time sensitive inquiry, please email the entire team to ensure a timely response.
+
+What are the dates that sponsors need to know about in advance?
+------------------------------------------------------------------
+
+* **SUNDAY**: The swag tables are available during the Writing Day, if you want to put out swag items early. 
+
+* **MONDAY**: Doors open at 9am, so we recommend arriving around this time to get the most interaction with attendees. This is the official start of the conference. The conference will run until around 5pm.
+
+* **TUESDAY**: The Job Fair will be in the morning, setup will start 30 minutes before the job fair starts. Sponsor tear down in the main hall will be 4pm on Tuesday. That will be the end of the conference, so feel free to book travel home that evening.
+
+How do I use get my free tickets?
+---------------------------------
+
+You should have recieved a unique URL with a discount code for your free sponsorship tickets. We are happy to send it over again, just ask!
+
+What do I need for the job fair?
+--------------------------------
+
+The job fair will be a low key event. Every participant will have a six-foot table and two chairs, in a seperate room from the primary conference. Giveaways/flyers are welcome, but please keep your setup requirements simple.
+
+What happens with my swag items?
+--------------------------------
+
+We will have a few "swag tables" that are placed around the back of the main ballroom. This will be where sponsor and community stickers & swag will be located, so that attendees are free to pick it up. 
+
+How do I ship items?
+--------------------
+
+Prior to the event, if you'd like to ship swag, we will send you the mailing address **3 weeks** prior to the event. We can't recieve packages before that. Anything sent to us will be available at the venue on the day of the event.
+

--- a/docs/conf/prague/2019/sponsors/prospectus.rst
+++ b/docs/conf/prague/2019/sponsors/prospectus.rst
@@ -13,8 +13,6 @@ Sponsorship Prospectus
    :depth: 1
    :backlinks: none
 
-**New this year**: our `Job Fair`_.
-
 Concept
 =======
 
@@ -25,7 +23,7 @@ theory, and information delivery.
 Writing and maintaining documentation involves a multidisciplinary
 community of technical writers, designers, librarians, typesetters, developers,
 support teams, marketers and many others. This group of people can be
-collectively referred to as “documentarians”.
+collectively referred to as "documentarians".
 
 **Write the Docs** creates a time and a place for this community to
 share information, discuss ideas, and work together to improve the art
@@ -235,7 +233,7 @@ Run of Show
 
 A quick overview of the spaces:
 
-* The *Main Ballroom* is where talks and most sponsorship activity happens. 
+* The *Main Ballroom* is where talks and most sponsorship activity happens.
 * The *Unconference Room* is across from the main ballroom. This is where the Unconference & Job Fair happens.
 
 An overview of the conference schedule:
@@ -259,7 +257,7 @@ Eric Holscher <eric@writethedocs.org> will be your primary contact, but our team
 What are the dates that sponsors need to know about in advance?
 ------------------------------------------------------------------
 
-* **SUNDAY**: The swag tables are available during the Writing Day, if you want to put out swag items early. 
+* **SUNDAY**: The swag tables are available during the Writing Day, if you want to put out swag items early.
 
 * **MONDAY**: Doors open at 9am, so we recommend arriving around this time to get the most interaction with attendees. This is the official start of the conference. The conference will run until around 5pm.
 
@@ -278,10 +276,9 @@ The job fair will be a low key event. Every participant will have a six-foot tab
 What happens with my swag items?
 --------------------------------
 
-We will have a few "swag tables" that are placed around the back of the main ballroom. This will be where sponsor and community stickers & swag will be located, so that attendees are free to pick it up. 
+We will have a few "swag tables" that are placed around the back of the main ballroom. This will be where sponsor and community stickers & swag will be located, so that attendees are free to pick it up.
 
 How do I ship items?
 --------------------
 
 Prior to the event, if you'd like to ship swag, we will send you the mailing address **3 weeks** prior to the event. We can't recieve packages before that. Anything sent to us will be available at the venue on the day of the event.
-

--- a/docs/conf/prague/2019/tickets.rst
+++ b/docs/conf/prague/2019/tickets.rst
@@ -1,0 +1,81 @@
+:template: {{year}}/generic.html
+
+Tickets
+=======
+
+
+{% if flagticketsonsale %}
+
+**Tickets are on sale now!**
+
+{% endif %}
+
+Each ticket includes:
+
+* Entry to all conference events and activities
+* Breakfast, snacks, and lunch on all conference days
+* Welcome Reception and Social Event with light snacks and free drinks
+* Wifi throughout the event
+* Meeting lots of fantastic people in a spacious, inviting venue
+
+
+.. class:: ticket
+
+**Community Sponsorship Tickets** *{{tickets.community.price}}*
+------------------------------------------
+
+Support the growing community! Get a logo on our website, as well as a ticket.
+This option is great for startups, open-source projects, and small non-profit organizations.
+Limit 1 per organization.
+If you are a larger company or organization, please contact us at sponsorship@writethedocs.org to arrange for sponsorship.
+
+{% if flagticketsonsale %}
+
+* `Buy Community Sponsorship Ticket <https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}>`__
+
+{% endif %}
+
+.. class:: ticket
+
+**Corporate Tickets** *{{tickets.corporate.price}}*
+------------------------------------
+
+Purchase this ticket if a company is paying for your attendance. Companies interested in sponsorship can also receive tickets to the conference with a sponsorship package.
+
+{% if flagticketsonsale %}
+
+* `Buy Corporate Ticket <https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}>`__
+
+{% endif %}
+
+.. class:: ticket
+
+**Independent Tickets** *{{tickets.independent.price}}*
+------------------------------------
+
+Purchase this ticket if you are paying for yourself, or if you work at a non-profit, a government, or a company with less than 10 employees.
+
+{% if flagticketsonsale %}
+
+* `Buy Independent Ticket <https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}>`__
+
+{% endif %}
+
+.. class:: ticket
+
+**Student or Unemployed Tickets** *{{tickets.student.price}}*
+----------------------------------------
+
+Purchase this ticket if you are currently enrolled as a student, or don't currently have a source of income.
+
+{% if flagticketsonsale %}
+
+* `Buy Student or Unemployed Ticket <https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}>`__
+
+{% endif %}
+.. class:: ticket
+
+**None of the above**
+---------------------
+
+If you can't afford these prices and still wish to attend, please email us at `{{shortcode}}@writethedocs.org <mailto:{{shortcode}}@writethedocs.org>`_. Being a community event that keeps prices low, we can only offer discounted ticket prices, and not travel or hotel assistance.

--- a/docs/conf/prague/2019/unconference.rst
+++ b/docs/conf/prague/2019/unconference.rst
@@ -1,0 +1,12 @@
+:template: {{year}}/generic.html
+:banner: _static/2019/assets/headers/writing-day.png
+
+Unconference
+============
+
+{% include "conf/events/unconference.rst" %}
+
+Schedule
+--------
+
+Unconference sessions run all day on Monday, and also in the afternoon on Tuesday after the Job Fair.

--- a/docs/conf/prague/2019/venue.rst
+++ b/docs/conf/prague/2019/venue.rst
@@ -1,0 +1,6 @@
+:template: {{year}}/generic.html
+
+About the Venue
+===============
+
+{% include "conf/" + shortcode + "/venue.rst" %}

--- a/docs/conf/prague/2019/visiting.rst
+++ b/docs/conf/prague/2019/visiting.rst
@@ -1,0 +1,7 @@
+:template: {{year}}/generic.html
+:banner: _static/2019/assets/headers/hike.png
+
+Visiting {{ city }}
+=======================
+
+{% include "conf/" + shortcode + "/visiting.rst" %}

--- a/docs/conf/prague/2019/writing-day.rst
+++ b/docs/conf/prague/2019/writing-day.rst
@@ -1,0 +1,15 @@
+:template: {{year}}/generic.html
+:banner: _static/2019/assets/headers/writing-day.png
+
+Writing Day
+===========
+
+{% include "conf/events/writing-day.rst" %}
+
+Schedule
+--------
+
+
+- Date & Time: **{{date.day_two.dotw}}, {{date.month}} {{date.day_two.date}}, 9am-6pm**,
+  with the conference opening reception in the same space from 17:00.
+- Location: **{{about.venue}}**. We will be in the main ballroom.

--- a/docs/include/conf/current.rst
+++ b/docs/include/conf/current.rst
@@ -2,7 +2,7 @@
 ----------------
 
 - :doc:`Write the Docs Portland </conf/portland/2019/index>`, May 19-21, **Portland, Oregon**
-- :doc:`Write the Docs Prague </conf/prague/2019/index>`, September 15-17, **Prague, Czech Republic**
+- :doc:`Write the Docs Prague </conf/prague/2019/index>`, September 15-17, **Prague, Czechia**
 - More details soon for other events
 
 2018 Conferences

--- a/docs/include/conf/current.rst
+++ b/docs/include/conf/current.rst
@@ -2,7 +2,7 @@
 ----------------
 
 - :doc:`Write the Docs Portland </conf/portland/2019/index>`, May 19-21, **Portland, Oregon**
-- Write the Docs Prague, September 
+- :doc:`Write the Docs Prague </conf/prague/2019/index>`, September 15-17, **Prague, Czech Republic**
 - More details soon for other events
 
 2018 Conferences

--- a/docs/include/conf/prague/boat.rst
+++ b/docs/include/conf/prague/boat.rst
@@ -4,14 +4,4 @@ If you're only in town for a few days, it's a perfect sampling of the main archi
 Of course, you can also walk around, but we tried that the first year and got a little sunburned! The next year, we got rained on, but being in a boat we didn't mind so much!
 So join us on a two-hour cruise of the city's highlights, all the while being protected from the elements!
 
-Logistics
----------
-
--  Date & Time: The boat leaves promptly on **Saturday, September 8 at 14:00**. Boarding at
-   **13:45**
--  Location: `Prague Boats, pier no. 5 <https://goo.gl/maps/bqLP3VaytVo>`__
--  Drinks and light snacks are included with the ticket!
-
-**This activity is priced separately and is not included in your conference ticket.** Please `register here <https://ti.to/writethedocs/write-the-docs-prague-2018>`_.
-
-You don't have to attend the conference to purchase a ticket for this boat tour, so friends and family are welcome to register too!
+Further details will be announced later.


### PR DESCRIPTION
This is my attempt at setting up the Prague 2019 landing page. It works, but there may be conventions that I overlooked. I started out from the Prague 2018 website. I don't know whether I'm supposed to remove all other content other than the landing page from conf/prague/2019.

I don't know if we usually do a "dates announced" announcement, but apparently the news posting list generator needs at least one item in the ``prague-2019`` tag, or it'll publish all general news.

Also, there appears to be a reference somewhere to `_templates/include/2019/prague-sponsors.html` and the build would break without it. I haven't been able to track down where this reference came from, so I made that an empty file right now to get it to build