### PR TITLE
Bump pyyaml version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ ablog==0.9.2
 tox==2.3.1
 sphinxcontrib.datatemplates
 sphinx_autobuild
-PyYAML==3.12
+PyYAML>=4.2b1
 docutils<0.13.1
 csvkit==1.0.2
 yamllint


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2017-18342

I'm getting some errors install the deps locally, related to the datatemplates stuff.

```
Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/home/samuel/Nosync/Repositories/WTD/www/venv/lib/python3.6/tokenize.py", line 452, in open
      buffer = _builtin_open(filename, 'rb')
  FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-install-zuhzv40o/sphinxcontrib-datatemplates/setup.py'
  
  ----------------------------------------
  Failed building wheel for sphinxcontrib-datatemplates
  Running setup.py clean for sphinxcontrib-datatemplates
  Complete output from command /home/samuel/Nosync/Repositories/WTD/www/venv/bin/python3.6 -u -c "import setuptools, tokenize;__file__='/tmp/pip-install-zuhzv40o/sphinxcontrib-datatemplates/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" clean --all:
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/home/samuel/Nosync/Repositories/WTD/www/venv/lib/python3.6/tokenize.py", line 452, in open
      buffer = _builtin_open(filename, 'rb')
  FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-install-zuhzv40o/sphinxcontrib-datatemplates/setup.py'
  
  ----------------------------------------
  Failed cleaning build dir for sphinxcontrib-datatemplates
Successfully built sphinxcontrib-datatemplates
```

Safe to ignore? I reckon so. 
