### PR TITLE
Update nav buttons for post-conf Portland 2019

### DIFF
--- a/docs/_data/config-portland-2019.yaml
+++ b/docs/_data/config-portland-2019.yaml
@@ -24,14 +24,14 @@ buttons:
     #   link: /tickets
     # - text: See the talks!
     #   link: /speakers
-    - text: See the Schedule!
-      link: /schedule
+#    - text: See the Schedule!
+#      link: /schedule
     # - text: Welcome Wagon
     #   link: /welcome-wagon
-    - text: Watch the Live Stream
-      link: /livestream
-    # - text: Browse the photos
-    #  link: /livestream
+#    - text: Watch the Live Stream
+#      link: /livestream
+     - text: Browse the photos
+       link_absolute: https://www.flickr.com/photos/writethedocs/albums/72157691507514803
   bottom:
     # - text: Sponsor the conference
     #  link: /sponsors/prospectus
@@ -39,14 +39,14 @@ buttons:
     #  link: /cfp
     # - text: Buy a Ticket!
     #   link: /tickets
-    - text: Prepare with the Welcome Wagon
-      link: /welcome-wagon
-    - text: See the schedule!
-      link: /schedule
+#    - text: Prepare with the Welcome Wagon
+#      link: /welcome-wagon
+#    - text: See the schedule!
+#      link: /schedule
     # - text: Watch the Live Stream
     #  link: /livestream
-    # - text: Browse the photos
-    #  link: /livestream
+     - text: Browse the photos
+       link_absolute: https://www.flickr.com/photos/writethedocs/albums/72157691507514803
 
 tickets:
   community:
@@ -101,6 +101,7 @@ about:
     You can find out more information about the venue and its accessibility on our :doc:`/conf/portland/2019/venue` page."
   location:
     "Crystal Ballroom located at 1332 W Burnside St"
+  photos: https://www.flickr.com/photos/writethedocs/albums/72157691507514803
 
 cfp:
   url: https://docs.google.com/forms/d/e/1FAIpQLScCK5qIaRwmn2UouYvtxfrQk56r_X72aliVWLnoGKb69HZuug/viewform
@@ -170,7 +171,8 @@ flagspeakersannounced: True
 flaghasschedule: True
 flaghasshirts: True
 flagvideos: False
-flaglivestreaming: True
+flaglivestreaming: False
+flagpostconf: True
 
 # Truthy things that don't change
 flaghashike: True

--- a/docs/_templates/2019/base.html
+++ b/docs/_templates/2019/base.html
@@ -72,7 +72,7 @@
         {% block footerhead %}
          {% if buttons is defined %} 
              {% for callout in buttons.bottom %}
-               <a class="uk-button uk-button-secondary uk-text-center" href="{{ pathto('conf/' + shortcode + '/' + year|string + callout.link ) }}">{{ callout.text }}</a>
+               <a class="uk-button uk-button-secondary uk-text-center" href="{% if callout.link_absolute %}{{ callout.link_absolute }}{% else %}{{ pathto('conf/' + shortcode + '/' + year|string + callout.link ) }}{% endif %}">{{ callout.text }}</a>
              {% endfor %}
          {% endif %}
         {% endblock %}

--- a/docs/_templates/2019/index.html
+++ b/docs/_templates/2019/index.html
@@ -66,7 +66,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
          {% if buttons is defined %} 
          {% for callout in buttons.top %}
-           <a class="uk-button uk-button-secondary uk-text-center" href="{{ pathto('conf/' + shortcode + '/' + year|string + callout.link ) }}">{{ callout.text }}</a>
+           <a class="uk-button uk-button-secondary uk-text-center" href="{% if callout.link_absolute %}{{ callout.link_absolute }}{% else %}{{ pathto('conf/' + shortcode + '/' + year|string + callout.link ) }}{% endif %}">{{ callout.text }}</a>
          {% endfor %}
          {% endif %}
 
@@ -75,7 +75,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
     </div>
   </div><!-- end hero -->
 
-  {% if flagvideos %}
+  {% if flagvideos or flagpostconf %}
 
   <div class="announcement">
     <div class="uk-container">


### PR DESCRIPTION
This also adds a flagpostconf setting, as otherwise the "conference is over" text can only appear when videos are live.
Buttons at the top/bottom can now also contain absolute links.