### PR TITLE
Remove Austin organizers who stepped down

### DIFF
--- a/docs/_data/meetups/usa-austin.yaml
+++ b/docs/_data/meetups/usa-austin.yaml
@@ -11,9 +11,5 @@ organizers:
     link: https://twitter.com/beckatodd
   - name: Margaret Eker
     link: https://twitter.com/meker
-  - name: Mary Snider
-    link: https://linkedin.com/in/mary-snider-8b590b78
   - name: Mary Connor
     link: https://twitter.com/maryfconnor
-  - name: Chad Sterling
-    link: https://twitter.com/Techwritrtweetr


### PR DESCRIPTION
Remove two organizers who are no longer involved in the Write the Docs ATX meetup group.