### PR TITLE
Add Portland 2021 sketchnotes and videos

### DIFF
--- a/docs/_data/portland-2021-sessions.yaml
+++ b/docs/_data/portland-2021-sessions.yaml
@@ -3,6 +3,9 @@
   series: Write the Docs Portland
   series_slug: portland
   year: 2021
+  youtubeId: 3prrgLv4qt4
+  sketchnoteLink: https://www.flickr.com/photos/writethedocs/51194873060/in/album-72157719233307148/
+  sketchnoteImage: https://live.staticflickr.com/65535/51194873060_6c51412c81_b_d.jpg
   speakers:
   - name: Abigail McCarthy
     slug: abigail-mccarthy
@@ -42,6 +45,9 @@
   series: Write the Docs Portland
   series_slug: portland
   year: 2021
+  youtubeId: T4mJ1Du-VB4
+  sketchnoteLink: https://www.flickr.com/photos/writethedocs/51194025688/in/album-72157719233307148/
+  sketchnoteImage: https://live.staticflickr.com/65535/51194025688_78f5137801_b_d.jpg
   speakers:
   - name: Jessica Garson
     slug: jessica-garson
@@ -56,6 +62,9 @@
   series: Write the Docs Portland
   series_slug: portland
   year: 2021
+  youtubeId: PkK1lowfeFU
+  sketchnoteLink: https://www.flickr.com/photos/writethedocs/51193104672/in/album-72157719233307148/
+  sketchnoteImage: https://live.staticflickr.com/65535/51193104672_a1f9024ce4_b_d.jpg
   speakers:
   - name: Deanna Thompson
     slug: deanna-thompson
@@ -77,6 +86,9 @@
   series: Write the Docs Portland
   series_slug: portland
   year: 2021
+  youtubeId: efmtoJ6Q-0Q
+  sketchnoteLink: https://www.flickr.com/photos/writethedocs/51193104322/in/album-72157719233307148/
+  sketchnoteImage: https://live.staticflickr.com/65535/51193104322_de699189c2_b_d.jpg
   speakers:
   - name: Katherine Karaus
     slug: katherine-karaus
@@ -110,6 +122,9 @@
   series: Write the Docs Portland
   series_slug: portland
   year: 2021
+  youtubeId: aaBLXKGs9cQ
+  sketchnoteLink: https://www.flickr.com/photos/writethedocs/51194582364/in/album-72157719233307148/
+  sketchnoteImage: https://live.staticflickr.com/65535/51194582364_c82051e737_b_d.jpg
   speakers:
   - name: Rachael Stavchansky
     slug: rachael-stavchansky
@@ -144,6 +159,9 @@
   series: Write the Docs Portland
   series_slug: portland
   year: 2021
+  youtubeId: f7hHwGvR0_Q
+  sketchnoteLink: https://www.flickr.com/photos/writethedocs/51193104612/in/album-72157719233307148/
+  sketchnoteImage: https://live.staticflickr.com/65535/51193104612_60dc522dd6_b_d.jpg
   speakers:
   - name: Falon Darville
     slug: falon-darville
@@ -183,6 +201,9 @@
   series: Write the Docs Portland
   series_slug: portland
   year: 2021
+  youtubeId: Wc7n7uIg4AM
+  sketchnoteLink: https://www.flickr.com/photos/writethedocs/51194583024/in/album-72157719233307148/
+  sketchnoteImage: https://live.staticflickr.com/65535/51194583024_5598519014_b_d.jpg
   speakers:
   - name: Daniele Procida
     slug: daniele-procida
@@ -238,6 +259,9 @@
   series: Write the Docs Portland
   series_slug: portland
   year: 2021
+  youtubeId: TV-bawUDibc
+  sketchnoteLink: https://www.flickr.com/photos/writethedocs/51194582294/in/album-72157719233307148/
+  sketchnoteImage: https://live.staticflickr.com/65535/51194582294_6e549bf00c_b_d.jpg
   speakers:
   - name: Rin Oliver
     slug: rin-oliver
@@ -283,6 +307,9 @@
   series: Write the Docs Portland
   series_slug: portland
   year: 2021
+  youtubeId: FQ7DkPOw3Cc
+  sketchnoteLink: https://www.flickr.com/photos/writethedocs/51194872110/in/album-72157719233307148/
+  sketchnoteImage: https://live.staticflickr.com/65535/51194872110_5cb46ba37d_b_d.jpg
   speakers:
   - name: Swapnil Ogale
     slug: swapnil-ogale
@@ -320,6 +347,9 @@
   series: Write the Docs Portland
   series_slug: portland
   year: 2021
+  youtubeId: Ti5lfI0l190
+  sketchnoteLink: https://www.flickr.com/photos/writethedocs/51193103897/in/album-72157719233307148/
+  sketchnoteImage: https://live.staticflickr.com/65535/51193103897_8a850b0a69_b_d.jpg
   speakers:
   - name: Sarah R. Rodlund
     slug: sarah-r-rodlund
@@ -354,6 +384,9 @@
   series: Write the Docs Portland
   series_slug: portland
   year: 2021
+  youtubeId: VEDdflVPTv0
+  sketchnoteLink: https://www.flickr.com/photos/writethedocs/51193104112/in/album-72157719233307148/
+  sketchnoteImage: https://live.staticflickr.com/65535/51193104112_dcf16baef1_b_d.jpg
   speakers:
   - name: Paris Buttfield-Addison
     slug: paris-buttfield-addison
@@ -398,6 +431,9 @@
   series: Write the Docs Portland
   series_slug: portland
   year: 2021
+  youtubeId: ROhFB4HL0CU
+  sketchnoteLink: https://www.flickr.com/photos/writethedocs/51194025423/in/album-72157719233307148/
+  sketchnoteImage: https://live.staticflickr.com/65535/51194025423_059aba15d0_b_d.jpg
   speakers:
   - name: Nicola Yap
     slug: nicola-yap
@@ -462,6 +498,9 @@
   series: Write the Docs Portland
   series_slug: portland
   year: 2021
+  youtubeId: TG7vKolsqb4
+  sketchnoteLink: https://www.flickr.com/photos/writethedocs/51194582839/in/album-72157719233307148/
+  sketchnoteImage: https://live.staticflickr.com/65535/51194582839_6b28262224_b_d.jpg
   speakers:
   - name: Ines Stefanovic
     slug: ines-stefanovic
@@ -487,6 +526,9 @@
   series: Write the Docs Portland
   series_slug: portland
   year: 2021
+  youtubeId: 57ik4zDMKJY
+  sketchnoteLink: https://www.flickr.com/photos/writethedocs/51194872595/in/album-72157719233307148/
+  sketchnoteImage: https://live.staticflickr.com/65535/51194872595_b94581ea0e_b_d.jpg
   speakers:
   - name: Laura Novich
     slug: laura-novich

--- a/docs/_data/portland-2021-sessions.yaml
+++ b/docs/_data/portland-2021-sessions.yaml
@@ -166,7 +166,7 @@
   - name: Falon Darville
     slug: falon-darville
     twitter: 
-    website: falondarville.com
+    website: https://falondarville.com
   abstract: '<p>When I was hired at DISQO as a Technical Writer,  the number of engineers
     was hovering around seventy, and there was just one of me. With numerous Google
     Docs and Markdown files strewn about and much to still be documented, it was critical

--- a/docs/_data/schema-sessions.yaml
+++ b/docs/_data/schema-sessions.yaml
@@ -9,6 +9,8 @@ session-details:
   slug: str()
   slides: str(required=False)
   youtubeId: str(required=False)
+  sketchnoteLink: str(required=False)
+  sketchnoteImage: str(required=False)
   series: str(required=False)
   series_slug: str(required=False)
   year: int(min=2000, required=False)

--- a/docs/_templates/videos/video-detail.html
+++ b/docs/_templates/videos/video-detail.html
@@ -13,6 +13,10 @@
       </div>
       {% endif %}
 
+      {% if talk.sketchnoteLink and talk.sketchnoteImage %}
+          <h2>Sketchnote</h2>
+          <a href="{{ talk.sketchnoteLink }}"><img alt="Sketchnote" src="{{ talk.sketchnoteImage }}" /></a>
+      {% endif %}
 
       <h2>Description</h2>
 

--- a/docs/videos/portland/2021/a-guide-to-getting-started-in-open-source-abigail-mccarthy.rst
+++ b/docs/videos/portland/2021/a-guide-to-getting-started-in-open-source-abigail-mccarthy.rst
@@ -1,0 +1,8 @@
+A guide to getting started in open source
+=========================================
+
+.. datatemplate-video::
+   :source: /_data/portland-2021-sessions.yaml
+   :template: videos/video-detail.html
+   :key: 0
+

--- a/docs/videos/portland/2021/almost-none-to-some-driving-disqo-s-doc-culture-as-a-solo-documentarian-falon-darville.rst
+++ b/docs/videos/portland/2021/almost-none-to-some-driving-disqo-s-doc-culture-as-a-solo-documentarian-falon-darville.rst
@@ -1,0 +1,8 @@
+Almost None to Some: Driving DISQO's Doc Culture as a Solo Documentarian
+========================================================================
+
+.. datatemplate-video::
+   :source: /_data/portland-2021-sessions.yaml
+   :template: videos/video-detail.html
+   :key: 5
+

--- a/docs/videos/portland/2021/always-complete-never-finished-daniele-procida.rst
+++ b/docs/videos/portland/2021/always-complete-never-finished-daniele-procida.rst
@@ -1,0 +1,8 @@
+Always complete, never finished
+===============================
+
+.. datatemplate-video::
+   :source: /_data/portland-2021-sessions.yaml
+   :template: videos/video-detail.html
+   :key: 6
+

--- a/docs/videos/portland/2021/beyond-metrics-using-maturity-models-to-develop-a-docs-strategy-sarah-r-rodlund.rst
+++ b/docs/videos/portland/2021/beyond-metrics-using-maturity-models-to-develop-a-docs-strategy-sarah-r-rodlund.rst
@@ -1,0 +1,8 @@
+Beyond metrics: Using maturity models to develop a docs strategy
+================================================================
+
+.. datatemplate-video::
+   :source: /_data/portland-2021-sessions.yaml
+   :template: videos/video-detail.html
+   :key: 9
+

--- a/docs/videos/portland/2021/building-a-style-guide-from-the-ground-up-lessons-learned-from-a-lone-writer-deanna-thompson.rst
+++ b/docs/videos/portland/2021/building-a-style-guide-from-the-ground-up-lessons-learned-from-a-lone-writer-deanna-thompson.rst
@@ -1,0 +1,8 @@
+Building a style guide from the ground up: lessons learned from a lone writer
+=============================================================================
+
+.. datatemplate-video::
+   :source: /_data/portland-2021-sessions.yaml
+   :template: videos/video-detail.html
+   :key: 2
+

--- a/docs/videos/portland/2021/documentation-communities-sound-strategy-or-documentarian-s-gambit-laura-novich.rst
+++ b/docs/videos/portland/2021/documentation-communities-sound-strategy-or-documentarian-s-gambit-laura-novich.rst
@@ -1,0 +1,8 @@
+Documentation Communities: Sound Strategy or Documentarian's Gambit?
+====================================================================
+
+.. datatemplate-video::
+   :source: /_data/portland-2021-sessions.yaml
+   :template: videos/video-detail.html
+   :key: 13
+

--- a/docs/videos/portland/2021/index.rst
+++ b/docs/videos/portland/2021/index.rst
@@ -1,0 +1,12 @@
+Videos of Write the Docs PORTLAND 2021
+=============================================================
+
+.. toctree::
+   :glob:
+   :hidden:
+
+   *
+
+.. datatemplate::
+   :source: /_data/portland-2021-sessions.yaml
+   :template: videos/video-listing.html

--- a/docs/videos/portland/2021/invisible-influence-the-documentation-behind-ux-copy-katherine-karaus.rst
+++ b/docs/videos/portland/2021/invisible-influence-the-documentation-behind-ux-copy-katherine-karaus.rst
@@ -1,0 +1,8 @@
+Invisible influence — the documentation behind UX copy
+======================================================
+
+.. datatemplate-video::
+   :source: /_data/portland-2021-sessions.yaml
+   :template: videos/video-detail.html
+   :key: 3
+

--- a/docs/videos/portland/2021/is-tech-writer-a-tester-and-vice-versa-is-tester-a-tech-writer-ines-stefanovic.rst
+++ b/docs/videos/portland/2021/is-tech-writer-a-tester-and-vice-versa-is-tester-a-tech-writer-ines-stefanovic.rst
@@ -1,0 +1,8 @@
+Is Tech Writer a Tester, and Vice Versa, Is Tester a Tech Writer?
+=================================================================
+
+.. datatemplate-video::
+   :source: /_data/portland-2021-sessions.yaml
+   :template: videos/video-detail.html
+   :key: 12
+

--- a/docs/videos/portland/2021/level-up-onboarding-that-enables-writers-to-thrive-nicola-yap.rst
+++ b/docs/videos/portland/2021/level-up-onboarding-that-enables-writers-to-thrive-nicola-yap.rst
@@ -1,0 +1,8 @@
+Level Up - Onboarding that enables writers to thrive
+====================================================
+
+.. datatemplate-video::
+   :source: /_data/portland-2021-sessions.yaml
+   :template: videos/video-detail.html
+   :key: 11
+

--- a/docs/videos/portland/2021/putting-the-tech-in-technical-writer-swapnil-ogale.rst
+++ b/docs/videos/portland/2021/putting-the-tech-in-technical-writer-swapnil-ogale.rst
@@ -1,0 +1,8 @@
+Putting the “tech” in technical writer
+======================================
+
+.. datatemplate-video::
+   :source: /_data/portland-2021-sessions.yaml
+   :template: videos/video-detail.html
+   :key: 8
+

--- a/docs/videos/portland/2021/shuffle-ball-change-sashay-your-way-to-clearer-api-documentation-rachael-stavchansky.rst
+++ b/docs/videos/portland/2021/shuffle-ball-change-sashay-your-way-to-clearer-api-documentation-rachael-stavchansky.rst
@@ -1,0 +1,8 @@
+Shuffle ball change: Sashay your way to clearer API documentation
+=================================================================
+
+.. datatemplate-video::
+   :source: /_data/portland-2021-sessions.yaml
+   :template: videos/video-detail.html
+   :key: 4
+

--- a/docs/videos/portland/2021/the-secret-history-of-libraries-paris-buttfield-addison.rst
+++ b/docs/videos/portland/2021/the-secret-history-of-libraries-paris-buttfield-addison.rst
@@ -1,0 +1,8 @@
+The Secret History of Libraries
+===============================
+
+.. datatemplate-video::
+   :source: /_data/portland-2021-sessions.yaml
+   :template: videos/video-detail.html
+   :key: 10
+

--- a/docs/videos/portland/2021/writing-a-perfect-technical-tutorial-jessica-garson.rst
+++ b/docs/videos/portland/2021/writing-a-perfect-technical-tutorial-jessica-garson.rst
@@ -1,0 +1,8 @@
+Writing a perfect technical tutorial
+====================================
+
+.. datatemplate-video::
+   :source: /_data/portland-2021-sessions.yaml
+   :template: videos/video-detail.html
+   :key: 1
+

--- a/docs/videos/portland/2021/writing-documentation-with-neurodivergent-open-source-contributors-in-mind-rin-oliver.rst
+++ b/docs/videos/portland/2021/writing-documentation-with-neurodivergent-open-source-contributors-in-mind-rin-oliver.rst
@@ -1,0 +1,8 @@
+Writing Documentation with Neurodivergent Open Source Contributors In Mind
+==========================================================================
+
+.. datatemplate-video::
+   :source: /_data/portland-2021-sessions.yaml
+   :template: videos/video-detail.html
+   :key: 7
+


### PR DESCRIPTION
Flickr's URLs contain some random hashes, so we can't easily include a flickr ID in the config. Hence a new sketchnote URL and image in the sessions file.

https://writethedocs-www--1537.org.readthedocs.build/videos/portland/2021/writing-a-perfect-technical-tutorial-jessica-garson/ for an example