### PR TITLE
Update Quorum meetup participants and attempt to fix broken links

### DIFF
--- a/docs/_data/meetups/qrm-usEast.yaml
+++ b/docs/_data/meetups/qrm-usEast.yaml
@@ -3,7 +3,7 @@ country: USA
 state: East Coast
 city:
 website: https://www.meetup.com/virtual-write-the-docs-east-coast-quorum/
-meetup: Write-The-Docs-East-Coast
+meetup: Virtual-Write-The-Docs-East-Coast-Quorum
 twitter:
 organizers:
   - name: Alyssa Whipple Rock

--- a/docs/_data/meetups/qrm-usWest.yaml
+++ b/docs/_data/meetups/qrm-usWest.yaml
@@ -3,7 +3,7 @@ country: USA
 state: West Coast
 city:
 website: https://www.meetup.com/virtual-write-the-docs-west-coast-quorum/
-meetup: Write-The-Docs-West-Coast
+meetup: Virtual-Write-The-Docs-West-Coast-Quorum
 twitter:
 organizers:
   - name: Alyssa Whipple Rock

--- a/docs/meetups/index.rst
+++ b/docs/meetups/index.rst
@@ -69,12 +69,12 @@ Several meetups are members of the Quorum North America East group:
 
 * Atlanta
 * Austin
-* Boston
 * Detroit / Windsor
 * Florida
+* New England
 * Ottawa / Montreal
 * Philadelphia
-* Raleigh / Durham
+* Washington, D.C.
 
 .. meetup-listing::
     :region: Quorum-US-East
@@ -88,6 +88,7 @@ Several meetups are members of the Quorum North America West group:
 * Los Angeles
 * Portland (OR)
 * Salt Lake City
+* Seattle
 
 .. meetup-listing::
     :region: Quorum-US-West


### PR DESCRIPTION
This PR updates the list of Quorum meetup participants to sync with the latest list. It also attempts to fix  broken links to the Quorum programs on Meetup.com, but I honestly don't know if this will fix the links. They URLs appear correct to me and I don't know why it's failing.