### PR TITLE
Enable Prague 2021 tickets

### DIFF
--- a/docs/_data/prague-2021-config.yaml
+++ b/docs/_data/prague-2021-config.yaml
@@ -167,7 +167,7 @@ sponsors:
 flagcfp: True
 flaglanding: False
 flaghassponsors: True
-flagticketsonsale: False
+flagticketsonsale: True
 flagsoldout: False
 flagspeakersannounced: False
 flagrunofshow: False


### PR DESCRIPTION
https://writethedocs-www--1538.org.readthedocs.build/conf/prague/2021/tickets/

The tito event is not live yet, so only visible if you're logged in to tito with admin permissions.