### PR TITLE
Only show tickets on sale after the CFP ends

### DIFF
--- a/docs/_templates/2019/index.html
+++ b/docs/_templates/2019/index.html
@@ -65,7 +65,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
         <div class="ctas-block">
          <a class="uk-button uk-button-secondary uk-text-center" href="{{ pathto('conf/' + shortcode + '/' + year|string + '/sponsors/prospectus') }}">Sponsor the conference</a>
 
-         {% if flagticketsonsale %}
+         {% if flagticketsonsale and not cfp %}
 
          <a class="uk-button uk-button-secondary uk-text-center" href="{{ pathto('conf/' + shortcode + '/2019/tickets') }}">Buy a Ticket!</a>
 


### PR DESCRIPTION
Fix button display issue in #761 

An alternative would be to flip the logic, and not show the CFP there once tickets are on sale, as we've already got the *speak* button in the menu