### PR TITLE
Add 2020 stats and community update

### DIFF
--- a/docs/blog/2021-community-kickoff.rst
+++ b/docs/blog/2021-community-kickoff.rst
@@ -1,0 +1,176 @@
+.. post:: Jan 12, 2021
+   :tags: stats, year in review, newsletter
+   :author: Eric Holscher
+
+Write the Docs 2020 Stats and Community Update
+==============================================
+
+A new year comes with many expectations.
+Hoping for change,
+setting new goals,
+and feeling optimistic about the fresh year that has just begun.
+
+Sadly this year that optimism has been dashed in record time.
+We have written many times throughout 2020 that we hope you're okay,
+and we will have to continue that tradition once more in our inaugural newsletter of 2021.
+
+We hope you're okay,
+and we hope that the storm we have been engulfed in will soon pass.
+
+A heartfelt thanks
+------------------
+
+We had a lot of big plans for this year,
+but most of those had to be put on hold in March as we scrambled to move our community fully online.
+Getting to see all the happy faces at our in-person events is one of the largest motivators for people who organize events.
+Sadly this year, we weren't able to make that happen.
+
+2020 has shown that the love and care we put into the community will be returned back to us when needed.
+When we moved the conferences online,
+we were genuinely worried about the health and longevity of Write the Docs.
+As we noted in our `ticket choices`_ page for Portland,
+we had a lot of outstanding debts and we didn't know how much support we would get with our online conferences.
+It was easy to see a worst case scenario where our venues didn't refund us and people didn't support the online events.
+
+We are happy to report that we received overwhelming support from our vendors, sponsors, speakers, team, and attendees:
+
+* Most of our vendors refunded our down payments in full
+* All but 1 of our sponsors stayed with us for our virtual event
+* Our speakers pulled together to record videos and handle live online Q&A
+* Our team pulled together to run virtual events that exceeded our expectations for what those events could be
+* Our attendees, most importantly, made our virtual events *feel* like our conferences, with a supportive and generous spirit
+
+2020 has been a hard year,
+but we wanted to take this chance to give thanks to those who made 2020 a special year.
+We feel incredibly lucky to be able to support this wonderful community,
+and we look forward to making 2021 the best year yet,
+with your help.
+
+.. _ticket choices: https://www.writethedocs.org/conf/portland/2020/ticket-choices/
+
+Looking forward
+---------------
+
+One of the largest things we noticed in 2020 was how much more our community needed support.
+As we scrambled to move our events online,
+people were also adjusting to working remote for the first time.
+We saw lots of activity in our Slack network,
+as people were trying to build community online.
+Meetups slowly adjusted,
+trying to move online and keep some momentum going.
+
+Write the Docs itself was able to provide similar value as in the past,
+but we didn't have the resources to adjust to the changing world.
+The profits from our conferences pay for everything we do,
+which constrains our ability to adjust to events as they happen.
+
+We are planning a way for our community to support the organization directly.
+We are proud that all the content that Write the Docs produces is free to everyone,
+and we don't plan to change that any time soon.
+The goal for 2021 is to be able to provide additional support to our community,
+paid for by members in that community.
+
+We're still working out the details,
+and will be posting a `WEP`_ soon to ask the community for feedback.
+We hope that you'll support us in building a community that is better able to support you.
+
+.. _WEP: https://www.writethedocs.org/blog/introducing-weps/
+
+Write the Docs Quorum Meetups
+-----------------------------
+
+One of the first things we're excited about this year is an evolution of our meetups: Quorum meetups.
+These quarterly, remote, "super" meetups are an hour long and include a presentation by a speaker followed by breakout networking.
+
+Write the Docs is running two Quorum pilot programs for 2021:
+
+* `Virtual Write the Docs East Coast Quorum on Meetup.com <https://www.meetup.com/virtual-write-the-docs-east-coast-quorum/>`_ - For participants in the Eastern (UTC-4) and Central (UTC-5) time zones. The first meetup is planned for **February**.
+
+* `Virtual Write the Docs West Coast Quorum on Meetup.com <https://www.meetup.com/virtual-write-the-docs-west-coast-quorum/>`_ - For participants in the Pacific (UTC-7) and Mountain (UTC-6) time zones. The first meetup is planned for **March**.
+
+* `Write the Docs Australia on Meetup.com <https://www.meetup.com/Write-the-Docs-Australia/>`_ - We are planning to continue hosting collaborative APAC meetups via our Australia meetup group that are similar in concept.
+
+Events are free and open to all.
+Quarterly meetups will typically occur at 7:00p.m. local time on a Monday through Thursday evening.
+
+If you are a local meetup organizer in the these timezones who would like to learn more about what is required to participate,
+or are located in EMEA and would like to know if the program expands to your time zones,
+contact Alyssa Rock on the Write the Docs Slack network.
+
+You can read more about these meetups in the `quorum meetups GitHub repository`_.
+
+.. _quorum meetups GitHub repository: https://github.com/write-the-docs-quorum/quorum-meetups
+
+Other community updates
+-----------------------
+
+We have lots of things going on with our Portland conference currently.
+Check out the `Portland Call for Proposals page <https://www.writethedocs.org/conf/portland/2021/cfp/#submit-your-proposal>`_ for more details about what we are looking for.
+Remember to submit your talk by **January 25th**.
+
+If you need feedback or help with your talk proposal,
+some of our meetups are hosting a `proposal workshop <https://www.meetup.com/Write-The-Docs-PDX/events/275331733/>`_.
+**The proposal workshop will happen January 20th from 4-6PM PST (UTC-8)**.
+
+We are also working to get our 2020 Salary Survey analyzed and published.
+The plan for this year is to have a few different reports,
+one that comes out each month looking at different aspects of the data.
+We're hoping to have the first report out for our February newsletter.
+
+
+We have shared our high-level community stats for the past 4 years,
+and will continue to do it each year going forward.
+You can view our 2020 stats on our blog at :doc:`/write-the-docs-2020-stats`.
+
+From our sponsor
+----------------
+
+This month’s newsletter is sponsored by `Paligo <https://bit.ly/3fuibKK>`__:
+
+.. raw:: html
+
+    <hr>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="width:100%; max-width: 600px;">
+      <tbody>
+        <tr>
+          <td width="75%">
+              <p>
+              <a href="https://bit.ly/3fuibKK">Paligo is an all-in-one cloud-based CCMS platform.</a> Authoring, versioning, branching, release workflows, publishing, translation management, and more - all updated continuously in the cloud. No more worrying about locally installed software and deployment!
+              </p>
+
+              <p>
+              Read the case study: <a href="https://bit.ly/2UV2uCQ">https://bit.ly/2UV2uCQ</a>
+              </p>
+          </td>
+          <td width="25%">
+            <a href="https://bit.ly/3fuibKK">
+              <img style="margin-left: 15px;" alt="Paligo" src="/_static/img/sponsors/paligo.png">
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <hr>
+
+*Interested in sponsoring the newsletter? Take a look at our* `sponsorship prospectus </sponsorship/newsletter/>`__.
+
+Featured job posts
+------------------
+
+* `Technical Writer (Developer Documentation) <https://jobs.writethedocs.org/job/265/technical-writer-developer-documentation/>`__, Ably
+   Remote (London, UK), full-time
+* `API Technical Writer (m/f/x) <https://jobs.writethedocs.org/job/261/api-technical-writer-m-f-x/>`__, finn GmbH
+   Munich, Germany, full-time
+
+*To apply for these jobs and more, visit the* `Write the Docs job board <https://jobs.writethedocs.org/>`_.
+
+
+Thanks again
+------------
+
+All these numbers remind us of the scale and impact of our work.
+Thanks again for being part of our journey.
+
+To a better 2021,
+
+The Write the Docs team

--- a/docs/blog/2021-community-kickoff.rst
+++ b/docs/blog/2021-community-kickoff.rst
@@ -5,6 +5,10 @@
 Write the Docs 2020 Stats and Community Update
 ==============================================
 
+Hey folks, Eric Holscher here, one of the co-founders of Write the Docs.
+This is your January edition of the newsletter,
+which contains a community update to give the newsletter team the month off.
+
 A new year comes with many expectations.
 Hoping for change,
 setting new goals,
@@ -12,7 +16,7 @@ and feeling optimistic about the fresh year that has just begun.
 
 Sadly this year that optimism has been dashed in record time.
 We have written many times throughout 2020 that we hope you're okay,
-and we will have to continue that tradition once more in our inaugural newsletter of 2021.
+and we're continuing that tradition once more in our inaugural newsletter of 2021.
 
 We hope you're okay,
 and we hope that the storm we have been engulfed in will soon pass.
@@ -20,7 +24,7 @@ and we hope that the storm we have been engulfed in will soon pass.
 A heartfelt thanks
 ------------------
 
-We had a lot of big plans for this year,
+We had a lot of big plans for last year,
 but most of those had to be put on hold in March as we scrambled to move our community fully online.
 Getting to see all the happy faces at our in-person events is one of the largest motivators for people who organize events.
 Sadly this year, we weren't able to make that happen.
@@ -34,11 +38,11 @@ It was easy to see a worst case scenario where our venues didn't refund us and p
 
 We are happy to report that we received overwhelming support from our vendors, sponsors, speakers, team, and attendees:
 
-* Most of our vendors refunded our down payments in full
-* All but 1 of our sponsors stayed with us for our virtual event
-* Our speakers pulled together to record videos and handle live online Q&A
-* Our team pulled together to run virtual events that exceeded our expectations for what those events could be
-* Our attendees, most importantly, made our virtual events *feel* like our conferences, with a supportive and generous spirit
+* Most of our vendors refunded our down payments in full. Our A/V and captioning folks adapted perfectly to the new format.
+* Only 1 of our sponsors canceled because of the transition to a virtual event.
+* Our speakers pulled together to record videos and handle live online Q&A.
+* Our team pulled together to run virtual events that exceeded our expectations for what those events could be.
+* Our attendees, most importantly, made our virtual events *feel* like our conferences, with a supportive and generous spirit.
 
 2020 has been a hard year,
 but we wanted to take this chance to give thanks to those who made 2020 a special year.
@@ -51,11 +55,11 @@ with your help.
 Looking forward
 ---------------
 
-One of the largest things we noticed in 2020 was how much more our community needed support.
+One of the largest things we noticed in 2020 was how much more support our community needed.
 As we scrambled to move our events online,
-people were also adjusting to working remote for the first time.
+people were also adjusting to working remotely for the first time.
 We saw lots of activity in our Slack network,
-as people were trying to build community online.
+as people were trying to connect online.
 Meetups slowly adjusted,
 trying to move online and keep some momentum going.
 
@@ -104,9 +108,15 @@ You can read more about these meetups in the `quorum meetups GitHub repository`_
 Other community updates
 -----------------------
 
-We have lots of things going on with our Portland conference currently.
-Check out the `Portland Call for Proposals page <https://www.writethedocs.org/conf/portland/2021/cfp/#submit-your-proposal>`_ for more details about what we are looking for.
-Remember to submit your talk by **January 25th**.
+We have shared our high-level community stats for the past 4 years,
+and will continue to do it each year going forward.
+You can view our 2020 stats on our blog at :doc:`/write-the-docs-2020-stats`.
+
+We're still accepting `talk proposals <https://www.writethedocs.org/conf/portland/2021/cfp/#submit-your-proposal>`_ for our virtual Portland conference, April 25-27.
+Especially if you've not been able to attend due to travel logistics, or if you've not spoken before we'd love to hear your voice.
+**Tell us your ideas by the January 25**,
+and if accepted,
+put together a 30 min talk video by the end of March.
 
 If you need feedback or help with your talk proposal,
 some of our meetups are hosting a `proposal workshop <https://www.meetup.com/Write-The-Docs-PDX/events/275331733/>`_.
@@ -116,11 +126,6 @@ We are also working to get our 2020 Salary Survey analyzed and published.
 The plan for this year is to have a few different reports,
 one that comes out each month looking at different aspects of the data.
 We're hoping to have the first report out for our February newsletter.
-
-
-We have shared our high-level community stats for the past 4 years,
-and will continue to do it each year going forward.
-You can view our 2020 stats on our blog at :doc:`/write-the-docs-2020-stats`.
 
 From our sponsor
 ----------------

--- a/docs/blog/2021-community-kickoff.rst
+++ b/docs/blog/2021-community-kickoff.rst
@@ -122,6 +122,11 @@ If you need feedback or help with your talk proposal,
 some of our meetups are hosting a `proposal workshop <https://www.meetup.com/Write-The-Docs-PDX/events/275331733/>`_.
 **The proposal workshop will happen January 20th from 4-6PM PST (UTC-8)**.
 
+Given the increased usage of our Slack network,
+we have also seen the need for increased formalization of our moderation.
+We will be proposing a `WEP <https://www.writethedocs.org/blog/introducing-weps/>`_ to formalize our process around moderation.
+Look for announcements of that in the newsletter if you want to contribute.
+
 We are also working to get our 2020 Salary Survey analyzed and published.
 The plan for this year is to have a few different reports,
 one that comes out each month looking at different aspects of the data.

--- a/docs/blog/2021-community-kickoff.rst
+++ b/docs/blog/2021-community-kickoff.rst
@@ -64,7 +64,7 @@ Meetups slowly adjusted,
 trying to move online and keep some momentum going.
 
 Write the Docs itself was able to provide similar value as in the past,
-but we didn't have the resources to adjust to the changing world.
+but we had limited resources to adjust to the changing world.
 The profits from our conferences pay for everything we do,
 which constrains our ability to adjust to events as they happen.
 
@@ -72,7 +72,7 @@ We are planning a way for our community to support the organization directly.
 We are proud that all the content that Write the Docs produces is free to everyone,
 and we don't plan to change that any time soon.
 The goal for 2021 is to be able to provide additional support to our community,
-paid for by members in that community.
+funded by members in that community, who are able to contribute.
 
 We're still working out the details,
 and will be posting a `WEP`_ soon to ask the community for feedback.
@@ -86,7 +86,7 @@ Write the Docs Quorum Meetups
 One of the first things we're excited about this year is an evolution of our meetups: Quorum meetups.
 These quarterly, remote, "super" meetups are an hour long and include a presentation by a speaker followed by breakout networking.
 
-Write the Docs is running two Quorum pilot programs for 2021:
+Write the Docs is running three Quorum pilot programs for 2021:
 
 * `Virtual Write the Docs East Coast Quorum on Meetup.com <https://www.meetup.com/virtual-write-the-docs-east-coast-quorum/>`_ - For participants in the Eastern (UTC-4) and Central (UTC-5) time zones. The first meetup is planned for **February**.
 
@@ -113,7 +113,7 @@ and will continue to do it each year going forward.
 You can view our 2020 stats on our blog at :doc:`/write-the-docs-2020-stats`.
 
 We're still accepting `talk proposals <https://www.writethedocs.org/conf/portland/2021/cfp/#submit-your-proposal>`_ for our virtual Portland conference, April 25-27.
-Especially if you've not been able to attend due to travel logistics, or if you've not spoken before we'd love to hear your voice.
+Especially if you've not been able to attend due to travel logistics, or if you've not spoken before we'd love to hear your voice. The virtual conference format means you can speak from anywhere, though it's ideal if you are close to the local time in Portland.
 **Tell us your ideas by the January 25**,
 and if accepted,
 put together a 30 min talk video by the end of March.

--- a/docs/blog/2021-january-community-update.rst
+++ b/docs/blog/2021-january-community-update.rst
@@ -2,12 +2,15 @@
    :tags: stats, year in review, newsletter
    :author: Eric Holscher
 
-Write the Docs 2020 Stats and Community Update
-==============================================
+Write the Docs 2021 January Community Update
+============================================
 
 Hey folks, Eric Holscher here, one of the co-founders of Write the Docs.
 This is your January edition of the newsletter,
 which contains a community update to give the newsletter team the month off.
+
+A new year
+----------
 
 A new year comes with many expectations.
 Hoping for change,
@@ -16,7 +19,7 @@ and feeling optimistic about the fresh year that has just begun.
 
 Sadly this year that optimism has been dashed in record time.
 We have written many times throughout 2020 that we hope you're okay,
-and we're continuing that tradition once more in our inaugural newsletter of 2021.
+and we're continuing that tradition once more in our first newsletter of 2021.
 
 We hope you're okay,
 and we hope that the storm we have been engulfed in will soon pass.
@@ -113,11 +116,12 @@ and will continue to do it each year going forward.
 You can view our 2020 stats on our blog at :doc:`/write-the-docs-2020-stats`.
 
 We're still accepting `talk proposals <https://www.writethedocs.org/conf/portland/2021/cfp/#submit-your-proposal>`_ for our virtual Portland conference, April 25-27.
-Especially if you've not been able to attend due to travel logistics, or if you've not spoken before we'd love to hear your voice. The virtual conference format means you can speak from anywhere, though it's ideal if you are close to the local time in Portland.
+Especially if you've not been able to attend due to travel logistics, or if you've not spoken before we'd love to hear your voice.
+The virtual conference format means you can speak from anywhere, though it's ideal if you are close to the local time in Portland.
+
 **Tell us your ideas by the January 25**,
 and if accepted,
 put together a 30 min talk video by the end of March.
-
 If you need feedback or help with your talk proposal,
 some of our meetups are hosting a `proposal workshop <https://www.meetup.com/Write-The-Docs-PDX/events/275331733/>`_.
 **The proposal workshop will happen January 20th from 4-6PM PST (UTC-8)**.

--- a/docs/blog/2021-january-community-update.rst
+++ b/docs/blog/2021-january-community-update.rst
@@ -98,7 +98,7 @@ Write the Docs is running three Quorum pilot programs for 2021:
 * `Write the Docs Australia on Meetup.com <https://www.meetup.com/Write-the-Docs-Australia/>`_ - We are planning to continue hosting collaborative APAC meetups via our Australia meetup group that are similar in concept.
 
 Events are free and open to all.
-Quarterly meetups will typically occur at 7:00p.m. local time on a Monday through Thursday evening.
+Quarterly meetups will typically occur at 7PM local time on a Monday through Thursday evening.
 
 If you are a local meetup organizer in the these timezones who would like to learn more about what is required to participate,
 or are located in EMEA and would like to know if the program expands to your time zones,

--- a/docs/blog/2021-january-community-update.rst
+++ b/docs/blog/2021-january-community-update.rst
@@ -1,4 +1,4 @@
-.. post:: Jan 12, 2021
+.. post:: Jan 13, 2021
    :tags: stats, year in review, newsletter
    :author: Eric Holscher
 
@@ -6,7 +6,7 @@ Write the Docs 2021 January Community Update
 ============================================
 
 Hey folks, Eric Holscher here, one of the co-founders of Write the Docs.
-This is your January edition of the newsletter,
+This is the January edition of the newsletter,
 which contains a community update to give the newsletter team the month off.
 
 A new year
@@ -113,15 +113,15 @@ Other community updates
 
 We have shared our high-level community stats for the past 4 years,
 and will continue to do it each year going forward.
-You can view our 2020 stats on our blog at :doc:`/write-the-docs-2020-stats`.
+You can view our 2020 stats on our blog at :doc:`/blog/write-the-docs-2020-stats`.
 
 We're still accepting `talk proposals <https://www.writethedocs.org/conf/portland/2021/cfp/#submit-your-proposal>`_ for our virtual Portland conference, April 25-27.
 Especially if you've not been able to attend due to travel logistics, or if you've not spoken before we'd love to hear your voice.
 The virtual conference format means you can speak from anywhere, though it's ideal if you are close to the local time in Portland.
 
-**Tell us your ideas by the January 25**,
-and if accepted,
-put together a 30 min talk video by the end of March.
+**Submit your talk proposals by January 25th**,
+If accepted,
+we'll ask you to put together a 30 min talk video by the end of March.
 If you need feedback or help with your talk proposal,
 some of our meetups are hosting a `proposal workshop <https://www.meetup.com/Write-The-Docs-PDX/events/275331733/>`_.
 **The proposal workshop will happen January 20th from 4-6PM PST (UTC-8)**.
@@ -153,7 +153,7 @@ This month’s newsletter is sponsored by `Paligo <https://bit.ly/3fuibKK>`__:
               </p>
 
               <p>
-              Read the case study: <a href="https://bit.ly/2UV2uCQ">https://bit.ly/2UV2uCQ</a>
+              <a href="https://bit.ly/2UV2uCQ">Read the case study</a> to learn more.
               </p>
           </td>
           <td width="25%">

--- a/docs/blog/write-the-docs-2020-stats.rst
+++ b/docs/blog/write-the-docs-2020-stats.rst
@@ -84,9 +84,9 @@ These quarterly, remote, "super" meetups are an hour long and include a presenta
 
 Write the Docs is running two Quorum pilot programs for 2021:
 
-* `Virtual Write the Docs East Coast Quorum on Meetup.com <https://www.meetup.com/virtual-write-the-docs-east-coast-quorum/>`_` - For participants in the Eastern (UTC-4) and Central (UTC-5) time zones. The first meetup is planned for **February**.
+* `Virtual Write the Docs East Coast Quorum on Meetup.com <https://www.meetup.com/virtual-write-the-docs-east-coast-quorum/>`_ - For participants in the Eastern (UTC-4) and Central (UTC-5) time zones. The first meetup is planned for **February**.
 
-* `Virtual Write the Docs West Coast Quorum on Meetup.com <https://www.meetup.com/virtual-write-the-docs-west-coast-quorum/>`_` - For participants in the Pacific (UTC-7) and Mountain (UTC-6) time zones. The first meetup is planned for **March**.
+* `Virtual Write the Docs West Coast Quorum on Meetup.com <https://www.meetup.com/virtual-write-the-docs-west-coast-quorum/>`_ - For participants in the Pacific (UTC-7) and Mountain (UTC-6) time zones. The first meetup is planned for **March**.
 
 * `Write the Docs Australia on Meetup.com <https://www.meetup.com/Write-the-Docs-Australia/>`_ - We are planning to continue hosting collaborative APAC meetups via our Australia meetup group that are similar in concept.
 

--- a/docs/blog/write-the-docs-2020-stats.rst
+++ b/docs/blog/write-the-docs-2020-stats.rst
@@ -1,11 +1,11 @@
-.. post:: Jan 12, 2021
+.. post:: Jan 13, 2021
    :tags: stats, year in review, newsletter
    :author: Eric Holscher
 
 Write the Docs 2020 Stats
 =========================
 
-This year we have done a :doc:`2021-community-kickoff` email along with our stats.
+This year we have done a :doc:`/blog/2021-january-community-update` post along with our stats.
 Check there for context around the community going into 2021.
 
 2020 Stats

--- a/docs/blog/write-the-docs-2020-stats.rst
+++ b/docs/blog/write-the-docs-2020-stats.rst
@@ -38,7 +38,7 @@ We are happy to report that we received overwhelming support from our vendors, s
 * All but 1 of our sponsors stayed with us for our virtual event
 * Our speakers pulled together to record videos and handle live online Q&A
 * Our team pulled together to run virtual events that exceeded our expectations for what those events could be
-* Our attendees, most importantly, made our virtual events _feel_ like our conferences, with a supportive and generous spirit
+* Our attendees, most importantly, made our virtual events *feel* like our conferences, with a supportive and generous spirit
 
 2020 has been a hard year,
 but we wanted to take this chance to give thanks to those who made 2020 a special year.

--- a/docs/blog/write-the-docs-2020-stats.rst
+++ b/docs/blog/write-the-docs-2020-stats.rst
@@ -2,104 +2,11 @@
    :tags: stats, year in review, newsletter
    :author: Eric Holscher
 
-Write the Docs 2020 Stats and Community Update
-==============================================
+Write the Docs 2020 Stats
+=========================
 
-A new year comes with many expectations.
-Hoping for change,
-setting new goals,
-and feeling optimistic about the fresh year that has just begun.
-
-Sadly this year that optimism has been dashed in record time.
-We have written many times throughout 2020 that we hope you're okay,
-and we will have to continue that tradition once more in our inaugural newsletter of 2021.
-
-We hope you're okay,
-and we hope that the storm we have been engulfed in will soon pass.
-
-A heartfelt thanks
-------------------
-
-We had a lot of big plans for this year,
-but most of those had to be put on hold in March as we scrambled to move our community fully online.
-Getting to see all the happy faces at our in-person events is one of the largest motivators for people who organize events.
-Sadly this year, we weren't able to make that happen.
-
-2020 has shown that the love and care we put into the community will be returned back to us when needed.
-When we moved the conferences online,
-we were genuinely worried about the health and longevity of Write the Docs.
-As we noted in our `ticket choices`_ page for Portland,
-we had a lot of outstanding debts and we didn't know how much support we would get with our online conferences.
-It was easy to see a worst case scenario where our venues didn't refund us and people didn't support the online events.
-
-We are happy to report that we received overwhelming support from our vendors, sponsors, speakers, team, and attendees:
-
-* Most of our vendors refunded our down payments in full
-* All but 1 of our sponsors stayed with us for our virtual event
-* Our speakers pulled together to record videos and handle live online Q&A
-* Our team pulled together to run virtual events that exceeded our expectations for what those events could be
-* Our attendees, most importantly, made our virtual events *feel* like our conferences, with a supportive and generous spirit
-
-2020 has been a hard year,
-but we wanted to take this chance to give thanks to those who made 2020 a special year.
-We feel incredibly lucky to be able to support this wonderful community,
-and we look forward to making 2021 the best year yet,
-with your help.
-
-.. _ticket choices: https://www.writethedocs.org/conf/portland/2020/ticket-choices/
-
-Looking forward
----------------
-
-One of the largest things we noticed in 2020 was how much more our community needed support.
-As we scrambled to move our events online,
-people were also adjusting to working remote for the first time.
-We saw lots of activity in our Slack network,
-as people were trying to build community online.
-Meetups slowly adjusted,
-trying to move online and keep some momentum going.
-
-Write the Docs itself was able to provide similar value as in the past,
-but we didn't have the resources to adjust to the changing world.
-The profits from our conferences pay for everything we do,
-which constrains our ability to adjust to events as they happen.
-
-We are planning a way for our community to support the organization directly.
-We are proud that all the content that Write the Docs produces is free to everyone,
-and we don't plan to change that any time soon.
-The goal for 2021 is to be able to provide additional support to our community,
-paid for by members in that community.
-
-We're still working out the details,
-and will be posting a `WEP`_ soon to ask the community for feedback.
-We hope that you'll support us in building a community that is better able to support you.
-
-.. _WEP: https://www.writethedocs.org/blog/introducing-weps/
-
-Write the Docs Quorum Meetups
------------------------------
-
-One of the first things we're excited about this year is an evolution of our meetups: Quorum meetups.
-These quarterly, remote, "super" meetups are an hour long and include a presentation by a speaker followed by breakout networking.
-
-Write the Docs is running two Quorum pilot programs for 2021:
-
-* `Virtual Write the Docs East Coast Quorum on Meetup.com <https://www.meetup.com/virtual-write-the-docs-east-coast-quorum/>`_ - For participants in the Eastern (UTC-4) and Central (UTC-5) time zones. The first meetup is planned for **February**.
-
-* `Virtual Write the Docs West Coast Quorum on Meetup.com <https://www.meetup.com/virtual-write-the-docs-west-coast-quorum/>`_ - For participants in the Pacific (UTC-7) and Mountain (UTC-6) time zones. The first meetup is planned for **March**.
-
-* `Write the Docs Australia on Meetup.com <https://www.meetup.com/Write-the-Docs-Australia/>`_ - We are planning to continue hosting collaborative APAC meetups via our Australia meetup group that are similar in concept.
-
-Events are free and open to all.
-Quarterly meetups will typically occur at 7:00p.m. local time on a Monday through Thursday evening.
-
-If you are a local meetup organizer in the these timezones who would like to learn more about what is required to participate,
-or are located in EMEA and would like to know if the program expands to your time zones,
-contact Alyssa Rock on the Write the Docs Slack network.
-
-You can read more about these meetups in the `quorum meetups GitHub repository`_.
-
-.. _quorum meetups GitHub repository: https://github.com/write-the-docs-quorum/quorum-meetups
+This year we have done a :doc:`2021-community-kickoff` email along with our stats.
+Check there for context around the community going into 2021.
 
 2020 Stats
 ----------
@@ -169,49 +76,6 @@ GitHub
 .. commits: git rev-list --count --all --after="2020-01-01" --before="2021-01-01"
 .. _commits: https://github.com/writethedocs/www/commits/master
 .. _people: https://github.com/writethedocs/www/graphs/contributors?from=2020-01-01&to=2021-01-01&type=c
-
-From our sponsor
-----------------
-
-This month’s newsletter is sponsored by `Paligo <https://bit.ly/3fuibKK>`__:
-
-.. raw:: html
-
-    <hr>
-    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="width:100%; max-width: 600px;">
-      <tbody>
-        <tr>
-          <td width="75%">
-              <p>
-              <a href="https://bit.ly/3fuibKK">Paligo is an all-in-one cloud-based CCMS platform.</a> Authoring, versioning, branching, release workflows, publishing, translation management, and more - all updated continuously in the cloud. No more worrying about locally installed software and deployment!
-              </p>
-
-              <p>
-              Read the case study: <a href="https://bit.ly/2UV2uCQ">https://bit.ly/2UV2uCQ</a>
-              </p>
-          </td>
-          <td width="25%">
-            <a href="https://bit.ly/3fuibKK">
-              <img style="margin-left: 15px;" alt="Paligo" src="/_static/img/sponsors/paligo.png">
-            </a>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-    <hr>
-
-*Interested in sponsoring the newsletter? Take a look at our* `sponsorship prospectus </sponsorship/newsletter/>`__.
-
-Featured job posts
-------------------
-
-* `Technical Writer (Developer Documentation) <https://jobs.writethedocs.org/job/265/technical-writer-developer-documentation/>`__, Ably
-   Remote (London, UK), full-time
-* `API Technical Writer (m/f/x) <https://jobs.writethedocs.org/job/261/api-technical-writer-m-f-x/>`__, finn GmbH
-   Munich, Germany, full-time
-
-*To apply for these jobs and more, visit the* `Write the Docs job board <https://jobs.writethedocs.org/>`_.
-
 
 Thanks again
 ------------

--- a/docs/blog/write-the-docs-2020-stats.rst
+++ b/docs/blog/write-the-docs-2020-stats.rst
@@ -170,7 +170,6 @@ GitHub
 .. _commits: https://github.com/writethedocs/www/commits/master
 .. _people: https://github.com/writethedocs/www/graphs/contributors?from=2020-01-01&to=2021-01-01&type=c
 
-----------------
 From our sponsor
 ----------------
 

--- a/docs/blog/write-the-docs-2020-stats.rst
+++ b/docs/blog/write-the-docs-2020-stats.rst
@@ -1,0 +1,190 @@
+.. post:: Jan 12, 2021
+   :tags: stats, year in review, newsletter
+   :author: Eric Holscher
+
+Write the Docs 2020 Stats and Community Update
+==============================================
+
+A new year comes with many expectations.
+Hoping for change,
+setting new goals,
+and feeling optimistic about the fresh year that has just begun.
+
+Sadly this year that optimism has been dashed in record time.
+We have written many times throughout 2020 that we hope you're okay,
+and we will have to continue that tradition once more in our inaugural newsletter of 2021.
+
+We hope you're okay,
+and we hope that the storm we have been engulfed in will soon pass.
+
+A heartfelt thanks
+------------------
+
+We had a lot of big plans for this year,
+but most of those had to be put on hold in March as we scrambled to move our community fully online.
+Getting to see all the happy faces at our in-person events is one of the largest motivators for people who organize events.
+Sadly this year, we weren't able to make that happen.
+
+2020 has shown that the love and care we put into the community will be returned back to us when needed.
+When we moved the conferences online,
+we were genuinely worried about the health and longevity of Write the Docs.
+As we noted in our `ticket choices`_ page for Portland,
+we had a lot of outstanding debts and we didn't know how much support we would get with our online conferences.
+It was easy to see a worst case scenario where our venues didn't refund us and people didn't support the online events.
+
+We are happy to report that we received overwhelming support from our vendors, sponsors, speakers, team, and attendees:
+
+* Most of our vendors refunded our down payments in full
+* All but 1 of our sponsors stayed with us for our virtual event
+* Our speakers pulled together to record videos and handle live online Q&A
+* Our team pulled together to run virtual events that exceeded our expectations for what those events could be
+* Our attendees, most importantly, made our virtual events _feel_ like our conferences, with a supportive and generous spirit
+
+2020 has been a hard year,
+but we wanted to take this chance to give thanks to those who made 2020 a special year.
+We feel incredibly lucky to be able to support this wonderful community,
+and we look forward to making 2021 the best year yet,
+with your help.
+
+.. _ticket choices: https://www.writethedocs.org/conf/portland/2020/ticket-choices/
+
+Looking forward
+---------------
+
+One of the largest things we noticed in 2020 was how much more our community needed support.
+As we scrambled to move our events online,
+people were also adjusting to working remote for the first time.
+We saw lots of activity in our Slack network,
+as people were trying to build community online.
+Meetups slowly adjusted,
+trying to move online and keep some momentum going.
+
+Write the Docs itself was able to provide similar value as in the past,
+but we didn't have the resources to adjust to the changing world.
+The profits from our conferences pay for everything we do,
+which constrains our ability to adjust to events as they happen.
+
+We are planning a way for our community to support the organization directly.
+We are proud that all the content that Write the Docs produces is free to everyone,
+and we don't plan to change that any time soon.
+The goal for 2021 is to be able to provide additional support to our community,
+paid for by members in that community.
+
+We're still working out the details,
+and will be posting a `WEP`_ soon to ask the community for feedback.
+We hope that you'll support us in building a community that is better able to support you.
+
+.. _WEP: https://www.writethedocs.org/blog/introducing-weps/
+
+Write the Docs Quorum Meetups
+-----------------------------
+
+One of the first things we're excited about this year is an evolution of our meetups: Quorum meetups.
+These quarterly, remote, "super" meetups are an hour long and include a presentation by a speaker followed by breakout networking.
+
+Write the Docs is running two Quorum pilot programs for 2021:
+
+* `Virtual Write the Docs East Coast Quorum on Meetup.com <https://www.meetup.com/virtual-write-the-docs-east-coast-quorum/>`_` - For participants in the Eastern (UTC-4) and Central (UTC-5) time zones. The first meetup is planned for **February**.
+
+* `Virtual Write the Docs West Coast Quorum on Meetup.com <https://www.meetup.com/virtual-write-the-docs-west-coast-quorum/>`_` - For participants in the Pacific (UTC-7) and Mountain (UTC-6) time zones. The first meetup is planned for **March**.
+
+* `Virtual Write the Docs Australia Quorum on Meetup.com <https://www.meetup.com/Write-the-Docs-Australia/>`_ - We are planning to continue hosting collaborative APAC meetups via our Australia meetup group.
+
+Events are free and open to all.
+Quarterly meetups will typically occur at 7:00p.m. local time on a Monday through Thursday evening.
+
+If you are a local meetup organizer in the these timezones who would like to learn more about what is required to participate,
+or are located in EMEA and would like to know if the program expands to your time zones,
+contact Alyssa Rock on the Write the Docs Slack network.
+
+2020 Stats
+----------
+
+We have shared our high-level community stats for the past 4 years,
+and will continue to do it each year going forward.
+
+You can read our previous posts from 2016_, 2017_, 2018_, and 2019_.
+
+.. _2019: https://www.writethedocs.org/blog/write-the-docs-2019-stats/
+.. _2018: https://www.writethedocs.org/blog/write-the-docs-2018-stats/
+.. _2017: https://www.writethedocs.org/blog/write-the-docs-2017-stats/
+.. _2016: https://www.writethedocs.org/blog/write-the-docs-2016-year-in-review/
+
+Conferences
+~~~~~~~~~~~
+
+* 600 attendees in Portland (up from 500)
+* 325 attendees in Prague (up from 300)
+* 125 attendees in Australia & India (up from 100)
+
+Given the move to virtual conferences,
+we were able to allow more people to attend this year.
+We also experimented with a joint conference with Australia & India.
+Working to bridge communities across distances is a major value of virtual events.
+
+
+Slack Network
+~~~~~~~~~~~~~
+
+* 11,350 :doc:`members </slack>` (up from 8,250)
+
+Newsletters
+~~~~~~~~~~~
+
+* 8,225 :doc:`subscribers </newsletter>` (up from 7,386)
+
+Meetups
+~~~~~~~
+
+* Over 10,000 members (too many to count)
+* 50 :doc:`meetups </meetups/index>` (up from 46)
+
+Podcast
+~~~~~~~
+
+* 32 :doc:`episodes </podcast>` total (up from 26)
+
+Website
+~~~~~~~
+
+* 225,000 sessions (down from 250,000)
+* 375,000 page views (down from 430,000)
+
+The website numbers have been dropping a bit in recent years.
+Generally this is because we are respecting Do Not Track preferences from our users,
+which results in a 5-10% drop in numbers.
+This means the website traffic is likely pretty stable,
+but the measurement drops over time as more users set this setting.
+
+GitHub
+~~~~~~
+
+* 1,321 commits_ to our repository (down from 1,955)
+* 35 people_ who contributed to our repository (down from 56)
+
+.. commits: git rev-list --count --all --after="2020-01-01" --before="2021-01-01"
+.. _commits: https://github.com/writethedocs/www/commits/master
+.. _people: https://github.com/writethedocs/www/graphs/contributors?from=2020-01-01&to=2021-01-01&type=c
+
+
+------------------
+Featured job posts
+------------------
+
+* `Technical Writer (Developer Documentation) <https://jobs.writethedocs.org/job/265/technical-writer-developer-documentation/>`__, Ably
+   Remote (London, UK), full-time
+* `API Technical Writer (m/f/x) <https://jobs.writethedocs.org/job/261/api-technical-writer-m-f-x/>`__, finn GmbH
+   Munich, Germany, full-time
+
+*To apply for these jobs and more, visit the* `Write the Docs job board <https://jobs.writethedocs.org/>`_.
+
+
+Thanks again
+------------
+
+All these numbers remind us of the scale and impact of our work.
+Thanks again for being part of our journey.
+
+To a better 2021,
+
+The Write the Docs team

--- a/docs/blog/write-the-docs-2020-stats.rst
+++ b/docs/blog/write-the-docs-2020-stats.rst
@@ -99,7 +99,7 @@ contact Alyssa Rock on the Write the Docs Slack network.
 
 You can read more about these meetups in the `quorum meetups GitHub repository`_.
 
-.. _GitHub repo: https://github.com/write-the-docs-quorum/quorum-meetups
+.. _quorum meetups GitHub repository: https://github.com/write-the-docs-quorum/quorum-meetups
 
 2020 Stats
 ----------

--- a/docs/blog/write-the-docs-2020-stats.rst
+++ b/docs/blog/write-the-docs-2020-stats.rst
@@ -170,6 +170,38 @@ GitHub
 .. _commits: https://github.com/writethedocs/www/commits/master
 .. _people: https://github.com/writethedocs/www/graphs/contributors?from=2020-01-01&to=2021-01-01&type=c
 
+----------------
+From our sponsor
+----------------
+
+This month’s newsletter is sponsored by `Paligo <https://bit.ly/3fuibKK>`__:
+
+.. raw:: html
+
+    <hr>
+    <table width="100%" border="0" cellspacing="0" cellpadding="0" style="width:100%; max-width: 600px;">
+      <tbody>
+        <tr>
+          <td width="75%">
+              <p>
+              <a href="https://bit.ly/3fuibKK">Paligo is an all-in-one cloud-based CCMS platform.</a> Authoring, versioning, branching, release workflows, publishing, translation management, and more - all updated continuously in the cloud. No more worrying about locally installed software and deployment!
+              </p>
+
+              <p>
+              Read the case study: <a href="https://bit.ly/2UV2uCQ">https://bit.ly/2UV2uCQ</a>
+              </p>
+          </td>
+          <td width="25%">
+            <a href="https://bit.ly/3fuibKK">
+              <img style="margin-left: 15px;" alt="Paligo" src="/_static/img/sponsors/paligo.png">
+            </a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <hr>
+
+*Interested in sponsoring the newsletter? Take a look at our* `sponsorship prospectus </sponsorship/newsletter/>`__.
 
 Featured job posts
 ------------------

--- a/docs/blog/write-the-docs-2020-stats.rst
+++ b/docs/blog/write-the-docs-2020-stats.rst
@@ -88,7 +88,7 @@ Write the Docs is running two Quorum pilot programs for 2021:
 
 * `Virtual Write the Docs West Coast Quorum on Meetup.com <https://www.meetup.com/virtual-write-the-docs-west-coast-quorum/>`_` - For participants in the Pacific (UTC-7) and Mountain (UTC-6) time zones. The first meetup is planned for **March**.
 
-* `Virtual Write the Docs Australia Quorum on Meetup.com <https://www.meetup.com/Write-the-Docs-Australia/>`_ - We are planning to continue hosting collaborative APAC meetups via our Australia meetup group.
+* `Write the Docs Australia on Meetup.com <https://www.meetup.com/Write-the-Docs-Australia/>`_ - We are planning to continue hosting collaborative APAC meetups via our Australia meetup group that are similar in concept.
 
 Events are free and open to all.
 Quarterly meetups will typically occur at 7:00p.m. local time on a Monday through Thursday evening.
@@ -96,7 +96,8 @@ Quarterly meetups will typically occur at 7:00p.m. local time on a Monday throug
 If you are a local meetup organizer in the these timezones who would like to learn more about what is required to participate,
 or are located in EMEA and would like to know if the program expands to your time zones,
 contact Alyssa Rock on the Write the Docs Slack network.
-You can also read more about them in the `quorum meetups GitHub repository`_.
+
+You can read more about these meetups in the `quorum meetups GitHub repository`_.
 
 .. _GitHub repo: https://github.com/write-the-docs-quorum/quorum-meetups
 

--- a/docs/blog/write-the-docs-2020-stats.rst
+++ b/docs/blog/write-the-docs-2020-stats.rst
@@ -171,7 +171,6 @@ GitHub
 .. _people: https://github.com/writethedocs/www/graphs/contributors?from=2020-01-01&to=2021-01-01&type=c
 
 
-------------------
 Featured job posts
 ------------------
 

--- a/docs/blog/write-the-docs-2020-stats.rst
+++ b/docs/blog/write-the-docs-2020-stats.rst
@@ -96,6 +96,9 @@ Quarterly meetups will typically occur at 7:00p.m. local time on a Monday throug
 If you are a local meetup organizer in the these timezones who would like to learn more about what is required to participate,
 or are located in EMEA and would like to know if the program expands to your time zones,
 contact Alyssa Rock on the Write the Docs Slack network.
+You can also read more about them in the `quorum meetups GitHub repository`_.
+
+.. _GitHub repo: https://github.com/write-the-docs-quorum/quorum-meetups
 
 2020 Stats
 ----------


### PR DESCRIPTION
The community update got a bit long,
I"m wondering if we should split this out into two posts:

* 2020 Stats
* 2021 Kickoff

Where the 2021 kickoff goes to the newsletter,
and the stats are just linked.

We did this in 2018, but then did a combined update the last couple years.
I don't feel strongly either way.