### PR TITLE
Add Welcome Wagon tour to the Prague schedule

### DIFF
--- a/docs/_data/prague-2021-schedule.yaml
+++ b/docs/_data/prague-2021-schedule.yaml
@@ -8,13 +8,19 @@ writing_day:
   title: Team up and start working
 - duration: '1:00'
   title: Lunch Break (60 mins)
+- time: '14:00'
+  duration: '0:30'
+  title: Conference Intro and Tour with the Welcome Wagon
 - time: '17:00'
   title: End of Writing Day
 
 talks_day1:
 - time: '9:00'
-  duration: '1:00'
+  duration: '0:30'
   title: Platform opens
+- time: '9:30'
+  duration: '0:30'
+  title: Conference Intro and Tour with the Welcome Wagon
 - duration: '0:40'
   title: Write the Docs Team - Introduction to Write the Docs
 - duration: '0:5'


### PR DESCRIPTION
This PR adds a 30 min slot for the Welcome Wagon tour to the schedules of the Writing Day and Day 1.
It follows the pattern used at the Portland conference:
- 30 minutes after lunch on the Writing Day
- 30 min before the intro talk at the opening

~~I've also added a link to the CEST time zone, similar to what Portland had for the Pacific time zone. Seemed like a good idea?~~ Bad idea. It makes the build fail.