### PR TITLE
Hide the specific event times when we have a live schedule

### DIFF
--- a/docs/conf/portland/2021/schedule.rst
+++ b/docs/conf/portland/2021/schedule.rst
@@ -28,7 +28,9 @@ The only event scheduled on Saturday is the :doc:`annual hike to Pittock Mansion
 If you get into town early, join us on the hike and take the chance to explore Portland in all of its glory.
 
 * **Where**: Lower Macleay Park or Macleay Park Entrance.
+{% if not flaghasschedule %}
 * **When**: **{{ date.day_two.hike_time }} {{ tz }}**
+{% endif %}
 * **Details**: :doc:`Annual hike to Pittock Mansion </conf/{{shortcode}}/{{year}}/outing>`
 
 {% endif %}
@@ -61,7 +63,9 @@ Writing Day
 ~~~~~~~~~~~
 
 * **Where**: {{about.venue}}
+{% if not flaghasschedule %}
 * **When**: **{{ date.day_two.writing_day_time }} {{ tz }}**
+{% endif %}
 * **Details**: :doc:`Writing Day documentation sprints </conf/{{shortcode}}/{{year}}/writing-day>`
 
 .. separator to fix list formatting
@@ -112,7 +116,9 @@ Conference Talks
 ~~~~~~~~~~~~~~~~
 
 * **Where**: {{about.venue}}
+{% if not flaghasschedule %}
 * **When**: **{{ date.day_three.talk_time }} {{ tz }}**
+{% endif %}
 * **Details**: :doc:`/conf/{{shortcode}}/{{year}}/speakers`
 
 Talks are around 30 minutes. Most speakers will have a live, moderated Q&A session at the end of their talk.
@@ -174,7 +180,9 @@ Conference Talks
 ~~~~~~~~~~~~~~~~
 
 * **Where**: {{about.venue}}
+{% if not flaghasschedule %}
 * **When**: **{{ date.day_four.talk_time }} {{ tz }}**
+{% endif %}
 * **Details**: :doc:`/conf/{{shortcode}}/{{year}}/speakers`
 
 Talks are around 30 minutes. Most speakers will have a live, moderated Q&A session at the end of their talk.

--- a/docs/conf/portland/2021/schedule.rst
+++ b/docs/conf/portland/2021/schedule.rst
@@ -85,7 +85,9 @@ We encourage everyone to drop by on Sunday evening for the conference reception.
 We're hoping to have some fun activities planned for the evening online.
 
 * **Where**: {{about.venue}}, {{about.mainroom}}
+{% if not flaghasschedule %}
 * **When**: **{{ date.day_two.reception_time }} {{ tz }}**
+{% endif %}
 
 {% endif %}
 
@@ -133,7 +135,9 @@ Unconference
 The unconference sessions run in parallel to the main conference talks.
 
 * **Where**: {{about.venue}}, {{about.unconfroom}}
+{% if not flaghasschedule %}
 * **When**: **{{ date.day_three.unconference_time }} {{ tz }}**
+{% endif %}
 * **Details**: :doc:`/conf/{{shortcode}}/{{year}}/unconference`
 
 Social Event
@@ -145,7 +149,9 @@ but expect some music and games,
 and bring your favorite beverage to your computer :)
 
 * **Where**: {{ about.social_venue }}
+{% if not flaghasschedule %}
 * **When**: **{{ date.day_three.social_time }} {{ tz }}**
+{% endif %}
 
 
 .. raw:: html
@@ -193,7 +199,9 @@ Job Fair
 We'll be holding a job fair on Tuesday morning!
 
 * **Where**: {{about.venue}}, {{about.unconfroom}}
+{% if not flaghasschedule %}
 * **When**: **{{ date.day_four.job_fair_time }} {{ tz }}**
+{% endif %}
 * **Details**: :doc:`/conf/{{shortcode}}/{{year}}/job-fair`
 
 {% endif %}
@@ -204,5 +212,7 @@ Unconference
 The unconference sessions run in parallel to the main conference talks.
 
 * **Where**: {{about.venue}}, {{about.unconfroom}}
+{% if not flaghasschedule %}
 * **When**: **{{ date.day_four.unconference_time }} {{ tz }}**
+{% endif %}
 * **Details**: :doc:`/conf/{{shortcode}}/{{year}}/unconference`


### PR DESCRIPTION
This will stop these from being out of sync with the main schedule.
We should only have this data in one place,
so let's not include it both places.