### PR TITLE
Mention ticket refund in CFP

### DIFF
--- a/docs/conf/portland/2019/cfp.rst
+++ b/docs/conf/portland/2019/cfp.rst
@@ -130,6 +130,8 @@ Speaker benefits & logistics
 
 If you are selected to speak at Write the Docs, we will waive your attendance fee. We regret that we are not able to cover the cost of travel or lodging for all speakers at this time. By not covering travel costs for our speakers, we are able to keep ticket prices low and to make the conference accessible to the largest number of participants possible.
 
+If you already have a ticket, we will of course refund it - just drop us an  `{{email}} <mailto:{{email}}>`_.
+
 If your proposal is accepted but you would find it difficult to attend due to travel costs, please let us know and we will do our best to help make it happen.
 
 **You’ll hear from us with our proposal decisions by the end of {{cfp.notification}}.**

--- a/docs/conf/prague/2019/cfp.rst
+++ b/docs/conf/prague/2019/cfp.rst
@@ -78,6 +78,8 @@ Speaker benefits & logistics
 
 If you are selected to speak at Write the Docs, we will waive your attendance fee. We regret that we are not able to cover the cost of travel or lodging for all speakers at this time. By not covering travel costs for our speakers, we are able to keep ticket prices low and to make the conference accessible to the largest number of participants possible.
 
+If you already have a ticket, we will of course refund it - just drop us an  `{{email}} <mailto:{{email}}>`_.
+
 If your proposal is accepted but you are unable to attend due to travel costs, please let us know and we will do our best to help make it happen.
 
 **You’ll hear from us with our proposal decisions by {{cfp.notification}}.**

--- a/docs/conf/prague/2019/cfp.rst
+++ b/docs/conf/prague/2019/cfp.rst
@@ -1,21 +1,23 @@
 :template: {{year}}/generic.html
-:banner: _static/2019/assets/headers/speakers.jpg
 
 Call for Proposals
 ==================
 
-Hello hello, fellow documentarians!
+Hello hello, fellow documentarians! It's that time of year again: We’re very excited to announce that we are now accepting talk proposals for our next {{ area_adj }} conference, coming up on {{date.main}}.
 
-It's that time of year again: We’re very excited to announce that we are now accepting talk proposals for our next {{ area_adj }} conference, coming up on {{date.main}}.
+Every year, Write the Docs invites people from all across our community to come up on stage to share their insights and experience. Whether you've worked on documentation for decades or you've just started this year, we want to hear from you!
+Read on to learn more about the goals of the conference and what we look for in talk proposals.
 
-Every year, Write the Docs invites people from all across our community to come up on stage to share their insights and experience. Whether you’ve worked on documentation for decades or you’ve just started this year, we want to hear from
-you! Read on to learn more about the goals of the conference and what we look for in talk proposals.
+.. contents::
+    :local:
+    :depth: 1
+    :backlinks: none
 
 In the meantime, mark your calendars:
 
 **The deadline for submitting proposals is Midnight {{TZ}} on {{cfp.ends}}.**
 
-We'll let you know if your proposal has been accepted by {{cfp.notification}}.
+We'll let you know if your proposal has been accepted by the {{cfp.notification}}.
 
 Conference goals
 ----------------
@@ -26,47 +28,95 @@ Between the talks on stage, the discussions in the unconference, the collaborati
 
 Our goal is to give documentarians a chance to connect and learn from each other. You'll have the chance to compare notes on what's happening in the industry, dig into questions of convention and good practice, and generally nerd out about all the things we love about documentation.
 
-What we’re looking for
-----------------------
+This year, as usual, we're trying to iterate on our tried and tested processes, both to improve our program and to give you, the speakers, a better idea of what to expect.
 
-**Mix of topics and perspectives**
+Who we're looking for
+---------------------
 
-The focus of Write the Docs is software documentation, but we actively seek talks that address a wide range of related subjects,
-at various levels of expertise. Documentation perspectives from other fields are welcome! Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+The short description here is "if you care about documentation and have something to say about it, we want you to speak"!
+
+That said, there are some more helpful and concrete pointers below.
 
 **Diverse group of speakers**
 
-We welcome talks from first-time speakers, from industry experts, and from everyone in between. Whatever your background and experience, we prefer hearing about new approaches than about tried-and-tested technology. We especially welcome talks from underrepresented groups within the tech community.
+We welcome talks from first-time speakers, from industry experts, and from everyone in between.
+Whatever your background and experience, we prefer hearing about new approaches than about tried-and-tested technology.
+We especially welcome talks from underrepresented groups within the tech community.
+
+**Mix of roles and perspectives**
+
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+
+**Diverse audience**
+
+Likewise, we love the diversity of our community, and we encourage support-folks to attend talks about programming, developers to attend talks about writing, writers to attend talks about data, and so on and so forth.
+
+**Past speakers**
+
+Past speaker roles include but are not limited to
+
+* Writers
+* Developers
+* Designers
+* Testers
+* Support folks
+* Developer advocates
+* Community managers
+* Scientists
+* Librarians
+* Teachers
+
+What we’re looking for
+----------------------
+
+**Diverse topics**
+
+The focus of Write the Docs is software documentation, but we actively seek talks that address a wide range of related subjects, at various levels of expertise.
+Documentation perspectives from other fields are welcome, as are topics from adjacent fields!
 
 **Practicality and positivity**
 
-We prefer talks backed by experience and experimentation to talks about theory, and we definitely don't like talks that bad-mouth technologies or approaches. Don't tell us why you hate something – tell us how you overcame the problems it was causing.
+We prefer talks backed by experience and experimentation to talks about theory, and we definitely don't like talks that bad-mouth technologies or approaches.
+Don't tell us why you hate something – tell us how you overcame the problems it was causing.
 
 **Process over tooling**
 
-We tend to avoid talks about specific tools, which often turn into marketing pitches or tutorials. We would much rather hear about process, culture, data, people, or the metaphysical side effects of spending your life thinking about docs.
+We tend to avoid talks about specific tools, which often turn into marketing pitches or tutorials.
+We would much rather hear about process, culture, data, people, or the metaphysical side effects of spending your life thinking about docs.
 
 **Audience awareness**
 
-When crafting talk proposals, remember that you're going to be talking to a mix of levels of expertise, skill sets, and professions. Your talk doesn't have to be relevant to everyone, but it should be relevant to most people and shouldn't
-make too many assumptions about what people already know.
+When crafting talk proposals, remember that you're going to be talking to a mix of levels of expertise, skill sets, and professions.
+Your talk doesn't have to be relevant to everyone, but it should be relevant to most people and shouldn't make too many assumptions about what people already know.
+If you are making those assumptions about what your audience knows, it helps everyone if you state them up front explicitly.
 
-Take a look at the abstracts for accepted talks from the last couple of conferences for some ideas:
+It can be  helpful to check out topics that might be related to your talk from previous years as well:
 
-* `Portland 2019 <http://www.writethedocs.org/conf/portland/2019/speakers/>`_
+* `Portland 2018 <http://www.writethedocs.org/conf/portland/2018/speakers/>`_
+* `Prague 2018 <http://www.writethedocs.org/conf/prague/2018/speakers/>`_
 * `Portland 2017 <http://www.writethedocs.org/conf/na/2017/speakers/>`_
 * `Prague 2017 <http://www.writethedocs.org/conf/eu/2017/speakers/>`_
-* `Portland 2016 <http://www.writethedocs.org/conf/na/2016/speakers/>`_
-* `Prague 2016 <http://www.writethedocs.org/conf/eu/2016/speakers/>`_
 
-Need help?
------------
+Not sure about speaking?
+------------------------
 
-If you need a hand preparing your talk proposal, there are lots of good places to start:
+Don't worry too much about whether we will accept your talk proposal, just submit it anyway, and leave the selection up to us. Just because you're not sure whether your topic is a good fit, feel you don't have enough speaking experience for a conference, or you think someone else may be able to give a better talk on your topic does not mean you don't have awesome things to say.
+
+If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
 * **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
 * **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <http://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `http://slack.writethedocs.org/ <http://slack.writethedocs.org/>`_.)
+* **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
+
+
+Selection process
+------------------
+
+We have a small panel of proposal reviewers, and make sure to have a similar diversity in the panel as we're aiming for in our speakers.
+We rate talks out of five, and then discuss the top rated proposals.
+
+We actively balance for diversity in as many ways as we can, which means that we do not review talks anonymously. Maybe one day the industry will be in a place where can do that, but we're certainly not there yet.
 
 Presentation format
 -------------------
@@ -80,9 +130,11 @@ If you are selected to speak at Write the Docs, we will waive your attendance fe
 
 If you already have a ticket, we will of course refund it - just drop us an  `{{email}} <mailto:{{email}}>`_.
 
-If your proposal is accepted but you are unable to attend due to travel costs, please let us know and we will do our best to help make it happen.
+If your proposal is accepted but you would find it difficult to attend due to travel costs, please let us know and we will do our best to help make it happen.
 
-**You’ll hear from us with our proposal decisions by {{cfp.notification}}.**
+**You’ll hear from us with our proposal decisions by the end of {{cfp.notification}}.**
+
+Note that all Speakers must read, understand, and agree to our :doc:`/code-of-conduct`. All talks and slides will need to follow our Code of Conduct. If you are unsure about any aspect of this, please feel free to ask us for clarification
 
 Questions?
 ----------


### PR DESCRIPTION
We should let people know in the form that we'll publish the abstract (maybe edited) and that the other fields are for info only. 