### PR TITLE
testing: update to include new vale information

### DIFF
--- a/docs/guide/tools/testing.rst
+++ b/docs/guide/tools/testing.rst
@@ -96,14 +96,13 @@ Vale is a syntax-aware linter for prose built for speed and extensibility.
 
 https://github.com/errata-ai/vale
 
-It ships with the following default styles:
+You can use the following styles with Vale, although as of v2.0.0, Vale no longer includes these styles by default:
 
 * `Proselint <https://github.com/amperser/proselint>`_
 * `Write-good <https://github.com/btford/write-good>`_
 * `Joblint <https://github.com/rowanmanning/joblint>`_
 
-Several organizations have also created styles for use with Vale. Some of these
-styles have been collected in the following repository: https://github.com/testthedocs/vale-styles .
+You can also use an implementation of both the Microsoft Writing Style Guide and the Google Developer Documentation Style Guide with Vale. You can find these styles in the following repository: https://github.com/errata-ai/styles.
 
 To configure Vale, follow the instructions in the README. If needed, install
 the *vale* binary as an executable in your $PATH, so you can run *vale* directly


### PR DESCRIPTION
As of v2.0.0 Vale no longer includes `write-good`, `proselint`, or `Joblint` by default. These can now be installed at their own repositories, which can be found at the new styles library.

Vale release note indicating this change: https://github.com/errata-ai/vale/releases/tag/v2.0.0

Link to new Vale style library: https://github.com/errata-ai/styles