### PR TITLE
Update visiting.rst

### DIFF
--- a/docs/include/conf/portland/visiting.rst
+++ b/docs/include/conf/portland/visiting.rst
@@ -25,7 +25,7 @@ We are not working with any of the hotels for attendee accommodations, but there
 - `Crystal Hotel <http://www.mcmenamins.com/CrystalHotel>`__
 - `Ace Hotel <http://www.acehotel.com/portland>`__
 - `Hotel DeLuxe <http://www.hoteldeluxeportland.com/>`__
--_`Dossier Hotel <https://dossierhotel.com>`__
+- `Dossier Hotel <https://dossierhotel.com>`__
 - `Mark Spencer <http://www.markspencer.com/>`__
 - `The Sentinel <http://www.sentinelhotel.com/>`__
 - `The Society Hotel <https://thesocietyhotel.com>`__

--- a/docs/include/conf/portland/visiting.rst
+++ b/docs/include/conf/portland/visiting.rst
@@ -25,6 +25,7 @@ We are not working with any of the hotels for attendee accommodations, but there
 - `Crystal Hotel <http://www.mcmenamins.com/CrystalHotel>`__
 - `Ace Hotel <http://www.acehotel.com/portland>`__
 - `Hotel DeLuxe <http://www.hoteldeluxeportland.com/>`__
+-_`Dossier Hotel <https://dossierhotel.com>`__
 - `Mark Spencer <http://www.markspencer.com/>`__
 - `The Sentinel <http://www.sentinelhotel.com/>`__
 - `The Society Hotel <https://thesocietyhotel.com>`__
@@ -34,7 +35,7 @@ Check TripAdvisor to find other hotels and accommodations in the Portland area.
 How to get around
 -----------------
 
-Portland is a very accessible city and there are many transportation options available, public and otherwise. Portland is divided into five quadrants (with Burnside Avenue delineating north and south sections, and the Willamette River separating west and east sections). Portland is a city of neighborhoods, and each has its own distinct personality. We encourage you to connect with other documnentarians and explore our unique neighborhoods during your stay.
+Portland is a very accessible city and there are many transportation options available, public and otherwise. Portland is divided into five quadrants (with Burnside Avenue delineating north and south sections, and the Willamette River separating west and east sections). Portland is a city of neighborhoods, and each has its own distinct personality. We encourage you to connect with other documentarians and explore our unique neighborhoods during your stay.
 
 The MAX
 ~~~~~~~
@@ -43,22 +44,20 @@ The `MAX <http://trimet.org/max>`__ is Portland's major light-rail system. The M
 
 If you're flying into Portland Airport (PDX), we recommend taking the MAX into downtown Portland (service to downtown Portland runs between 5 am and midnight). There is a MAX station for the `Red Line <http://trimet.org/schedules/maxredline.htm>`__ in the airport itself. You may purchase MAX tickets from a ticket machine at the airport. Be sure to buy a ticket before boarding the train.
 
-The venue is along Burnside Street at 14th Ave, just east of the I-405 underpass. The closest stop to the Crystal Ballroom is Galleria SW 10th.
+The venue is along West Burnside Street at 14th Ave, just east of the I-405 underpass. The closest stop to the Crystal Ballroom is Galleria SW 10th.
 
 
-Streetcars and Buses
+Streetcars and buses
 ~~~~~~~~~~~~~~~~~~~~
 
-Portland has a `separate streetcar network <http://www.portlandstreetcar.org/>`__ which criss-crosses the MAX lines. These, along with Portland's extensive `bus network <http://trimet.org/bus/>`__, ought to suffice.
+Portland has a `separate streetcar network <http://www.portlandstreetcar.org/>`__ which criss-crosses the MAX lines. These, along with Portland's extensive `bus network <http://trimet.org/bus/>`__, ought to suffice. We recommend you use the `TriMet Trip Planner <https://trimet.org>`__. It's easy to tap your credit card for a one-time ride.
 
 If you are planning on using MAX, Portland Streetcar and/or city buses frequently during your stay, it may be worth investing in the `Hop Fastpass <https://myhopcard.com/>`__ fare card system.
 
-We recommend you use the `TriMet Trip Planner <https://trimet.org>`__.
-
-Taxi Companies
+Taxi companies
 ~~~~~~~~~~~~~~
 
-Portland has both Lyft and Uber, and they are quite popular. If you still prefer local taxi companies, here are a few recommendations:
+Portland has both Lyft and Uber, and they are quite popular. If you prefer local taxi companies, here are a few recommendations:
 
 - `Radio Cab <http://www.radiocab.net/>`__
 - `Broadway Cab <http://www.broadwaycab.com/>`__
@@ -68,23 +67,22 @@ Please note that it is *not* common to hail taxis in Portland, and that your bes
 
 Driving to Crystal Ballroom
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-If you drive to the conference, parking in downtown Portland is limited and expensive. You can find parking facilities on `this map <https://ccplots.myparkingworld.com/CCP/en?latlng=45.5230622,-122.67648159999999&_ga=2.42727333.1433763092.1525640043-1864967114.1525640043>`__. The Explore Portland committee recommends parking in the `Brewery Blocks Garage <http://www.breweryblocks.com/parking/>`__ for $13 all day (if you're in bo 10 a.m.). It is clean and well-lit, and you can get back in if you stay out late with your fellow documentarians.
+If you drive to the conference, parking in downtown Portland is limited and expensive. You can find parking facilities on `this map <https://ccplots.myparkingworld.com/CCP/en?latlng=45.5230622,-122.67648159999999&_ga=2.42727333.1433763092.1525640043-1864967114.1525640043>`__. The Explore Portland committee recommends parking in the `Brewery Blocks Garage <http://www.breweryblocks.com/parking/>`__ for $13 all day (if you're in by 10 a.m.). It is clean and well-lit, and you can get back in if you stay out late with your fellow documentarians.
 
-Bike Rentals
+Bike rentals
 ~~~~~~~~~~~~
 
 There are two bike rental companies in downtown Portland that may be good options if you want to experience Portland by bike (which we very much recommend), and a bikeshare program:
 
-- `Waterfront Bikes <http://www.waterfrontbikes.com/>`__
 - `Cycle Portland <http://www.portlandbicycletours.com/>`__
 - `Biketown <https://www.biketownpdx.com>`__
 
 Sundries
 --------
 - `Whole Foods <https://www.google.com/maps/place/Whole+Foods+Market/@45.5233154,-122.6858396,17z/data=!3m1!4b1!4m5!3m4!1s0x54950a0250842545:0xda581c4844197daf!8m2!3d45.5233154!4d-122.6836509?hl=en-us>`__ and `Target <https://www.google.com/maps/place/Target/@45.5201104,-122.6840493,17z/data=!3m1!4b1!4m5!3m4!1s0x54950a0497e34c3b:0x3bbb7b17d08ba5b0!8m2!3d45.5201104!4d-122.6818606?hl=en-us>`__ are less than 10 minutes' walk from the Crystal Ballroom. Target also has a CVS Pharmacy inside.
-- `Apple Pioneer Place <https://www.google.com/maps?hl=en-us&client=safari&yv=3&lqi=CgthcHBsZSBzdG9yZSIDiAEB&um=1&ie=UTF-8&fb=1&gl=us&entry=s&sa=X&ftid=0x54950a056f058c1f:0xe391f5206cbeea58&gmm=CgIgAQ%3D%3D>`__ and `Microsoft Store <https://www.google.com/maps/place/Microsoft/@45.51751,-122.678518,17z/data=!3m1!4b1!4m5!3m4!1s0x54950a0578ff9e25:0x99b82e842d6d8f4f!8m2!3d45.51751!4d-122.6763293?hl=en-us>`__ are both conveniently located in downtown Portland.
+- `Microsoft Store <https://www.google.com/maps/place/Microsoft/@45.51751,-122.678518,17z/data=!3m1!4b1!4m5!3m4!1s0x54950a0578ff9e25:0x99b82e842d6d8f4f!8m2!3d45.51751!4d-122.6763293?hl=en-us>`__ is conveniently located in downtown Portland.
 
-Things to Do in Portland
+Things to do in Portland
 ------------------------
 - `Food cart pods <http://www.foodcartsportland.com/>`__
 - `Lan Su Chinese Garden <https://www.lansugarden.org>`__


### PR DESCRIPTION
- Fixed couple of typos.
- Changed H2 and H3 camel case headers into sentence case (for consistency)
- Removed the links (and surrounding verbiage) for the Apple Store (closed until summer) and Waterfront Bikes (no longer there)
- Rearranged "Streetcar and buses" section with info about paying one-time with a card.
- Added Hotel Dossier to the list of nearby walkable hotels.
- Changed location of Crystal Ballroom to "West Burnside Street."