### PR TITLE
Enable Australia 2021 CFP, tickets and grants

### DIFF
--- a/docs/_data/australia-2021-config.yaml
+++ b/docs/_data/australia-2021-config.yaml
@@ -121,6 +121,11 @@ about:
   projector_ratio: "16:9"
   job_fair_room: "Sponsor area"
 
+grants:
+  url: https://docs.google.com/forms/d/e/1FAIpQLSe7IUKVckN5m-C_x9JguqwT3zt_PctyCl62yCkCf6D73be99A/viewform
+  ends: "October 15, 2021"
+  notification: "October 25, 2021"
+
 sponsors:
   keystone:
   patron:

--- a/docs/_data/australia-2021-config.yaml
+++ b/docs/_data/australia-2021-config.yaml
@@ -135,10 +135,10 @@ sponsors:
 
 
 # Things that change over time, listed in order of change
-flaglanding: True
+flaglanding: False
 flaghassponsors: False
 flagcfp: False
-flagticketsonsale: False
+flagticketsonsale: True
 flagsoldout: False
 flagspeakersannounced: False
 flagrunofshow: False

--- a/docs/_data/australia-2021-config.yaml
+++ b/docs/_data/australia-2021-config.yaml
@@ -121,6 +121,12 @@ about:
   projector_ratio: "16:9"
   job_fair_room: "Sponsor area"
 
+cfp:
+  url: https://pretalx.com/write-the-docs-australia-and-india-2021/cfp
+  ends: "June 30, 2021"           # 2 weeks to review and get confirmnations
+  notification: "July 16, 2021"   # leaves 6 weeks to write and record
+  video_by: "September 3, 2021"   # 4 weeks before the conf
+
 grants:
   url: https://docs.google.com/forms/d/e/1FAIpQLSe7IUKVckN5m-C_x9JguqwT3zt_PctyCl62yCkCf6D73be99A/viewform
   ends: "October 15, 2021"

--- a/docs/_data/australia-2021-config.yaml
+++ b/docs/_data/australia-2021-config.yaml
@@ -17,16 +17,16 @@ photos:
 
 buttons:
   top:
-    - text: Welcome to our conference
-      link: /news/welcome
+#    - text: Welcome to our conference
+#      link: /news/welcome
 #    - text: Date and ticket information
 #      link: /news/announcing-virtual-conf-dates-tickets
     # - text: Read our conference guide
     #   link: /welcome-wagon
     # - text: See the Schedule!
     #   link: /schedule
-#    - text: Buy a Ticket!
-#      link: /tickets
+    - text: Buy a Ticket!
+      link: /tickets
     - text: Sponsor us
       link: /sponsors/prospectus
     #- text: Submit a Talk
@@ -42,8 +42,8 @@ buttons:
     # - text: Watch the videos!
     #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHpkBJAPYFrob6gqdiBuePwGJ
   bottom:
-     - text: Welcome to our conference
-       link: /news/welcome
+#     - text: Welcome to our conference
+#       link: /news/welcome
     # - text: See the Schedule!
     #   link: /schedule
 #     - text: Date and ticket information
@@ -52,8 +52,8 @@ buttons:
        link: /sponsors/prospectus
     # - text: See the talks!
     #   link: /speakers
-#     - text: Buy a Ticket!
-#       link: /tickets
+     - text: Buy a Ticket!
+       link: /tickets
     # - text: Prepare with the Welcome Wagon
     #   link: /welcome-wagon
     # - text: See the schedule!

--- a/docs/conf/australia/2021/news/cfp-tickets.rst
+++ b/docs/conf/australia/2021/news/cfp-tickets.rst
@@ -1,0 +1,79 @@
+:template: {{year}}/generic.html
+
+.. post:: June 16, 2021
+   :tags: australia-2021, website, cfp, tickets
+
+Announcing Australia & India Tickets and Call for Proposals
+===========================================================
+
+Today we are announcing our `Call for Proposals <https://www.writethedocs.org/conf/australia/{{year}}/cfp/>`_ and `ticket sales <https://www.writethedocs.org/conf/australia/{{year}}/tickets/>`_.
+
+Due to the continuing global pandemic, we are keeping the Australia & India conference online. The conference will be held on **December 2-3, 2021**.
+We know that it hasn't been an easy year. Nevertheless, we'd love to see you on our online stage in October, to share your ideas with our inspiring community of documentarians.
+
+If there is something you’d really like to see a talk about this year, submit a proposal for it or refer someone else who would be good!
+
+Call for Proposals
+------------------
+
+Every year, Write the Docs invites people from all across our community to come up on stage to share their insights and experience.
+We're looking for ideas and use-cases from all disciplines and roles, so whether you're a technical writer, editor, developer, UX designer, community manager, or support professional who cares about content and communication, we want to hear from you!
+
+We're hoping that folks who would not be able to travel to Australia & India will be able to join us this time round, both as attendees and as speakers! If you've always wanted to talk about documentation but not been able to travel for whatever reason, now is the time.
+
+You can read our full `Call for Proposals <https://www.writethedocs.org/conf/australia/{{year}}/cfp/>`__ on the website.
+The Call for Proposals will be open until **Midnight {{tz}} on {{cfp.ends}}**.
+
+Get your ticket for the conference
+----------------------------------
+
+**The Australia & India conference will be held online on {{ date.short }}.** The `full event website <https://www.writethedocs.org/conf/australia/{{year}}/>`_ is live, with some preliminary details, and we'll be filling in more as it gets closer.
+
+Tickets are on sale now, so go ahead and `register for your ticket now <https://www.writethedocs.org/conf/australia/{{year}}/tickets/>`_! Even though our capacity is more flexible due to the virtual event platform, we might still sell out to make sure we're providing a manageable event size for our attendees, as always.
+
+Similar to last year's virtual conference, we're going to keep as much as possible of the spirit of the event alive:
+
+* Excellent single track of pre-recorded presentations with live moderated Q&A after each talk
+* Writing Day sessions
+* Unconference sessions
+* A virtual hallway track
+* A social event of some kind, bring your own beverage and snacks :)
+
+We really want to make sure that folks can get value from being at the event at the same time, and we think it will be another great year of helping our community connect.
+
+Grant program
+-------------
+
+We updated our grant program application to take into account the virtual format of the event.
+We're excited to be able to offer free tickets to a larger number of people, since there are now minimal other costs to attend the event.
+
+You can apply by **{{ grants.ends }}** on `our website <https://www.writethedocs.org/conf/australia/{{year}}/opportunity-grants/>`_.
+
+Submit your talk by June 30th
+-----------------------------
+
+There are still a few weeks left to submit your proposal! Check out the `Call for Proposals page <https://www.writethedocs.org/conf/australia/{{year}}/cfp/>`_ for more details about what we are looking for.
+
+And if you already have an idea but you’re having a hard time getting your proposal to come together, you can always ask for feedback on the `Write the Docs Slack <https://www.writethedocs.org/slack/>`_. The community is there to help!
+
+We’ll then be reviewing all the talk proposals, and will be contacting everyone who submitted a proposal by **{{ cfp.notification }}**.
+
+Support our community by sponsoring
+-----------------------------------
+
+Every year we are fortunate to have the support of like-minded organizations and communities, who believe in the collaborative and welcoming community spirit and help us make our events great.
+
+We have published our `virtual sponsorship prospectus`_ for the conference,
+and are open for new sponsorship inquiries.
+
+.. _virtual sponsorship prospectus: https://www.writethedocs.org/conf/australia/{{year}}/sponsors/prospectus/
+
+Stay updated
+------------
+
+Want to find out what's happening with the conference, or enjoy our monthly global community newsletter?
+Sign up to one or more of our `mailing lists <http://eepurl.com/cdWqc5>`_. Your information will never be shared with any third-parties, and you can unsubscribe at any time.
+
+Want to connect with other documentarians in real-time? Join our `Slack <http://slack.writethedocs.org/>`_.
+
+We hope you will join us for a new online Write the Docs conference.


### PR DESCRIPTION
- Pretalx and tito events are not live yet pending Swapnil's approval, so link to those will result in not found
- CFP dates are not set correctly, up to the Australia team to decide
- For grant dates I picked something reasonable, if we change it we also need to update it in the google form
- Announcement post is a rough draft