### PR TITLE
Fixed unconference links, schedule, and info on WtD AU/India 2020.

### DIFF
--- a/docs/conf/australia/2020/schedule.rst
+++ b/docs/conf/australia/2020/schedule.rst
@@ -49,10 +49,10 @@ Conference Talks
 Unconference
 ~~~~~~~~~~~~
 
-The unconference sessions run in parallel to the main conference talks.
+The unconference sessions run in the second half of the day.
 
 * **Where**: {{about.venue}}, {{about.unconfroom}}
-* **When**: **3:30pm-6:00pm AEDT**
+* **When**: **3:00pm-6:00pm AEDT**
 * **Details**: :doc:`/conf/{{shortcode}}/{{year}}/unconference`
 
 Thursday Night Social
@@ -102,8 +102,8 @@ Conference Talks
 Unconference
 ~~~~~~~~~~~~
 
-The unconference sessions run in parallel to the main conference talks.
+The unconference sessions run in the second half of the day.
 
 * **Where**: {{about.venue}}, {{about.unconfroom}}
-* **When**: **3:45pm-6:00pm AEDT**
+* **When**: **3:15pm-5.45pm AEDT**
 * **Details**: :doc:`/conf/{{shortcode}}/{{year}}/unconference`

--- a/docs/conf/australia/2020/schedule.rst
+++ b/docs/conf/australia/2020/schedule.rst
@@ -52,7 +52,7 @@ Unconference
 The unconference sessions run in the second half of the day.
 
 * **Where**: {{about.venue}}, {{about.unconfroom}}
-* **When**: **3:00pm-6:00pm AEDT**
+* **When**: **3:30pm-6:00pm AEDT**
 * **Details**: :doc:`/conf/{{shortcode}}/{{year}}/unconference`
 
 Thursday Night Social
@@ -105,5 +105,5 @@ Unconference
 The unconference sessions run in the second half of the day.
 
 * **Where**: {{about.venue}}, {{about.unconfroom}}
-* **When**: **3:15pm-5.45pm AEDT**
+* **When**: **3:45pm-6:15pm AEDT**
 * **Details**: :doc:`/conf/{{shortcode}}/{{year}}/unconference`

--- a/docs/conf/australia/2020/unconference.rst
+++ b/docs/conf/australia/2020/unconference.rst
@@ -4,13 +4,40 @@
 Unconference
 ============
 
-Unconference sessions create an opportunity for conference attendees to share ideas, solve problems, and participate in discussions in different ways than we can on the main stage of the conference.
+Unconference sessions create an opportunity for conference attendees to share ideas, solve problems, and participate in discussions in different ways from those on the main stage of the conference.
 
-If you've never attended an unconference, expect to interact closely with others from the community.
-Anyone can suggest and lead a session on a topic -- sessions can be organized around a presentation, a group discussion on a particular problem, or anything in between.
+At the unconference, you'll interact closely with others from the community.
+Anyone can suggest and lead a session on a topic. Session formats vary. You can choose to organize a session around a presentation, a group discussion on a particular problem, or anything in between.
+
+When is the unconference?
+-------------------------
+
+Unconference sessions take place in the second half of both days (Thursday and Friday) of the conference. The session times are in the `unconference schedule <http://tiny.cc/wtd-au-india-schedule2020>`__. There's a time and a table number for each session.
+
+Where is the unconference?
+--------------------------
+
+To take part in the unconference, open the **Sessions** tab in Hopin (our conference platform). Read on for further details.
+
+Scheduling a session
+--------------------
+
+If you want to lead an unconf session, propose a topic and pick a time:
+
+- Look for an empty slot in the `unconference signup sheet <http://tiny.cc/wtd-au-india-schedule2020>`__. 
+- Add your unconference topic. There's a time and a table number for each slot.
+
+We will start promoting the unconference sessions early in the day on the days of the conference, so post your topic early if you want a particular time slot, or to make sure that there's room.
 
 Leading a session
 -----------------
+
+Starting your session:
+
+- When it’s time for your unconference session to begin, go to **Sessions** in Hopin (our conference platform) and select the session that corresponds to your table number.
+- The previous unconference session will be in the same table. Let the attendees of the previous session know that their time is up, and your session will begin soon.
+- Once a group has entered your session, start the conversation!
+- When the unconference leader for the next session enters the session, finish up your discussion to make way for the next one.
 
 There is no stage in an unconference, and sessions instead focus on small group interaction.
 
@@ -21,17 +48,20 @@ Here are a few ideas for how to structure an unconf session, borrowed from `Scot
 -  **Group discussion** - Pick a topic and facilitate a group discussion
 -  **The semi-talk** - Use a short presentation to lead into a group discussion on a topic
 -  **Show and tell** - Show off your latest project, a new tool, or anything else you are excited about
--  **Presentation** - Because sessions are meant to be small and inclusive, this is a difficult format to lead a session with. You cannot rely on slides, because you will not have a screen to present with. Feel free to present a longer talk, but expect more interaction from others joining the session and break often for questions and discussion
+-  **Presentation** - Because sessions are meant to be small and inclusive, this is a difficult format to lead a session with. You cannot rely on slides, because you will not have a screen to present with. Feel free to present a longer talk, but expect more interaction from others joining the session and break often for questions and discussion.
 
-Scheduling a session
---------------------
+Tips for your unconference session:
 
-If you want to lead an unconf session, propose a topic and pick a time; unconf sessions are scheduled for the same time slots as talks on the main stage
+- Avoid doing roundtable introductions. You might run out of time to actually start the conversation!
+- Start the session with a prompt: think of a question that you have about the topic of your unconference and ask it. The conversation typically works itself out after that. If there’s a lull, ask the group if anyone else has a question to ask.
+- Up to 20 people can join the session with audio and video, but more people may join your unconference through chat. Be sure to check the session chat regularly and include people there in the conversation.
+- Be on the lookout for people who aren’t joining in and invite them to speak. Don’t insist, if they make it clear they want to listen only.
 
-We will start promoting the unconference sessions early in the day on the days of the conference, so post your topic early if you want a particular time slot, or to make sure that there's room.
+Joining an unconference session
+-------------------------------
 
+Here's how to take part in an unconference session:
 
-Schedule
---------
-
-Unconference sessions run all day on Thursday and Friday. **Exact schedule subject to confirmation**.
+- Starting Thursday afternoon, check the `unconference schedule <http://tiny.cc/wtd-au-india-schedule2020>`__ to see if there are any sessions you are interested in. New sessions are added all the time, so check back periodically.
+- At the time the session starts, go to the **Sessions** tab in Hopin (our unconference platform) and select the session with the table number that corresponds to the one in the `unconference schedule <http://tiny.cc/wtd-au-india-schedule2020>`__.
+- The session leader will start the session when the group has gathered.

--- a/docs/conf/australia/2020/welcome-wagon.rst
+++ b/docs/conf/australia/2020/welcome-wagon.rst
@@ -102,33 +102,33 @@ Helpful settings
 Unconference
 ------------
 
-- The Unconference is a set of informal sessions that take place both days (Thursday and Friday) afternoon after the lightning talks. `Unconference talks focus on conversations and exchanges of ideas between participants. <https://www.writethedocs.org/conf/Australia/2020/unconference/>`__
-- You can attend unconference sessions, or, if you have an idea for a session, you can lead one. Anyone can lead an unconference session, as long as they have a discussion idea and a willingness to encourage attendees to talk about it.
+- The unconference is a set of informal sessions that take place in the second half of both days (Thursday and Friday). Unconference talks focus on conversations and exchanges of ideas between participants.
+- You can attend unconference sessions, or, if you have an idea for a session, you can lead one.
 
 Lead an unconference session
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - Anyone can lead an unconference session, as long as they have a discussion idea and a willingness to encourage attendees to talk about it.
-- Look for an empty slot on the `Unconference sign-up <https://docs.google.com/spreadsheets/d/1IjA2yQWi1qVhopJ8PyG2obMVa5nodIRsggFSJACaWRk/edit?usp=sharing>`__, and add your Unconference topic. There will be a time and a table number for each slot.
-- When it’s time for your Unconference session to begin, go to **Sessions** and select the session that corresponds to your table number.
+- Look for an empty slot in the `unconference signup sheet <http://tiny.cc/wtd-au-india-schedule2020>`__ and add your unconference topic. There's a time and a table number for each slot.
+- When it’s time for your unconference session to begin, go to **Sessions** in Hopin (our conference platform) and select the session that corresponds to your table number.
 - The previous unconference session will be in the same table. Let the attendees of the previous session know that their time is up, and your session will begin soon.
 - Once a group has entered your session, start the conversation!
-- When the Unconference leader for the next session enters the session, finish up your discussion to make way for the next one.
+- When the unconference leader for the next session enters the session, finish up your discussion to make way for the next one.
 
 Tips for your unconference session
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Avoid doing roundtable introductions. You might run out of time to actually start the conversation!
 - Start the session with a prompt: think of a question that you have about the topic of your unconference and ask it. The conversation typically works itself out after that. If there’s a lull, ask the group if anyone else has a question to ask.
-- Up to 20 people can join the session with audio and video, but more people than that may join your Unconference through chat. Be sure to check the session chat regularly and include people there in the conversation.
+- Up to 20 people can join the session with audio and video, but more people may join your unconference through chat. Be sure to check the session chat regularly and include people there in the conversation.
 - Be on the lookout for people who aren’t joining in and invite them to speak. Don’t insist, if they make it clear they want to listen only.
 
 Join an unconference session
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-- Starting Thursday afternoon, check the `Unconference schedule <https://docs.google.com/spreadsheets/d/e/2PACX-1vTnTF98Sa8kqGT8G7zY3g8kTaEF1AqB8P5EfVJbz305s2BelEZo_rMpQzMIcL5Dfe7Ywfvy1ApHGp0Q/pubhtml>`__ to see if there are any sessions you are interested in joining. New ones are added all the time, so check back periodically.
-- At the time the session starts, go to **Sessions** and select the session with the table number that corresponds to the one in the `Unconference schedule <https://docs.google.com/spreadsheets/d/e/2PACX-1vTnTF98Sa8kqGT8G7zY3g8kTaEF1AqB8P5EfVJbz305s2BelEZo_rMpQzMIcL5Dfe7Ywfvy1ApHGp0Q/pubhtml>`__.
-- The session leader will begin when the group has gathered.
+- Starting Thursday afternoon, check the `unconference schedule <http://tiny.cc/wtd-au-india-schedule2020>`__ to see if there are any sessions you are interested in joining. New ones are added all the time, so check back periodically.
+- At the time the session starts, go to the **Sessions** tab in Hopin (our unconference platform) and select the session with the table number that corresponds to the one in the `unconference schedule <http://tiny.cc/wtd-au-india-schedule2020>`__.
+- The session leader will start the session when the group has gathered.
 
 Lightning talks
 ---------------


### PR DESCRIPTION
Fixed links to the unconference schedule (were pointing to Prague schedule).
Fixed the website schedule to match the unconference schedule.
Removed broken link from Welcome Wagon, as it was unnecessary anyway.
Copied info from Welcome Wagon to unconference page, so that both convey the same messages.