### PR TITLE
Add Writing Day project "Open Web Docs and MDN"

### DIFF
--- a/docs/conf/prague/2021/writing-day.rst
+++ b/docs/conf/prague/2021/writing-day.rst
@@ -15,6 +15,25 @@ Schedule
 Your Project Here
 -----------------
 
+Open Web Docs and MDN
+^^^^^^^^^^^^^^^^^^^^^
+`Open Web Docs <https://opencollective.com/open-web-docs>`_ was created to ensure the long-term health of web platform documentation independent of any single vendor or organization. It's supported by various organizations and individuals, and employs technical writers who create and maintain open documentation for the web platform. At the moment we’re focused on maintaining and improving `MDN Web Docs <https://developer.mozilla.org/>`_.
+
+We are happy to announce that, on the Writing Day, we will collaborate with writers from Mozilla, who will be joining us to improve MDN Web Docs.
+
+We'd love to collaborate with you on some of our projects. To get started, you’ll need a GitHub account. Here are some of the projects we’ll be working on:
+
+- **Markdown conversion**: we're in the middle of a project to convert the authoring format for MDN - all 11,000 pages of it - from HTML to Markdown. As part of this we need to clean up our content to make it Markdown-compatible.
+
+- **HTTP documentation editorial reviews**: we've recently started a revamp of the HTTP documentation on MDN, to include newer technologies like HTTP 2 and 3, and generally bring everything up to date. So it's a great time to get editorial reviews of this area!
+
+- **GitHub issues**: we'd love help fixing issues with MDN content that have been filed on GitHub. We've labeled issues that we think are especially suitable for new contributors, but we'd encourage you to work on anything that seems suitable. We have issues that are editorial fixes, technical fixes, and requests for new pages, so choose the bugs that suit you best.
+
+- We will lead a brainstorming session about **Documenting how to document** (expected time to start at 2pm).
+
+It’s an explicit goal of _Open Web Docs_ to create and support a community around web documentation. So if you do join us for Writing Day, please tell us about it - what worked and what didn’t, what was easy and what wasn’t - so we can improve the experience for contributors.
+
+
 Write the Docs Meetups
 ----------------------
 

--- a/docs/conf/prague/2021/writing-day.rst
+++ b/docs/conf/prague/2021/writing-day.rst
@@ -17,7 +17,7 @@ Your Project Here
 
 Open Web Docs and MDN
 ^^^^^^^^^^^^^^^^^^^^^
-`Open Web Docs <https://opencollective.com/open-web-docs>`_ was created to ensure the long-term health of web platform documentation independent of any single vendor or organization. It's supported by various organizations and individuals, and employs technical writers who create and maintain open documentation for the web platform. At the moment we’re focused on maintaining and improving `MDN Web Docs <https://developer.mozilla.org/>`_.
+`Open Web Docs <https://openwebdocs.org>`_ was created to ensure the long-term health of web platform documentation independent of any single vendor or organization. It's supported by various organizations and individuals, and employs technical writers who create and maintain open documentation for the web platform. At the moment we’re focused on maintaining and improving `MDN Web Docs <https://developer.mozilla.org/>`_.
 
 We are happy to announce that, on the Writing Day, we will collaborate with writers from Mozilla, who will be joining us to improve MDN Web Docs.
 
@@ -31,7 +31,7 @@ We'd love to collaborate with you on some of our projects. To get started, you�
 
 - We will lead a brainstorming session about **Documenting how to document** (expected time to start at 2pm).
 
-It’s an explicit goal of _Open Web Docs_ to create and support a community around web documentation. So if you do join us for Writing Day, please tell us about it - what worked and what didn’t, what was easy and what wasn’t - so we can improve the experience for contributors.
+It’s an explicit goal of *Open Web Docs* to create and support a community around web documentation. So if you do join us for Writing Day, please tell us about it - what worked and what didn’t, what was easy and what wasn’t - so we can improve the experience for contributors.
 
 
 Write the Docs Meetups


### PR DESCRIPTION
cc/ @elchi3, @ddbeck
This is our (Open Web Docs) for the Prague 2021 Writing Days. 

We are preparing documents about practical activities that we will link to the 4 projects before Sunday, but I think we can already advertise this!