### PR TITLE
[DRAFT] Add Vilnius 2019 schedule

### DIFF
--- a/docs/_data/config-vilnius-2019.yaml
+++ b/docs/_data/config-vilnius-2019.yaml
@@ -22,8 +22,8 @@ buttons:
     #link: /cfp
     - text: Buy a Ticket!
       link: /tickets
-    - text: See the talks!
-      link: /speakers
+    - text: See the Schedule!
+      link: /schedule
     # - text: Prepare with the Welcome Wagon
     #  link: /welcome-wagon
     # - text: Watch the Live Stream

--- a/docs/_data/config-vilnius-2019.yaml
+++ b/docs/_data/config-vilnius-2019.yaml
@@ -84,7 +84,7 @@ cfp:
 
 flagspeakersannounced: True
 flagcfp: False
-flaghasschedule: False
+flaghasschedule: True
 flagticketsonsale: True
 flaghashike: False
 flaghasboat: False

--- a/docs/_data/lt-2019-day-1.yaml
+++ b/docs/_data/lt-2019-day-1.yaml
@@ -11,50 +11,56 @@
   Session: Hadas Khen - OMG, it’s “Error 5”!
   Slug: hadas-khen
   Time: '10:20'
-- Duration: '30'
+- Duration: '20'
   Session: Snack break
   Time: '10:50'
 - Duration: '30'
   Session: Chris Ward - Decentralised Documentation - Defining standards for an ecosystem
   Slug: chris-ward
-  Time: '11:20'
+  Time: '11:10'
 - Duration: '10'
   Session: Switch Speakers
-  Time: '11:50'
+  Time: '11:40'
 - Duration: '30'
   Session: "Filipe Mendes - The Legend of Documentation: A markdown to the past"
   Slug: filipe-mendes
-  Time: '12:00'
+  Time: '11:50'
 - Duration: '60'
   Session: Lunch (60 mins)
-  Time: '12:30'
-- Duration: '40'
+  Time: '12:20'
+- Duration: '30'
   Session: Lightning talks
-  Time: '13:30'
+  Time: '13:20'
 - Duration: '10'
   Session: Switch Speakers
-  Time: '14:10'
+  Time: '13:50'
 - Duration: '30'
   Session: Anna Iosif - How do we know our documentation makes sense?
   Slug: anna-iosif
-  Time: '14:20'
-- Duration: '30'
+  Time: '14:00'
+- Duration: '20'
   Session: Snack break
-  Time: '14:50'
+  Time: '14:30'
 - Duration: '30'
   Session: Elina McCafferty - How to turn a freight ship around when all you have is a paddle
   Slug: elina-mccafferty
-  Time: '15:20'
+  Time: '14:50'
 - Duration: '10'
   Session: Switch Speakers
-  Time: '15:50'
+  Time: '15:20'
 - Duration: '30'
   Session: "Małgorzata Trojanowska - Technically you can: creating technical content for all audiences"
   Slug: malzgorita-trojanowska
-  Time: '16:00'
+  Time: '15:30'
 - Duration: '10'
   Session: '<b>Group Photo</b>'
-  Time: '16:30'
+  Time: '16:00'
 - Duration: '5'
   Session: Conference closing
-  Time: '16:40'
+  Time: '16:10'
+- Duration: '105'
+  Session: Informal networking
+  Time: '16:15'
+- Duration: ''
+  Session: Conference ends
+  Time: '18:00'

--- a/docs/_data/lt-2019-day-1.yaml
+++ b/docs/_data/lt-2019-day-1.yaml
@@ -1,0 +1,60 @@
+- Duration: '60'
+  Session: Doors Open, Breakfast Served
+  Time: '9:00'
+- Duration: '10'
+  Session: Conference opening
+  Time: '10:00'
+- Duration: '10'
+  Session: Switch Speakers
+  Time: '10:10'
+- Duration: '30'
+  Session: Hadas Khen - OMG, it’s “Error 5”!
+  Slug: omg-its-error-5-hadas-khen
+  Time: '10:20'
+- Duration: '30'
+  Session: Snack break
+  Time: '10:50'
+- Duration: '30'
+  Session: Chris Ward - Decentralised Documentation - Defining standards for an ecosystem
+  Slug: decentralised-documentation-defining-standards-for-an-ecosystem-chris-ward
+  Time: '11:20'
+- Duration: '10'
+  Session: Switch Speakers
+  Time: '11:50'
+- Duration: '30'
+  Session: "Filipe Mendes - The Legend of Documentation: A markdown to the past"
+  Slug: the-legend-of-documentation-a-markdown-to-the-past-filipe-mendes
+  Time: '12:00'
+- Duration: '60'
+  Session: Lunch (60 mins)
+  Time: '12:30'
+- Duration: '40'
+  Session: Lightning talks
+  Time: '13:30'
+- Duration: '10'
+  Session: Switch Speakers
+  Time: '14:10'
+- Duration: '30'
+  Session: Anna Iosif - How do we know our documentation makes sense?
+  Slug: how-do-we-know-our-documentation-makes-sense-anna-iosif
+  Time: '14:20'
+- Duration: '30'
+  Session: Snack break
+  Time: '14:50'
+- Duration: '30'
+  Session: Elina McCafferty - How to turn a freight ship around when all you have is a paddle
+  Slug: how-to-turn-a-freight-ship-around-when-all-you-have-is-a-paddle-elina-mccafferty
+  Time: '15:20'
+- Duration: '10'
+  Session: Switch Speakers
+  Time: '15:50'
+- Duration: '30'
+  Session: "Małgorzata Trojanowska - Technically you can: creating technical content for all audiences"
+  Slug: technically-you-can-creating-technical-content-for-all-audiences-malzgorita-trojanowska
+  Time: '16:00'
+- Duration: '10'
+  Session: '<b>Group Photo</b>'
+  Time: '16:30'
+- Duration: '5'
+  Session: Conference closing
+  Time: '16:40'

--- a/docs/_data/lt-2019-day-1.yaml
+++ b/docs/_data/lt-2019-day-1.yaml
@@ -9,21 +9,21 @@
   Time: '10:10'
 - Duration: '30'
   Session: Hadas Khen - OMG, it’s “Error 5”!
-  Slug: omg-its-error-5-hadas-khen
+  Slug: hadas-khen
   Time: '10:20'
 - Duration: '30'
   Session: Snack break
   Time: '10:50'
 - Duration: '30'
   Session: Chris Ward - Decentralised Documentation - Defining standards for an ecosystem
-  Slug: decentralised-documentation-defining-standards-for-an-ecosystem-chris-ward
+  Slug: chris-ward
   Time: '11:20'
 - Duration: '10'
   Session: Switch Speakers
   Time: '11:50'
 - Duration: '30'
   Session: "Filipe Mendes - The Legend of Documentation: A markdown to the past"
-  Slug: the-legend-of-documentation-a-markdown-to-the-past-filipe-mendes
+  Slug: filipe-mendes
   Time: '12:00'
 - Duration: '60'
   Session: Lunch (60 mins)
@@ -36,21 +36,21 @@
   Time: '14:10'
 - Duration: '30'
   Session: Anna Iosif - How do we know our documentation makes sense?
-  Slug: how-do-we-know-our-documentation-makes-sense-anna-iosif
+  Slug: anna-iosif
   Time: '14:20'
 - Duration: '30'
   Session: Snack break
   Time: '14:50'
 - Duration: '30'
   Session: Elina McCafferty - How to turn a freight ship around when all you have is a paddle
-  Slug: how-to-turn-a-freight-ship-around-when-all-you-have-is-a-paddle-elina-mccafferty
+  Slug: elina-mccafferty
   Time: '15:20'
 - Duration: '10'
   Session: Switch Speakers
   Time: '15:50'
 - Duration: '30'
   Session: "Małgorzata Trojanowska - Technically you can: creating technical content for all audiences"
-  Slug: technically-you-can-creating-technical-content-for-all-audiences-malzgorita-trojanowska
+  Slug: malzgorita-trojanowska
   Time: '16:00'
 - Duration: '10'
   Session: '<b>Group Photo</b>'

--- a/docs/conf/vilnius/2019/schedule.rst
+++ b/docs/conf/vilnius/2019/schedule.rst
@@ -44,7 +44,7 @@ The "main event" -- we'll have a variety of speakers on the stage sharing their 
 
 .. datatemplate::
    :source: /_data/{{templatecode}}-{{year}}-day-1.yaml
-   :template: include/schedule2018.rst
+   :template: include/schedule2019.rst
    :include_context:
 
 {% else %}


### PR DESCRIPTION
The day does end quite early (schedule page still says 18:00, we need to update this if this is the final schedule).
The original planned time was from 10-18, but we have 3 hours of talks, 40 minutes of lightning talks, an hour of lunch, an hour of snack breaks, ~30 minutes of speaker switching. So that's just over 6 hours - we just can't really fill 8 hours, hence the early ending.

Also, please double check that I didn't make any timing calculation errors.
(snack breaks are 30 minutes on purpose for a bit more padding)