### PR TITLE
Update locations for WW intro and WTD reception

### DIFF
--- a/docs/conf/portland/2019/schedule.rst
+++ b/docs/conf/portland/2019/schedule.rst
@@ -53,7 +53,7 @@ You'll have a chance to get acquainted with each other over some drinks and snac
 and pick up your badge so you can skip the line in the morning. Note that we are not
 able to accomodate additional guests at this event.
 
-* **Where**: Crystal Ballroom
+* **Where**: Lola's Room
 * **When**: **5pm-8pm**
 
 Welcome Wagon Introduction
@@ -61,7 +61,7 @@ Welcome Wagon Introduction
 
 Is this your first time at Write the Docs? Join us for an informal Introduction to Write the Docs, to the Welcome Wagon, and to other first-time conference attendees. We’ll pass on some information about the conference specifically for first-timers and give everyone a chance to meet someone new, before we join the opening reception.
 
-* **Where**: Lola's Room
+* **Where**: Crystal Ballroom
 * **When**: **5pm-6pm**
 
 Monday, May 20

--- a/docs/conf/portland/2019/welcome-wagon.rst
+++ b/docs/conf/portland/2019/welcome-wagon.rst
@@ -19,7 +19,7 @@ Welcome Wagon events
 
 **Write the Docs Welcome Wagon Introduction**
 
-*Sunday at 5:00pm in Lola’s Room*
+*Sunday at 5:00pm in the Crystal Ballroom*
 
 Join us for an informal Introduction to Write the Docs, to the Welcome Wagon, and to other first-time conference attendees. We’ll pass on some information about the conference specifically for first-timers and give everyone a chance to meet someone new, before we join the opening reception.
 


### PR DESCRIPTION
Based on comments from the last pull requests and past conferences, updating Opening Reception location to Lola's Room and WW Intro location to Crystal Ballroom. The Crystal worked great for the intro last year, because we could split up into groups and use the tables.