### PR TITLE
Add a backup-livestream page for fallback needs

### DIFF
--- a/docs/conf/portland/2020/backup-livestream.rst
+++ b/docs/conf/portland/2020/backup-livestream.rst
@@ -1,0 +1,18 @@
+:template: {{year}}/generic.html
+
+
+Backup Live Stream
+==================
+
+This page is a placeholder in case we have issues with our primary video platform.
+We have a backup plan to stream directly to this page in the event of extended downtime with our primary event platform.
+
+If you experience technical issues, please report them to us via an email to {{ shortcode }}@writethedocs.org.
+
+.. Commenting out the embed for now
+
+    .. raw:: html
+
+        <iframe width="100%" height="420" src="https://www.youtube.com/embed/9-zBDuekjak" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+    `View on YouTube <https://www.youtube.com/watch?v=9-zBDuekjak/>`_


### PR DESCRIPTION
This won't contain the embed until we need it,
but it will be a quick PR to add it if we do.