### PR TITLE
Fix formatting for ordered lists on the "Introduction to Markdown" page

### DIFF
--- a/docs/guide/writing/markdown.md
+++ b/docs/guide/writing/markdown.md
@@ -59,12 +59,12 @@ To add a numbered or ordered list of items:
 1. Just type a number followed by a dot.
 2. If you want to add a second item, just type in another number followed by a dot.
 1. If you make a mistake when typing numbers, fear not, Markdown will correct it for you.
-  1. If you press a tab key or type four spaces, you will get an indented list and the numbering
-  will start from scratch.
-    1. If you want to insert an indented numbered list within an existing indented numbered one,
-    just press the tab key again.
-      - If need be, you can also add an indented unordered list within an indented numbered one, an vice versa,
-      by pressing a tab key and typing a dash.
+    1. If you press a tab key or type four spaces, you will get an indented list and the numbering
+    will start from scratch.
+        1. If you want to insert an indented numbered list within an existing indented numbered one,
+        just press the tab key again.
+            - If need be, you can also add an indented unordered list within an indented numbered one, an vice versa,
+            by pressing a tab key and typing a dash.
 ```
 
 The formatted text will look like this:
@@ -72,11 +72,11 @@ The formatted text will look like this:
 1. Just type a number followed by a dot.
 2. If you want to add a second item, just type in another number followed by a dot.
 1. If you make a mistake when typing numbers, fear not, Markdown will correct it for you.
-  1. If you press a tab key or type four spaces, you will get an indented list and the numbering will start from scratch.
-    1. If you want to insert an indented numbered list within an existing indented numbered one,
-    just press the tab key again.
-      - If need be, you can also add an indented unordered list within an indented numbered one, an vice versa,
-      by pressing a tab key and typing a dash.
+    1. If you press a tab key or type four spaces, you will get an indented list and the numbering will start from scratch.
+        1. If you want to insert an indented numbered list within an existing indented numbered one,
+        just press the tab key again.
+            - If need be, you can also add an indented unordered list within an indented numbered one, an vice versa,
+            by pressing a tab key and typing a dash.
 
 ### Headers
 


### PR DESCRIPTION
(Changed lines 62-79 of markdown.md.) The example was rendering as items 1-5 without any indentation.
  1. Just type...
  2. If you want...
  3. If you make...
  4. If you press...
  5. If you want...
  - If need be,...

Fix example so that indents render and the numbering restarts on the fourth and fifth list items, as intended.

(Note that the github file viewer substitutes 'i' for '1' on a list item indented once, and it substitues 'a' for '1' on a list item indented twice. But the html output by sphinx restarts the numbering at '1' as intended.)