### PR TITLE
Update moderator list to everyone in the slack-mods channel

### DIFF
--- a/docs/team.rst
+++ b/docs/team.rst
@@ -55,8 +55,11 @@ Members
 
 * `Jennifer Rondeau <https://twitter.com/bradamante>`_ *
 * `Neal Kaplan <https://twitter.com/nealkaplan>`_
+* `Janine Chan <https://www.linkedin.com/in/janinechan/>`_ 
+* `Daniel Beck <https://twitter.com/ddbeck>`_
 * `Mike Jang <https://twitter.com/themikejang>`__
 * `Eric Holscher <https://twitter.com/ericholscher>`_
+* `Samuel Wright <https://twitter.com/plaindocs>`_ 
 
 
 Meetup Coordination Team


### PR DESCRIPTION
We should keep this list and the membership of that channel consistent,
so that users know who they can reach out to.