### PR TITLE
Fixed link by adding Vale config file extension

### DIFF
--- a/docs/guide/tools/testing.rst
+++ b/docs/guide/tools/testing.rst
@@ -121,7 +121,7 @@ installed Vale.
 Now to configure Vale, you'll need a .vale or a .vale.ini configuration file. For some
 examples, see
 
-* https://github.com/writethedocs/www/blob/master/.vale
+* https://github.com/writethedocs/www/blob/master/.vale.ini
 * https://github.com/cockroachdb/docs/blob/master/.vale.ini
 * https://github.com/linode/docs/blob/develop/.vale.ini
 


### PR DESCRIPTION
I fixed a bad link to the Write the Docs [Vale configuration file](https://www.writethedocs.org/guide/tools/testing/#vale).

Bad link: https://github.com/writethedocs/www/blob/master/.vale
Fixed link: https://github.com/writethedocs/www/blob/master/.vale.ini

Thanks!