### PR TITLE
salary-survey/2019.rst typo fix

### DIFF
--- a/docs/surveys/salary-survey/2019.rst
+++ b/docs/surveys/salary-survey/2019.rst
@@ -515,7 +515,7 @@ The top reasons listed for dissatisfaction were:
    +-----------------------------------+-----------------------------------+
 
 After the most common reasons for dissatisfaction, the following reasons
-wre identified by smaller numbers of respondents:
+were identified by smaller numbers of respondents:
 
 .. table::  Less Common Reasons for Dissatisfaction
 


### PR DESCRIPTION
First, thank you for sharing the survey results.

This PR fixes a typo: 

After the most common reasons for dissatisfaction, the following reasons **wre** identified by smaller numbers of respondents: