### PR TITLE
fix conference schedule typo

### DIFF
--- a/docs/conf/prague/2019/schedule.rst
+++ b/docs/conf/prague/2019/schedule.rst
@@ -82,7 +82,7 @@ We'll also help groups organize dinner plans, so you can continue your conversat
 * **Where**: {{about.venue}}, {{about.mainroom}}
 * **When**: **17:00-20:00**
 
-{{date.day_three.dotw}}, {{date.day_three.date}}
+Monday, September 16
 --------------------
 
 .. contents::

--- a/docs/conf/prague/2019/schedule.rst
+++ b/docs/conf/prague/2019/schedule.rst
@@ -134,7 +134,9 @@ There will be light snacks and drinks available on the conference while our tab 
 
 Further details will be announced later.
 
-{{date.day_four.dotw}}, {{date.day_four.date}}
+.. TODO add this variable? 
+
+Tuesday, September 17
 ---------------------
 
 .. contents::

--- a/docs/conf/prague/2019/schedule.rst
+++ b/docs/conf/prague/2019/schedule.rst
@@ -82,7 +82,7 @@ We'll also help groups organize dinner plans, so you can continue your conversat
 * **Where**: {{about.venue}}, {{about.mainroom}}
 * **When**: **17:00-20:00**
 
-Monday, September 10
+{{date.day_three.dotw}}, {{date.day_three.date}}
 --------------------
 
 .. contents::
@@ -134,7 +134,7 @@ There will be light snacks and drinks available on the conference while our tab 
 
 Further details will be announced later.
 
-Tuesday, September 11
+{{date.day_four.dotw}}, {{date.day_four.date}}
 ---------------------
 
 .. contents::


### PR DESCRIPTION
updated conference schedule page to avoid unnecessary time travel. If the rst syntax is wrong, please hard code Monday, September 16 and Tuesday, September 17 instead 😄