### PR TITLE
Updated details of workshop and doc fixit in AU conference 2019

### DIFF
--- a/docs/_data/2019.australia.speakers.yaml
+++ b/docs/_data/2019.australia.speakers.yaml
@@ -372,7 +372,9 @@
 
     <p>The Kubeflow docs are largely written by engineers. The engineers do a great job, but sometimes a tech writer’s touch adds that extra bit of shine.</p>
 
-    <p>During this doc fixit, you will work with the Kubeflow tech writer to fix doc bugs. The bugs include spelling mistakes, grammar that’s not quite right, sentences that could flow better, and more. While fixing bugs, you’ll learn about working in open source on GitHub. You’ll experience a static site generator (Hugo) for publishing docs. Best of all, you’ll improve the experience of the developers and data scientists who’re reading the docs.</p>'
+    <p>During this doc fixit, you will work with the Kubeflow tech writer to fix doc bugs. The bugs include spelling mistakes, grammar that’s not quite right, sentences that could flow better, and more. While fixing bugs, you’ll learn about working in open source on GitHub. You’ll experience a static site generator (Hugo) for publishing docs. Best of all, you’ll improve the experience of the developers and data scientists who’re reading the docs.</p>
+
+    <p>Read about prerequisites and more in the `doc fixit details <https://www.writethedocs.org/conf/australia/2019/doc-fixit-kubeflow/>`_.</p>`
   slug: kubeflow-doc-fixit-sarah-maddox
   speakers:
   - name: Sarah Maddox
@@ -396,7 +398,9 @@
   title: Git the Docs - A fun, hands-on introduction to version control
 - abstract: '<p>Tech Writing 101 is a class developed by tech writers at Google to train engineers and others in the principles of effective technical writing.</p>
 
-    <p>Everyone at Write the Docs Australia Conference 2019 is welcome. For tech writers and others, the class offers an interactive, discussion-filled approach to learning tech writing patterns.</p>'
+    <p>Everyone at Write the Docs Australia Conference 2019 is welcome. For tech writers and others, the class offers an interactive, discussion-filled approach to learning tech writing patterns.</p>
+
+    <p>Read about prerequisites and more in the `workshop details <https://www.writethedocs.org/conf/australia/2019/workshop-tech-writing/>`_.</p>'
   slug: techwriting-workshop-sarah-maddox
   speakers:
   - name: Sarah Maddox

--- a/docs/_data/2019.australia.speakers.yaml
+++ b/docs/_data/2019.australia.speakers.yaml
@@ -374,7 +374,7 @@
 
     <p>During this doc fixit, you will work with the Kubeflow tech writer to fix doc bugs. The bugs include spelling mistakes, grammar that’s not quite right, sentences that could flow better, and more. While fixing bugs, you’ll learn about working in open source on GitHub. You’ll experience a static site generator (Hugo) for publishing docs. Best of all, you’ll improve the experience of the developers and data scientists who’re reading the docs.</p>
 
-    <p>Read about prerequisites and more in the <a href="https://www.writethedocs.org/conf/australia/2019/doc-fixit-kubeflow/">doc fixit details</a>.</p>`
+    <p>Read about prerequisites and more in the <a href="https://www.writethedocs.org/conf/australia/2019/doc-fixit-kubeflow/">doc fixit details</a>.</p>'
   slug: kubeflow-doc-fixit-sarah-maddox
   speakers:
   - name: Sarah Maddox

--- a/docs/_data/2019.australia.speakers.yaml
+++ b/docs/_data/2019.australia.speakers.yaml
@@ -374,7 +374,7 @@
 
     <p>During this doc fixit, you will work with the Kubeflow tech writer to fix doc bugs. The bugs include spelling mistakes, grammar that’s not quite right, sentences that could flow better, and more. While fixing bugs, you’ll learn about working in open source on GitHub. You’ll experience a static site generator (Hugo) for publishing docs. Best of all, you’ll improve the experience of the developers and data scientists who’re reading the docs.</p>
 
-    <p>Read about prerequisites and more in the `doc fixit details <https://www.writethedocs.org/conf/australia/2019/doc-fixit-kubeflow/>`_.</p>`
+    <p>Read about prerequisites and more in the <a href="https://www.writethedocs.org/conf/australia/2019/doc-fixit-kubeflow/">doc fixit details</a>.</p>`
   slug: kubeflow-doc-fixit-sarah-maddox
   speakers:
   - name: Sarah Maddox
@@ -400,7 +400,7 @@
 
     <p>Everyone at Write the Docs Australia Conference 2019 is welcome. For tech writers and others, the class offers an interactive, discussion-filled approach to learning tech writing patterns.</p>
 
-    <p>Read about prerequisites and more in the `workshop details <https://www.writethedocs.org/conf/australia/2019/workshop-tech-writing/>`_.</p>'
+    <p>Read about prerequisites and more in the <a href="https://www.writethedocs.org/conf/australia/2019/workshop-tech-writing/">workshop details</a>.</p>'
   slug: techwriting-workshop-sarah-maddox
   speakers:
   - name: Sarah Maddox

--- a/docs/_data/australia-2019-day-2.yaml
+++ b/docs/_data/australia-2019-day-2.yaml
@@ -68,7 +68,7 @@
   Time: '14:20'
 - Duration: '120'
   Session: Sarah Maddox - Tech Writing 101 Workshop
-  Slug: sarah-maddox
+  Slug: sarah-maddox-workshop
   Time: '14:45'
 - Duration: '15'
   Session: Conference wraps up

--- a/docs/conf/australia/2019/doc-fixit-kubeflow.rst
+++ b/docs/conf/australia/2019/doc-fixit-kubeflow.rst
@@ -24,7 +24,7 @@ The doc fixit hosts:
 Schedule
 --------
 
-- Date & Time: **TBA**.
+- Date & Time: **Thursday, 14th November 2019, at 13:00-15:00**.
 - Location: {{about.mainroom}}.
 - Find out more:
   :doc:`/conf/australia/2019/venue`
@@ -44,11 +44,7 @@ Preparing for the Kubeflow doc fixit:
 
 * Before you get started, you need to sign up for a GitHub account [https://github.com/join] if you don't already have one. If you have time to do this before the start of the sprint, that's great. If not, you can do it during the sprint.
 
-* Sign the Google Contributor License Agreement (CLA). If you have time to do this before the start of the sprint, that's great. If not, you can do it during the sprint:
-
-* Head over to `https://cla.developers.google.com/ <https://cla.developers.google.com/>`_ to see your current agreements on file or to sign a new one. If you've already done this for some other project, you shouldn't need to do it again.
-
-* If you haven't signed the CLA by the time you send your first pull request (PR) during the doc fixit, the automated Googlebot will prompt you to sign the CLA.
+* Sign the Google Contributor License Agreement (CLA). If you have time to do this before the start of the sprint, that's great. If not, you can do it during the sprint. Head over to `https://cla.developers.google.com/ <https://cla.developers.google.com/>`_ to see your current agreements on file or to sign a new one. If you've already done this for some other project, you shouldn't need to do it again. If you haven't signed the CLA by the time you send your first pull request (PR) during the doc fixit, the automated Googlebot will prompt you to sign the CLA.
 
 * It’s not mandatory to do any prework, but it will help if you know some Markdown: `https://www.markdownguide.org/basic-syntax <https://www.markdownguide.org/basic-syntax>`_.
 

--- a/docs/conf/australia/2019/workshop-tech-writing.rst
+++ b/docs/conf/australia/2019/workshop-tech-writing.rst
@@ -35,7 +35,7 @@ Your workshop hosts are three tech writers from Google:
 Schedule
 --------
 
-- Date & Time: **TBA**.
+- Date & Time: **Friday, 15th November 2019, at 14:45-16:45**.
 - Location: {{about.mainroom}}.
 - Find out more:
   :doc:`/conf/australia/2019/venue`


### PR DESCRIPTION
Updated text for Kubeflow doc fixit and added date and time.
Added date and time to workshop page.
Fixed a link from the schedule to the TW101 workshop.
Added links from speakers page to essential info about workshop and doc fixit - otherwise people will arrive without the prerequisites.
