### PR TITLE
Validate that all sessions are scheduled if flaghasscheduled is set.

### DIFF
--- a/docs/_ext/core.py
+++ b/docs/_ext/core.py
@@ -72,26 +72,34 @@ def load_conference_context_from_yaml(shortcode, year, year_str, page):
     # Do some additional contextual validation that can't be done by a YAML schema validator.
     # This aims to produce clear warnings rather than unexplained empty schedule output.
     if data['flaghaswritingday'] and 'writing_day' not in schedule:
-            log.warning('Missing key "writing_day" while reading schedule from %s', schedule_yaml_file)
+        raise Exception('ERROR Missing key "writing_day" while reading schedule from %s' % schedule_yaml_file)
     for day in range(1, data['date']['total_talk_days'] + 1):
         key = 'talks_day' + str(day)
         if key not in schedule:
-            log.warning('Missing key "%s" while reading schedule from %s', key, schedule_yaml_file)
+            raise Exception('ERROR Missing key "%s" while reading schedule from %s' % (key, schedule_yaml_file))
 
     # The schedule contains a time and a slug or title for each session.
     # Slugs reference the speakers/talk info (abstract, name, etc.), and that
     # info is added to the session info in the context.
+    slugs_in_schedule = set()
     for day_schedule in schedule.values():
         for schedule_item in day_schedule:
             if 'slug' in schedule_item:
+                slug = schedule_item['slug']
                 try:
-                    session_data = sessions_by_slug[schedule_item['slug']]
+                    session_data = sessions_by_slug[slug]
                     schedule_item['data'] = session_data
                     schedule_item['speaker_names'] = speaker_names_display(session_data['speakers'])
+                    slugs_in_schedule.add(slug)
                 except KeyError:
-                    log.warning('Unable to find details for session %s in page %s', schedule_item['slug'], page)
+                    raise Exception('ERROR: Unable to find details for session %s while rendering page %s' % (slug, page))
             elif 'title' not in schedule_item:
-                log.warning('Item %s in schedule rendered for %s has neither a slug nor title', schedule_item, page)
+                raise Exception('ERROR: Item %s in schedule rendered for %s has neither a slug nor title' % (schedule_item, page))
+
+    missing_slugs_from_schedule = set(sessions_by_slug.keys()) - slugs_in_schedule
+    if missing_slugs_from_schedule:
+        raise Exception('ERROR: Session slugs were found in the speakers YAML, '
+                        'that are missing from the schedule: %s' % missing_slugs_from_schedule)
 
     data['schedule'] = schedule
     return data
@@ -106,7 +114,7 @@ def load_yaml_log_error(page, yaml_file):
         yaml_config = load_yaml(yaml_file)
         return yaml_config
     except (YAMLError, OSError) as error:
-        log.warning('Unable to process conference YAML file %s while rendering %s: %s', yaml_file, page, error)
+        log.error('Unable to process conference YAML file %s while rendering %s: %s', yaml_file, page, error)
         return {}
 
 

--- a/docs/organizer-guide/confs/website.rst
+++ b/docs/organizer-guide/confs/website.rst
@@ -269,7 +269,8 @@ Within each day, each item must have a ``time``, which is free text, so it
 can be in 12 hour or 24 hour time, and either a ``title`` or a ``slug``.
 A title is used for free text schedule items, like "Snack Break". A slug is
 used for conference talks, where the slug must match the slug of a session
-in the ``_data/<shortcode>-<year>-sessions.yaml`` file.
+in the ``_data/<shortcode>-<year>-sessions.yaml`` file. All sessions must
+be in the schedule.
 
 A schedule file for a very brief conference could look like::
 


### PR DESCRIPTION
Also makes the errors in scheduling explicit build aborts,
rather than warning logs, as they should always be fixed.