### PR TITLE
Blog post announcement salary survey 2021

### DIFF
--- a/docs/blog/2021-salary-survey.rst
+++ b/docs/blog/2021-salary-survey.rst
@@ -20,7 +20,7 @@ We hope that the survey data can help our community members determine what appro
 
 Additionally, we’re hoping the results spark discussion of employment-related trends and issues in our industry, including but not limited to the effects of the COVID-19 pandemic.
 
-The survey is divided into 6 sections, and takes between 5 and 10 minutes to complete, so go ahead and `fill it out <https://salary-survey.writethedocs.org/>`__. 
+The survey is divided into a few different sections, and takes between 5 and 10 minutes to complete, so go ahead and `fill it out <https://salary-survey.writethedocs.org/>`__. 
 
 The survey will be open until **20th December, 2021**. 
 Results will be published in early 2022. 

--- a/docs/blog/2021-salary-survey.rst
+++ b/docs/blog/2021-salary-survey.rst
@@ -32,5 +32,5 @@ Thanks
 Thanks again for for being a member of our community.
 We hope to see you soon at one of our online events, on our slack, or continue to see you here via this newsletter.
 
-You can always reply to this email if you have any questions or comments.
+You can always email us at support@writethedocs.org if you have any questions or comments.
 Stay tuned for another newsletter update next month!

--- a/docs/blog/2021-salary-survey.rst
+++ b/docs/blog/2021-salary-survey.rst
@@ -1,0 +1,36 @@
+.. post:: Oct 19, 2021
+   :tags: salary survey
+   :author: Mikey Ariel
+
+Write the Docs 2021 Salary Survey
+=================================
+
+Hey there documentarians!
+
+This is a special update to announce that the `2021 Salary Survey <https://salary-survey.writethedocs.org/>`_ is now live and ready for your input!
+
+Survey says...
+--------------
+
+As we've seen with the `previous two surveys <https://www.writethedocs.org/surveys/>`_, being a documentarian can encompass many roles, teams, and industries. 
+Our community is global and diverse, and the surveys reflected that. 
+Every person who submits the survey helps the entire community, so we hope you'll take a few minutes and fill it out. 
+
+We hope that the survey data can help our community members determine what appropriate salary ranges are, and provide a benchmark for future employment-related decisions and negotiations.
+
+Additionally, we’re hoping the results spark discussion of employment-related trends and issues in our industry, including but not limited to the effects of the COVID-19 pandemic.
+
+The survey is divided into 5 sections, and takes between 5 and 10 minutes to complete, so go ahead and `fill it out <https://salary-survey.writethedocs.org/>`__. 
+
+The survey will be open until **20th December, 2021**. 
+Results will be published in early 2022. 
+Shout out to `Kay Smoljak <https://twitter.com/goatlady>`_ for running this survey since it debuted in 2019!
+
+Thanks
+------
+
+Thanks again for for being a member of our community.
+We hope to see you soon at one of our online events, on our slack, or continue to see you here via this newsletter.
+
+You can always reply to this email if you have any questions or comments.
+Stay tuned for another newsletter update next month!

--- a/docs/blog/2021-salary-survey.rst
+++ b/docs/blog/2021-salary-survey.rst
@@ -20,7 +20,7 @@ We hope that the survey data can help our community members determine what appro
 
 Additionally, we’re hoping the results spark discussion of employment-related trends and issues in our industry, including but not limited to the effects of the COVID-19 pandemic.
 
-The survey is divided into 5 sections, and takes between 5 and 10 minutes to complete, so go ahead and `fill it out <https://salary-survey.writethedocs.org/>`__. 
+The survey is divided into 6 sections, and takes between 5 and 10 minutes to complete, so go ahead and `fill it out <https://salary-survey.writethedocs.org/>`__. 
 
 The survey will be open until **20th December, 2021**. 
 Results will be published in early 2022. 

--- a/docs/blog/2021-salary-survey.rst
+++ b/docs/blog/2021-salary-survey.rst
@@ -1,5 +1,5 @@
 .. post:: Oct 19, 2021
-   :tags: salary survey
+   :tags: salary-survey
    :author: Mikey Ariel
 
 Write the Docs 2021 Salary Survey


### PR DESCRIPTION
Since it's already been two weeks since the newsletter went out (which means we only have a couple of weeks until the next one!), I propose this updated plan: 

1. Publish this blog post without mailchimp RSS and share the link on social media
2. When the next newsletter goes out mention the survey again and link to the survey directly

This will both distribute the load on the server and give us more opportunities for buzz, rather than hook into the newsletter mailing list out of schedule. Thoughts?