### PR TITLE
Merging update to #job-posts-only purpose

### DIFF
--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -30,7 +30,7 @@ Everyone who joins the Slack will be added to these channels:
 
 * **#general** - The main channel for documentation related conversation and questions.
 * **#watercooler** - For talking about things that are off-topic. Get to know folks other interests that aren't around documentation :)
-* **#jobs-posts-only** - Posting or asking for jobs.
+* **#jobs-posts-only** - Posting jobs. (You can look for jobs in **#career-advice**)
 * **#wtd-conferences** - Questions and other thoughts around the :doc:`/conf/index`.
 * **#meetups** - Questions and other thoughts about our :doc:`/meetups/index`.
 * **#intros** - Introduce yourself! Let people know you're here, and why you care about docs :)


### PR DESCRIPTION
New users have been confused by the description of #job-posts-only here, so I updated it to hopefully reduce that confusion.