### PR TITLE
Removed redundant text

### DIFF
--- a/docs/_data/2019.portland.speakers.yaml
+++ b/docs/_data/2019.portland.speakers.yaml
@@ -241,8 +241,8 @@
     \ Authors don’t care if I think it “sounds right” this way. Readability indexes,\
     \ usability research, style guides, minimalism, and other objective tools are\
     \ more persuasive than telling them to make a change “because I said so.”  That\
-    \ approach didn’t work with my kids either. </p>\n<p>EDITING PRINCIPLE 5. EDITING\
-    \ PRINCIPLE 5. SEEK OTHER PEOPLE'S OPINIONS. \nYou are not the only person who\
+    \ approach didn’t work with my kids either. </p>\n<p>EDITING PRINCIPLE 5. \
+    \ SEEK OTHER PEOPLE'S OPINIONS. \nYou are not the only person who\
     \ can fine-tune a piece of content. Seeking out other experienced writers to review\
     \ a doc can give you insights that you would never have on your own. At Red Hat\
     \ we do crowdsourced peer review sessions, and they have made me a better editor.\


### PR DESCRIPTION
Removed redundant text from 2019.portland.speakers.yaml