### PR TITLE
Replaced link for Boston organizer Lisa Gay with LinkedIn URL

### DIFF
--- a/docs/_data/meetups/usa-boston.yaml
+++ b/docs/_data/meetups/usa-boston.yaml
@@ -12,4 +12,4 @@ organizers:
   - name: Sharon Robsky
     link: https://www.linkedin.com/in/sharon-robsky/
   - name: Lisa Gay
-    link: https://www.meetup.com/Write-the-Docs-BOS/members/197673049/
+    link: https://www.linkedin.com/in/lisa-gay/


### PR DESCRIPTION
I recommend checking that the link for Lisa Gay works.