### PR TITLE
Portland 2019 CFP reminder and ticket sales blog post

### DIFF
--- a/docs/_data/config-portland-2019.yaml
+++ b/docs/_data/config-portland-2019.yaml
@@ -71,8 +71,8 @@ about:
 cfp:
   url: https://docs.google.com/forms/d/e/1FAIpQLScCK5qIaRwmn2UouYvtxfrQk56r_X72aliVWLnoGKb69HZuug/viewform
 
-  ends: "17 January, 2019"
-  notification: "8 February, 2019"
+  ends: "31 January, 2019"
+  notification: "21 February, 2019"
 
 flaghashike: True
 flaglanding: False

--- a/docs/_data/config-portland-2019.yaml
+++ b/docs/_data/config-portland-2019.yaml
@@ -79,7 +79,7 @@ flaglanding: False
 flagspeakersannounced: False
 flagcfp: True
 flaghasschedule: False
-flagticketsonsale: False
+flagticketsonsale: True
 flaghasboat: False
 flaghasshirts: False
 flaghassponsors: True

--- a/docs/_templates/2019/index.html
+++ b/docs/_templates/2019/index.html
@@ -65,7 +65,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
         <div class="ctas-block">
          <a class="uk-button uk-button-secondary uk-text-center" href="{{ pathto('conf/' + shortcode + '/' + year|string + '/sponsors/prospectus') }}">Sponsor the conference</a>
 
-         {% if flagticketsonsale %}
+         {% if flagticketsonsale and not cfp %}
 
          <a class="uk-button uk-button-secondary uk-text-center" href="{{ pathto('conf/' + shortcode + '/2019/tickets') }}">Buy a Ticket!</a>
 

--- a/docs/conf/portland/2019/cfp.rst
+++ b/docs/conf/portland/2019/cfp.rst
@@ -17,6 +17,8 @@ In the meantime, mark your calendars:
 
 **The deadline for submitting proposals is Midnight {{TZ}} on {{cfp.ends}}.**
 
+.. note:: The original deadline was 17th January, with notification by 8th Feb. Check the :doc:`extension announcement </conf/portland/2019/news/cfp-reminder>`.
+
 We'll let you know if your proposal has been accepted by the {{cfp.notification}}.
 
 Conference goals

--- a/docs/conf/portland/2019/news/cfp-reminder.rst
+++ b/docs/conf/portland/2019/news/cfp-reminder.rst
@@ -9,7 +9,7 @@ CFP Reminder & Tickets on Sale
 
 Happy New Year, fellow documentarians!
 
-As we get ready to start the year, we're happy to share the latest update about the Portlant conference. We are extending our `call for proposals <http://www.writethedocs.org/conf/portland/2019/cfp/>`_ until **January 31st**, and `tickets for the conference are officially on sale <http://www.writethedocs.org/conf/portland/2019/tickets/>`_. Read on for more details on both!
+As we get ready to start the year, we're happy to share the latest update about the Portland conference. We are extending our `call for proposals <http://www.writethedocs.org/conf/portland/2019/cfp/>`_ until **January 31st**, and `tickets for the conference are officially on sale <http://www.writethedocs.org/conf/portland/2019/tickets/>`_. Read on for more details on both!
 
 Submit your talk by January 31st
 --------------------------------

--- a/docs/conf/portland/2019/news/cfp-reminder.rst
+++ b/docs/conf/portland/2019/news/cfp-reminder.rst
@@ -26,7 +26,7 @@ Get your ticket for the conference
 
 **The Portland conference will be returning to the Crystal Ballroom on May 19-21, 2019.** The `full event website <http://www.writethedocs.org/conf/portland/2019/>`_ is live, with some preliminary details, and we'll be filling in more as it gets closer. We're already excited to see what this year has in store!
 
-If you're excited too, go ahead and `register for your ticket now <http://www.writethedocs.org/conf/portland/2019/>`_! For the past several years the conference has sold out, so we highly recommend to buy early and reserve your spot.
+If you're excited too, go ahead and `register for your ticket now <http://www.writethedocs.org/conf/portland/2019/>`_! For the past several years the conference has sold out, so we highly recommend buying early and reserving your spot.
 
 **Please make sure to register for your ticket before you book your travel!** We cannot be responsible for any non-refundable travel costs, and if we reach capacity at the venue before you register, we cannot guarantee a spot for you, even if you booked your travel.
 

--- a/docs/conf/portland/2019/news/cfp-reminder.rst
+++ b/docs/conf/portland/2019/news/cfp-reminder.rst
@@ -26,7 +26,7 @@ Get your ticket for the conference
 
 **The Portland conference will be returning to the Crystal Ballroom on May 19-21, 2019.** The `full event website <http://www.writethedocs.org/conf/portland/2019/>`_ is live, with some preliminary details, and we'll be filling in more as it gets closer. We're already excited to see what this year has in store!
 
-If you're excited too, go ahead and `register for your ticket now <http://www.writethedocs.org/conf/portland/2019/>`_! For the past several years the conference has sold out, so we highly recommend buying early and reserving your spot.
+If you're excited too, go ahead and `register for your ticket now <http://www.writethedocs.org/conf/portland/2019/tickets/>`_! For the past several years the conference has sold out, so we highly recommend buying early and reserving your spot.
 
 **Please make sure to register for your ticket before you book your travel!** We cannot be responsible for any non-refundable travel costs, and if we reach capacity at the venue before you register, we cannot guarantee a spot for you, even if you booked your travel.
 

--- a/docs/conf/portland/2019/news/cfp-reminder.rst
+++ b/docs/conf/portland/2019/news/cfp-reminder.rst
@@ -1,0 +1,44 @@
+:template: {{year}}/generic.html
+
+.. post:: January 7, 2019
+   :tags: portland-2019, website, cfp, tickets
+
+
+CFP Reminder & Tickets on Sale
+==============================
+
+Happy New Year, fellow documentarians!
+
+As we get ready to start the year, we're happy to share the latest update about the Portlant conference. We are extending our `call for proposals <http://www.writethedocs.org/conf/portland/2019/cfp/>`_ until **January 31st**, and `tickets for the conference are officially on sale <http://www.writethedocs.org/conf/portland/2019/tickets/>`_. Read on for more details on both!
+
+Submit your talk by January 31st
+--------------------------------
+
+As we are aware that many documentarians were away for the holidays, we'd like to give everyone an opportunity to submit their talks.
+The Call for Proposals will remain open until **Thursday, January 31st at midnight PST**. Check out the `CFP page <http://www.writethedocs.org/conf/portland/2019/cfp/#submit-your-proposal>`_ for more details about what we are looking for and how to submit your proposal.
+
+And if you've already got an idea, but you’re having a hard time getting your proposal to come together, you can always ask for feedback on the `WTD Slack <http://www.writethedocs.org/slack/>`_. The community is there to help!
+
+As always, we're eagerly looking forward to `your submissions <http://www.writethedocs.org/conf/portland/2019/cfp/#submit-your-proposal>`_! We’ll be reviewing all the talk proposals in early February, and will be contacting speakers by mid-February.
+
+Get your ticket for the conference
+----------------------------------
+
+**The Portland conference will be returning to the Crystal Ballroom on May 19-21, 2019.** The `full event website <http://www.writethedocs.org/conf/portland/2019/>`_ is live, with some preliminary details, and we'll be filling in more as it gets closer. We're already excited to see what this year has in store!
+
+If you're excited too, go ahead and `register for your ticket now <http://www.writethedocs.org/conf/portland/2019/>`_! For the past several years the conference has sold out, so we highly recommend to buy early and reserve your spot.
+
+**Please make sure to register for your ticket before you book your travel!** We cannot be responsible for any non-refundable travel costs, and if we reach capacity at the venue before you register, we cannot guarantee a spot for you, even if you booked your travel.
+
+Support our community by sponsoring
+-----------------------------------
+
+Every year we are fortunate to have the support of like-minded organizations and communities, who believe in the collaborative and welcoming community spirit and help us make our events more awesome.
+
+If your company is interested in sponsoring one or more conferences, check out `our prospectus for details on the different packages <http://www.writethedocs.org/conf/portland/2019/sponsors/prospectus/>`_ and drop us a line at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org>`_
+
+Follwing the successful launch in 2018, this year we will run the `job fair <http://www.writethedocs.org/conf/portland/2019/job-fair/>`_ again, helping documentarians and organizations connect with each other. Check out the sponsorship prospectus for more details.
+
+Looking forward to seeing you all in Portland!
+
+The Write the Docs Team

--- a/docs/conf/portland/2019/news/cfp-reminder.rst
+++ b/docs/conf/portland/2019/news/cfp-reminder.rst
@@ -19,7 +19,7 @@ The Call for Proposals will remain open until **Thursday, January 31st at midnig
 
 And if you've already got an idea, but you’re having a hard time getting your proposal to come together, you can always ask for feedback on the `WTD Slack <http://www.writethedocs.org/slack/>`_. The community is there to help!
 
-As always, we're eagerly looking forward to `your submissions <http://www.writethedocs.org/conf/portland/2019/cfp/#submit-your-proposal>`_! We’ll be reviewing all the talk proposals early February, and will be contacting everyone who submitted a proposal mid-February.
+As always, we're eagerly looking forward to `your submissions <http://www.writethedocs.org/conf/portland/2019/cfp/#submit-your-proposal>`_! We’ll be reviewing all the talk proposals early February, and will be contacting everyone who submitted a proposal by {{ cfp.notification }}.
 
 Get your ticket for the conference
 ----------------------------------

--- a/docs/conf/portland/2019/news/cfp-reminder.rst
+++ b/docs/conf/portland/2019/news/cfp-reminder.rst
@@ -19,7 +19,7 @@ The Call for Proposals will remain open until **Thursday, January 31st at midnig
 
 And if you've already got an idea, but you’re having a hard time getting your proposal to come together, you can always ask for feedback on the `WTD Slack <http://www.writethedocs.org/slack/>`_. The community is there to help!
 
-As always, we're eagerly looking forward to `your submissions <http://www.writethedocs.org/conf/portland/2019/cfp/#submit-your-proposal>`_! We’ll be reviewing all the talk proposals in early February, and will be contacting speakers by mid-February.
+As always, we're eagerly looking forward to `your submissions <http://www.writethedocs.org/conf/portland/2019/cfp/#submit-your-proposal>`_! We’ll be reviewing all the talk proposals early February, and will be contacting everyone who submitted a proposal mid-February.
 
 Get your ticket for the conference
 ----------------------------------

--- a/docs/conf/portland/2019/news/cfp-reminder.rst
+++ b/docs/conf/portland/2019/news/cfp-reminder.rst
@@ -37,7 +37,7 @@ Every year we are fortunate to have the support of like-minded organizations and
 
 If your company is interested in sponsoring one or more conferences, check out `our prospectus for details on the different packages <http://www.writethedocs.org/conf/portland/2019/sponsors/prospectus/>`_ and drop us a line at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org>`_
 
-Follwing the successful launch in 2018, this year we will run the `job fair <http://www.writethedocs.org/conf/portland/2019/job-fair/>`_ again, helping documentarians and organizations connect with each other. Check out the sponsorship prospectus for more details.
+Following the successful launch in 2018, this year we will run the `job fair <http://www.writethedocs.org/conf/portland/2019/job-fair/>`_ again, helping documentarians and organizations connect with each other. Check out the sponsorship prospectus for more details.
 
 Looking forward to seeing you all in Portland!
 


### PR DESCRIPTION
Specific review points:

- [x] @ericholscher - I created the Tito event and updated ticket prices, but we need to enter GDPR information before we go live, and I don't know all of the fields (it's in Customize > Data Protection)

- [x] @plaindocs - I think we should probably extend the CFP by 1-2 weeks, and I noted this in the blog post (added 2 weeks but please tell me if that's too long, and I'll shorten it by however much you say)

- [x] I also don't know how to turn on ticket sale flags etc, if someone can push this to the PR it'll be great (and show me sometime how to do this?)