### PR TITLE
Create an atom feed with absolute links for Mailchimp

### DIFF
--- a/docs/_ext/atom_absolute.py
+++ b/docs/_ext/atom_absolute.py
@@ -34,7 +34,7 @@ def rewrite_atom_feed(app, exception):
         root = doc.getroot()
 
         # Rewrite the namespace map to not be Null
-        namespace = root.nsmap.values()[0]
+        namespace = list(root.nsmap.values())[0]
         nsmap = {'atom': namespace}
 
         # Convert the content nodes to use absolute links
@@ -43,7 +43,7 @@ def rewrite_atom_feed(app, exception):
             html_content.make_links_absolute(feed_url)
             content.text = html.tostring(html_content)
 
-        with open(rewritten_feed_path, 'w') as fd:
+        with open(rewritten_feed_path, 'wb') as fd:
             doc.write(fd)
             logger.info('Wrote absolute atom feed to {}'.format(rewritten_feed_path))
 

--- a/docs/_ext/atom_absolute.py
+++ b/docs/_ext/atom_absolute.py
@@ -1,0 +1,49 @@
+from __future__ import unicode_literals
+
+import os.path
+
+from lxml import etree, html
+from six.moves.urllib.parse import urljoin
+from sphinx.util import logging
+
+
+logger = logging.getLogger(__name__)
+
+
+def rewrite_atom_feed(app, exception):
+    """
+    Rewrites the atom feed content elements to use absolute instead of relative links
+    Applies to <a> and <img>
+    """
+    if exception:
+        logger.info('Skipping atom feed link rewrite due to errors...')
+    else:
+        logger.info('Rewriting atom feed...')
+
+        feed_path = os.path.join(app.outdir, 'blog/archive/tag/newsletter/atom.xml')
+        feed_url = urljoin(app.config.blog_baseurl, 'archive/atom.xml')
+        rewritten_feed_path = os.path.join(
+            app.outdir, 'blog/archive/tag/newsletter/atom_absolute.xml'
+        )
+
+        if not os.path.isfile(feed_path):
+            logger.error('Atom feed does not exist at: {}'.format(feed_path))
+            return
+
+        doc = etree.parse(feed_path)
+        root = doc.getroot()
+
+        # Rewrite the namespace map to not be Null
+        namespace = root.nsmap.values()[0]
+        nsmap = {'atom': namespace}
+
+        # Convert the content nodes to use absolute links
+        for content in root.xpath('//atom:entry/atom:content', namespaces=nsmap):
+            html_content = html.fromstring(content.text)
+            html_content.make_links_absolute(feed_url)
+            content.text = html.tostring(html_content)
+
+        with open(rewritten_feed_path, 'w') as fd:
+            doc.write(fd)
+            logger.info('Wrote absolute atom feed to {}'.format(rewritten_feed_path))
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ on_netlify = os.environ.get('BUILD_VIDEOS') == 'True'
 on_travis = os.environ.get('TRAVIS') == 'True'
 if not on_rtd and not on_netlify and not on_travis:
     exclude_patterns.append('videos')
-REWRITE_FEED = True
+REWRITE_FEED = False
 
 extensions = [
     'ablog',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,8 +19,7 @@ from _ext.core import (
     set_html_context, unset_html_context
 )
 from _ext.meetups import MeetupListing
-#from _ext.videos import main
-
+from _ext.atom_absolute import rewrite_atom_feed
 
 exclude_patterns = [
     '_build',
@@ -35,6 +34,7 @@ on_netlify = os.environ.get('BUILD_VIDEOS') == 'True'
 on_travis = os.environ.get('TRAVIS') == 'True'
 if not on_rtd and not on_netlify and not on_travis:
     exclude_patterns.append('videos')
+REWRITE_FEED = True
 
 extensions = [
     'ablog',
@@ -129,9 +129,10 @@ html_context = {
 }
 
 # Uncomment this line to generate videos
-#html_context.update(main())
+# html_context.update(main())
 
 # html_experimental_html5_writer = True
+
 
 def setup(app):
     # Set up our custom jinja filters
@@ -146,6 +147,9 @@ def setup(app):
 
     # Render HTML templates with proper HTML context
     app.connect('html-page-context', override_page_template)
+
+    if on_rtd or on_netlify or on_travis or REWRITE_FEED:
+        app.connect('build-finished', rewrite_atom_feed)
 
     app.add_directive('meetup-listing', MeetupListing)
     app.add_config_value('recommonmark_config', {

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ git+https://github.com/ericholscher/datatemplates@add-key-and-context#egg=sphinx
 urllib3[secure]==1.24.1
 yamale==1.8.0
 ruamel.yaml==0.15.86
+lxml==4.3.0


### PR DESCRIPTION
This will fix the issue where we have relative links in our emails.
Most feed readers do this automatically,
but not mailchimp.