### PR TITLE
Adding topic suggestions to "Starting a Meetup" page

### DIFF
--- a/docs/organizer-guide/meetups/starting.rst
+++ b/docs/organizer-guide/meetups/starting.rst
@@ -186,6 +186,11 @@ The following are examples of topics that have worked well for other meetups:
 * Info architecture
 * Language and cultural differences
 * Docs as code
+* Documenting yourself
+* UI text
+* What are you looking for in a new writer
+* Collaborating with stakeholders
+* Creating content with limited resources and support
 
 If You Can't Find a Local Speaker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/organizer-guide/meetups/starting.rst
+++ b/docs/organizer-guide/meetups/starting.rst
@@ -172,25 +172,25 @@ Topics:
 
 The following are examples of topics that have worked well for other meetups:
 
-* API docs
-* Contributing to OSS
-* Easy entry to OSS
-* Navigating career path (different sectors of tech writing)
-* Sketchnoting as documentation
-* Hackathon -- creating docs “The lone writers guide”
-* Howto Markdown (multiple methods)
-* Best practices
-* Pub socials
-* Communication probs with R&D
-* Visual docs
-* Info architecture
-* Language and cultural differences
-* Docs as code
-* Documenting yourself
-* UI text
-* What are you looking for in a new writer
-* Collaborating with stakeholders
-* Creating content with limited resources and support
+* API docs -- Approaches, tools, and best practices in API documentation.
+* Contributing to OSS -- Getting started with Github and open source projects.
+* Easy entry to OSS -- Finding good beginner projects to contribute to.
+* Navigating career path -- Understanding different sectors of tech writing and creating a long term plan.
+* Hackathon -- creating docs “The lone writers guide.”
+* Howto Markdown (multiple methods) -- Looking at different markdown implementations.
+* Best practices -- Determining, documenting, and implementing best practices in your tech writing team.
+* Pub socials -- Casual meetups that promote more freeform discussions and idea exchange.
+* Communication problems with R&D -- Bridging the gap between development and documentation.
+* Visual docs -- Represent non-linguistics ideas and instructions. 
+* Sketchnoting as documentation -- A kind of visual documentation or note-taking consisting of notes, drawings, hand-drawn typography, and other visual elements used to express ideas.
+* Information architecture -- Strategies for structuring and organizing documentation.
+* Language and cultural differences -- Discussing sociocultural factors impacting documentation.
+* Documentation as code -- Rethinking philosophy, tools, workflows, integration.
+* Documenting yourself -- Building effective portfolios. 
+* UI text -- Unique considerations in writing UI text.
+* What are you looking for in a new writer -- Thinking about experience, technical skills, culture fit, and trainability.
+* Collaborating with stakeholders -- Aligning goals on projects.
+* Creating content with limited resources and support -- How to approach tight deadlines and less-than-ideal situations.
 
 If You Can't Find a Local Speaker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Updated "Starting a Meetup" page (https://www.writethedocs.org/organizer-guide/meetups/starting/) with suggestions from issue #488 (https://github.com/writethedocs/www/issues/488)