### PR TITLE
Fix warning triggered by conf/na/2016/news/announcing-2016.md

### DIFF
--- a/docs/conf/na/2016/news/announcing-2016.md
+++ b/docs/conf/na/2016/news/announcing-2016.md
@@ -40,5 +40,5 @@ We’ve been so thrilled to see how much this community of documentarians has gr
 
 Remember, talk proposals will open soon. Start gathering your ideas and getting excited about another year of great talks and conversations!
 
-Cheers,   
-Write the Docs Team   
+Cheers,
+Write the Docs Team


### PR DESCRIPTION
Apparently, trailing spaces on a line can confuse one of the parsers. The warning was annoying me.