### PR TITLE
Fix #1328 - Make sponsor brand key mandatory

### DIFF
--- a/docs/_data/config-australia-2019.yaml
+++ b/docs/_data/config-australia-2019.yaml
@@ -70,7 +70,7 @@ sponsors:
       link: https://www.atlassian.com
   second:
     - name: buildkite
-      brand: BuildKite
+      brand: Buildkite
       link: https://buildkite.com/
     - name: gandi
       brand: Gandi
@@ -80,7 +80,7 @@ sponsors:
       link: https://gitlab.com
   first:
     - name: datalust
-      brand: datalist
+      brand: datalust
       link: https://datalust.co/seq
     - name: redocly
       brand: Redocly

--- a/docs/_data/config-australia-2019.yaml
+++ b/docs/_data/config-australia-2019.yaml
@@ -59,23 +59,31 @@ sponsors:
     # They actually got a custom sponsorship somewhere in the middle,
     # but let's bump them because they've been a steady supporter
     - name: google
+      brand: Google
       link: https://www.google.com
   publisher:
     - name: knowledgeowl
+      brand: KnowledgeOwl
       link: https://www.knowledgeowl.com
     - name: atlassian
+      brand: Atlassian
       link: https://www.atlassian.com
   second:
     - name: buildkite
+      brand: BuildKite
       link: https://buildkite.com/
     - name: gandi
+      brand: Gandi
       link: https://www.gandi.net/en
     - name: gitlab
+      brand: GitLab
       link: https://gitlab.com
   first:
     - name: datalust
+      brand: datalist
       link: https://datalust.co/seq
     - name: redocly
+      brand: Redocly
       link: https://redoc.ly/
 
 date: # how do we handle these? human readable would be nice.

--- a/docs/_data/config-portland-2019.yaml
+++ b/docs/_data/config-portland-2019.yaml
@@ -115,54 +115,77 @@ cfp:
 sponsors:
   keystone:
     - name: google
+      brand: Google
       link: https://www.google.com
   patron:
     - name: oracle-cloud
+      brand: Oracle cloud
       link: https://cloud.oracle.com/iaas
   publisher:
     - name: alexa
+      brand: Alexa
       link: https://developer.amazon.com/alexa
     - name: aws
+      brand: AWS
       link: https://aws.amazon.com/
     - name: square
+      brand: Square
       link: https://squareup.com/
     - name: microsoft
+      brand: Microsoft
       link: https://developer.microsoft.com
     - name: braintree
+      brand: Braintree
       link: https://www.braintreepayments.com/
     - name: twilio
+      brand: Twillio
       link: https://www.twilio.com/
     - name: redhat
+      brand: RedHat
       link: https://www.redhat.com/
     - name: mozilla-new
+      brand: Mozilla
       link: https://developer.mozilla.org/
   second:
     - name: salesforce
+      brand: Salesforce
       link: https://www.salesforce.com
     - name: gitlab
+      brand: GitLab
       link: https://gitlab.com
     - name: elastic
+      brand: Elastic
       link: https://www.elastic.co
     - name: cisco
+      brand: Cisco
       link: https://www.cisco.com
     - name: knowledgeowl
+      brand: KnowledgeOwl
       link: https://www.knowledgeowl.com
     - name: netlify
+      brand: Netlify
       link: https://www.netlify.com/wtd
     - name: appian
+      brand: Appian
       link: https://www.appian.com/
     - name: cockroachlabs
+      brand: Cockroach Labs
       link: https://www.cockroachlabs.com/
     - name: asciidoctor
+      brand: asciidoctor
       link: https://asciidoctor.org/
     - name: redocly
+      brand: redocly
       link: https://redoc.ly
   first:
     - name: support-driven
+      brand: support driven
       link: https://supportdriven.com
     - name: cncf
+      brand: CNCF
       link: https://www.cncf.io
     - name: stickermule
+      brand: Sticker Mule
       link: https://www.stickermule.com/supports/writethedocs-portland
 
 

--- a/docs/_data/config-prague-2019.yaml
+++ b/docs/_data/config-prague-2019.yaml
@@ -60,35 +60,48 @@ sponsors:
   patron:
     # They are actually a publisher, but I want these styles :)
     - name: mozilla-new
+      brand: Mozilla
       link: https://developer.mozilla.org/en-US/
     - name: document360
+      brand: Document360
       link: https://document360.io
   publisher:
   second:
     - name: redhat-new
+      brand: RedHat
       link: https://www.redhat.com/
     - name: umbraco
+      brand: Umbraco
       link: https://umbraco.com/
     - name: knowledgeowl
+      brand: KnowledgeOwl
       link: https://www.knowledgeowl.com
       width: 250px
     - name: contact-software
+      brand: Contact Software
       link: https://www.contact-software.com/en/
     - name: kiwi
+      brand: Kiwi
       link: https://www.kiwi.com/
     - name: people-text
+      brand: PeopleText
       link: https://www.people-text.de/
     - name: jetbrains
+      brand: JetBrains
       link: https://www.jetbrains.com/
   first:
     - name: buildkite
+      brand: BuildKite
       link: https://buildkite.com/
     - name: cncf
+      brand: CNCF
       link: https://www.cncf.io/
   media:
     - name: bart
+      brand: Bart at Work
       link: http://www.bartatwork.com
     - name: techwriter-pl
+      brand: TechWriter.pl
       link: http://techwriter.pl
 
 date: # how do we handle these? human readable would be nice.

--- a/docs/_data/config-prague-2019.yaml
+++ b/docs/_data/config-prague-2019.yaml
@@ -91,7 +91,7 @@ sponsors:
       link: https://www.jetbrains.com/
   first:
     - name: buildkite
-      brand: BuildKite
+      brand: Buildkite
       link: https://buildkite.com/
     - name: cncf
       brand: CNCF

--- a/docs/_data/config-vilnius-2019.yaml
+++ b/docs/_data/config-vilnius-2019.yaml
@@ -55,9 +55,11 @@ sponsors:
   publisher:
   second:
     - name: knowledgeowl
+      brand: KnowledgeOwl
       link: https://www.knowledgeowl.com
   first:
     - name: techwriter-pl
+      brand: TechWriter.pl
       link: http://techwriter.pl
 
 date:

--- a/docs/_data/schema-config.yaml
+++ b/docs/_data/schema-config.yaml
@@ -142,7 +142,7 @@ sponsors-details:
 sponsor-detail:
   name: str(required=True)
   link: str(required=True)
-  brand: str(required=False)
+  brand: str(required=True)
   text: str(required=False)
   width: str(required=False)
 


### PR DESCRIPTION
Also added it for a few 2019 ones where it was missing but probably not used. Easier to just add it than deal with more config versions.