### PR TITLE
Fix green header for Prague 2019.

### DIFF
--- a/docs/conf/prague/2019/index.rst
+++ b/docs/conf/prague/2019/index.rst
@@ -1,5 +1,5 @@
 :template: {{year}}/index.html
-:banner: _static/2019/assets/images/backgrounds/{{ shortcode }}-green.jpg
+:banner: _static/{{year}}/assets/headers/prague-group.png
 :orphan:
 
 .. raw:: html


### PR DESCRIPTION
new screenshot:
![screenshot 2018-12-18 at 16 51 28](https://user-images.githubusercontent.com/98594/50165585-7e39e300-02e5-11e9-90ac-a976d8e9f259.png)
