### PR TITLE
Add CFP delay blog post

### DIFF
--- a/docs/_data/portland-2021-config.yaml
+++ b/docs/_data/portland-2021-config.yaml
@@ -154,14 +154,17 @@ about:
 
 cfp:
   url: https://pretalx.com/write-the-docs-portland-2021/cfp
-  ends: "January 25, 2021"          # 2 weeks to review and get confirmnations
-  notification: "February 10, 2021" # leaves 6 weeks to write and record
+  ends: "February 1, 2021"          # 2 weeks to review and get confirmnations
+  notification: "February 15, 2021" # leaves 6 weeks to write and record
   video_by: "March 31, 2021"        # 3 weeks before the conf
 
 sponsors:
   keystone:
   patron:
   publisher:
+    - name: cncf
+      link: https://www.cncf.io/
+      brand: Cloud Native Computing Foundation
   second:
   first:
 

--- a/docs/conf/portland/2021/news/cfp-delay.rst
+++ b/docs/conf/portland/2021/news/cfp-delay.rst
@@ -13,7 +13,7 @@ We'd love to see some new voices in the program this year,
 and we hope that prerecorded talks and fewer timezone restrictions makes that possible.
 
 CFP deadline extended to February 1st
-----------------------------------
+-------------------------------------
 
 Check out the `Call for Proposals page <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/cfp/#submit-your-proposal>`_ for more details about what we are looking for.
 Especially if you've not been able to attend due to travel logistics, or if you've not spoken before we'd love to hear your voice.
@@ -28,8 +28,8 @@ The community is there to help!
 
 We’ll be reviewing all the talk proposals next month, and will be contacting everyone who submitted a proposal by {{ cfp.notification }}.
 
-Grant program
--------------
+Grant program reminder
+----------------------
 
 We updated our grant program application to take into account the virtual format of the event.
 We're excited to be able to offer free tickets to a larger number of people this year, since there are now minimal other costs to attend the event.

--- a/docs/conf/portland/2021/news/cfp-delay.rst
+++ b/docs/conf/portland/2021/news/cfp-delay.rst
@@ -6,20 +6,20 @@
 CFP update and grant program reminder
 =====================================
 
-The last few weeks has been pretty rough on us here in the US.
+The last few weeks have been pretty rough on those of us who are in the US.
 Knowing that,
-we have made the decision to move our CFP deadline back a week in order to give you more time to get proposals in.
-We hope to see some new voices in the program this year,
-given the ability to participate remotely.
+we have made the decision to extend our CFP deadline by a week in order to give you more time to get proposals in.
+We'd love to see some new voices in the program this year,
+and we hope that prerecorded talks and fewer timezone restrictions makes that possible.
 
-CFP deadline moved to February 1st
+CFP deadline extended to February 1st
 ----------------------------------
 
 Check out the `Call for Proposals page <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/cfp/#submit-your-proposal>`_ for more details about what we are looking for.
 Especially if you've not been able to attend due to travel logistics, or if you've not spoken before we'd love to hear your voice.
-The virtual conference format means you can speak from anywhere, though it's ideal if you are close to the local time in Portland.
+The virtual conference format means you can speak from anywhere, though it's ideal if you can be online and present around your talk slot in Portland time, PST.
 
-Submit your talk proposals by February 1st,
+Submit your talk proposals by **February 1st**,
 If accepted,
 we'll ask you to put together a 30 min talk video by the end of March.
 And if you already have an idea but you’re having a hard time getting your proposal to come together,

--- a/docs/conf/portland/2021/news/cfp-delay.rst
+++ b/docs/conf/portland/2021/news/cfp-delay.rst
@@ -1,0 +1,53 @@
+:template: {{year}}/generic.html
+
+.. post:: Jan 22, {{year}}
+   :tags: {{shortcode}}-{{year}}, website, cfp, tickets
+
+CFP update and grant program reminder
+=====================================
+
+The last few weeks has been pretty rough on us here in the US.
+Knowing that,
+we have made the decision to move our CFP deadline back a week in order to give you more time to get proposals in.
+We hope to see some new voices in the program this year,
+given the ability to participate remotely.
+
+CFP deadline moved to February 1st
+----------------------------------
+
+Check out the `Call for Proposals page <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/cfp/#submit-your-proposal>`_ for more details about what we are looking for.
+Especially if you've not been able to attend due to travel logistics, or if you've not spoken before we'd love to hear your voice.
+The virtual conference format means you can speak from anywhere, though it's ideal if you are close to the local time in Portland.
+
+Submit your talk proposals by February 1st,
+If accepted,
+we'll ask you to put together a 30 min talk video by the end of March.
+And if you already have an idea but you’re having a hard time getting your proposal to come together,
+you can always ask for feedback on the `Write the Docs Slack <https://www.writethedocs.org/slack/>`_.
+The community is there to help!
+
+We’ll be reviewing all the talk proposals next month, and will be contacting everyone who submitted a proposal by {{ cfp.notification }}.
+
+Grant program
+-------------
+
+We updated our grant program application to take into account the virtual format of the event.
+We're excited to be able to offer free tickets to a larger number of people this year, since there are now minimal other costs to attend the event.
+
+You can apply by **{{ grants.ends }}** on `our website <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/opportunity-grants/>`_.
+
+Thanks to our sponsors
+----------------------
+
+We are so grateful to have our sponsors help in bringing these events to life every year. Thanks sincerely to the following companies for supporting the Write the Docs community:
+
+.. datatemplate::
+   :source: /_data/{{shortcode}}-{{year}}-config.yaml
+   :template: {{year}}/sponsors-simplelist.rst
+
+Head over to our `sponsorship prospectus <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/sponsors/prospectus/>`_ for details on how your company can get involved!
+We have several types of sponsorship available, including tables at the job fair that we'll be hosting on Tuesday.
+
+And that's the latest on the Portland conference. We hope you're all getting as excited as we are! Stay tuned for more details.
+
+The Write the Docs Team


### PR DESCRIPTION
This moves the CFP deadline to Feb 1 and notification back to Feb 15.
We've also gotten our first sponsor,
so I've included them in the mailer as well.