### PR TITLE
Fix Mapbox link

### DIFF
--- a/docs/guide/tools/testing.rst
+++ b/docs/guide/tools/testing.rst
@@ -85,7 +85,7 @@ commonly mistaken branding issues.
 
 Here are a few links that might be interesting:
 
-* https://www.mapbox.com/blog/retext-mapbox-standard/
+* https://blog.mapbox.com/regulating-english-with-retext-mapbox-standard-d79a8158f251
 * https://krausefx.com/blog/writing-automated-tests-for-your-documentation
 
 


### PR DESCRIPTION
Mapbox link not working the new link is the correct url