### PR TITLE
Add a section on creating channels to Slack guide

### DIFF
--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -37,8 +37,13 @@ That doesn't mean everything gets lost, though - you can always react to a messa
 ``:suggest-for-newsletter:`` emoji to nominate it for inclusion in our next monthly newsletter. 
 Read the newsletter archives at :doc:`/newsletter` and subscribe if you want them directly in your inbox! 
 
+Channel guide
+-------------
+
+There are lots of channels. Here's an overview of interesting channels and how to find more.
+
 Default channels
-----------------
+^^^^^^^^^^^^^^^^
 
 Everyone who joins the Slack will be added to these channels:
 
@@ -50,7 +55,7 @@ Everyone who joins the Slack will be added to these channels:
 * **#intros** - Introduce yourself! Let people know you're here, and why you care about docs :)
 
 Other useful topical channels
------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * **#career-advice** - Should you take that job? Am I being paid enough? Ask here!
 * **#markup-the-docs** - Talk about markup languages. Markdown, rST, Asciidoc, etc.
@@ -61,6 +66,35 @@ Other useful topical channels
 * **#community-showcase** - Announce your projects here! Blog posts, docs, code, products—whatever you make that you're excited to share!
 * **#community-help-wanted** - Got an open-source project that needs docs contributors? Looking for open-source communities who will mentor you while you contribute to their docs? This channel is for you! Only for volunteer/unpaid work with open-source projects; companies and paid job postings should continue to use #job-posts-only. 
 * **#wtd-weps** - Ask questions about the Write the Docs Enhancement Proposal (WEP) system and brainstorm on pre-proposal ideas to help improve our community processes and governance.
+
+Channels that serve specific communities & their allies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Allies are welcome as guests in these channels. Please be considerate.
+
+* **#bipoc** - Social and discussion space for Write the Docs' :doc:`/bipoc` community.
+* **#lgbtq** - Social and discussion space for LGBTQ+ people in the WTD community.
+
+Location-based channels
+^^^^^^^^^^^^^^^^^^^^^^^
+
+We have too many location-based channels to list.
+Chances are we have a large group of folks in your area,
+so join up and chat with them.
+They're a great way to get in touch with your local meetup organizer and community.
+
+Creating channels
+^^^^^^^^^^^^^^^^^
+
+If you didn't see a channel that matches your interests, make sure to browse the complete channel list in Slack.
+
+If you still can't find a suitable channel, you can propose a new channel. To propose a channel:
+
+1. Find two other people to cosponsor your channel idea. Ask in related channels to find people who share your interest.
+2. Together, come up with a channel name and write a channel description.
+3. Post in **#meta** requesting a channel. Be sure to share your proposed channel name, description, and to tag your cosponsors.
+
+The Write the Docs moderation team will review your proposal.
 
 Autoresponders
 --------------
@@ -93,21 +127,6 @@ We have some helpful Slackbot responses that you can summon in any channel, at a
 * ``?history``
 
   - Returns the answer for one of our most frequently asked questions: why you can't access the full chat history in the Write the Docs Slack.
-
-Channels that serve specific communities & their allies
--------------------------------------------------------
-Allies are welcome as guests in these channels. Please be considerate.
-
-* **#bipoc** - Social and discussion space for Write the Docs' :doc:`/bipoc` community.
-* **#lgbtq** - Social and discussion space for LGBTQ+ people in the WTD community.
-
-Location-based channels
------------------------
-
-We have too many location-based channels to list.
-Chances are we have a large group of folks in your area,
-so join up and chat with them.
-They're a great way to get in touch with your local meetup organizer and community.
 
 Guidelines
 ----------

--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -70,13 +70,8 @@ We have some helpful Slackbot responses that you can summon in any channel, at a
 
   - Returns the answer for one of our most frequently asked questions: why you can't access the full chat history in the Write the Docs Slack.
 
-Channel guide
--------------
-
-There are lots of channels. Here's an overview of interesting channels and how to find more.
-
 Default channels
-~~~~~~~~~~~~~~~~
+----------------
 
 Everyone who joins the Slack will be added to these channels:
 
@@ -86,6 +81,11 @@ Everyone who joins the Slack will be added to these channels:
 * **#wtd-conferences** - Questions and other thoughts around the :doc:`/conf/index`.
 * **#meetups** - Questions and other thoughts about our :doc:`/meetups/index`.
 * **#intros** - Introduce yourself! Let people know you're here, and why you care about docs :)
+
+Channel guide
+-------------
+
+There are lots of channels. Here's an overview of interesting channels and how to find more.
 
 Other useful topical channels
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -37,6 +37,39 @@ That doesn't mean everything gets lost, though - you can always react to a messa
 ``:suggest-for-newsletter:`` emoji to nominate it for inclusion in our next monthly newsletter. 
 Read the newsletter archives at :doc:`/newsletter` and subscribe if you want them directly in your inbox! 
 
+
+Autoresponders
+--------------
+We have some helpful Slackbot responses that you can summon in any channel, at any time.
+
+* ``?invite`` / ``?join``
+
+  - Get a link you can send to a friend to invite them to the Write the Docs Slack. (You can also invite people directly from Slack by clicking **Write the Docs** > **Invite people to Write the Docs**.)
+
+* ``?conferences`` / ``?conference``
+
+  - Get information on past and future Write the Docs :doc:`/conf/index`.
+
+* ``?jobseeking`` / ``?hiring`` / ``?interview`` / ``?interviewing``
+
+  - Get information on both hiring and getting hired, including a link to the :doc:`/hiring-guide/index`.
+
+* ``?getstarted`` / ``?resources`` / ``?learn``
+
+  - We're always excited to help new people into working on documentation! This is for you if you want some resources on how to get started, including a link to some of our favorite :doc:`/about/learning-resources`.
+
+* ``?coc``
+
+  - "COC" is short for the :doc:`/code-of-conduct`. This is an easy way to get a link to it, and to summon a member of the :ref:`moderation-team` if you need one.
+
+* ``?mods`` / ``?moderators`` / ``?modsquad``
+
+  - Returns the members of the :ref:`moderation-team` if you need to ping someone directly for help.
+
+* ``?history``
+
+  - Returns the answer for one of our most frequently asked questions: why you can't access the full chat history in the Write the Docs Slack.
+
 Channel guide
 -------------
 
@@ -95,38 +128,6 @@ If you still can't find a suitable channel, you can propose a new channel. To pr
 3. Post in **#meta** requesting a channel. Be sure to share your proposed channel name, description, and to tag your cosponsors.
 
 The Write the Docs moderation team will review your proposal.
-
-Autoresponders
---------------
-We have some helpful Slackbot responses that you can summon in any channel, at any time.
-
-* ``?invite`` / ``?join``
-
-  - Get a link you can send to a friend to invite them to the Write the Docs Slack. (You can also invite people directly from Slack by clicking **Write the Docs** > **Invite people to Write the Docs**.)
-
-* ``?conferences`` / ``?conference``
-
-  - Get information on past and future Write the Docs :doc:`/conf/index`.
-
-* ``?jobseeking`` / ``?hiring`` / ``?interview`` / ``?interviewing``
-
-  - Get information on both hiring and getting hired, including a link to the :doc:`/hiring-guide/index`.
-
-* ``?getstarted`` / ``?resources`` / ``?learn``
-
-  - We're always excited to help new people into working on documentation! This is for you if you want some resources on how to get started, including a link to some of our favorite :doc:`/about/learning-resources`.
-
-* ``?coc``
-
-  - "COC" is short for the :doc:`/code-of-conduct`. This is an easy way to get a link to it, and to summon a member of the :ref:`moderation-team` if you need one.
-
-* ``?mods`` / ``?moderators`` / ``?modsquad``
-
-  - Returns the members of the :ref:`moderation-team` if you need to ping someone directly for help.
-
-* ``?history``
-
-  - Returns the answer for one of our most frequently asked questions: why you can't access the full chat history in the Write the Docs Slack.
 
 Guidelines
 ----------

--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -70,8 +70,15 @@ We have some helpful Slackbot responses that you can summon in any channel, at a
 
   - Returns the answer for one of our most frequently asked questions: why you can't access the full chat history in the Write the Docs Slack.
 
+Channel guide
+-------------
+
+The Write the Docs Slack has _lots_ of channels.
+Some channels are widely joined, while others are more specialized.
+Here's an overview of how we use channels on Slack.
+
 Default channels
-----------------
+~~~~~~~~~~~~~~~~
 
 Everyone who joins the Slack will be added to these channels:
 
@@ -81,11 +88,6 @@ Everyone who joins the Slack will be added to these channels:
 * **#wtd-conferences** - Questions and other thoughts around the :doc:`/conf/index`.
 * **#meetups** - Questions and other thoughts about our :doc:`/meetups/index`.
 * **#intros** - Introduce yourself! Let people know you're here, and why you care about docs :)
-
-Channel guide
--------------
-
-There are lots of channels. Here's an overview of interesting channels and how to find more.
 
 Other useful topical channels
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -76,7 +76,7 @@ Channel guide
 There are lots of channels. Here's an overview of interesting channels and how to find more.
 
 Default channels
-^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~
 
 Everyone who joins the Slack will be added to these channels:
 
@@ -88,7 +88,7 @@ Everyone who joins the Slack will be added to these channels:
 * **#intros** - Introduce yourself! Let people know you're here, and why you care about docs :)
 
 Other useful topical channels
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * **#career-advice** - Should you take that job? Am I being paid enough? Ask here!
 * **#markup-the-docs** - Talk about markup languages. Markdown, rST, Asciidoc, etc.
@@ -101,7 +101,7 @@ Other useful topical channels
 * **#wtd-weps** - Ask questions about the Write the Docs Enhancement Proposal (WEP) system and brainstorm on pre-proposal ideas to help improve our community processes and governance.
 
 Channels that serve specific communities & their allies
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Allies are welcome as guests in these channels. Please be considerate.
 
@@ -109,7 +109,7 @@ Allies are welcome as guests in these channels. Please be considerate.
 * **#lgbtq** - Social and discussion space for LGBTQ+ people in the WTD community.
 
 Location-based channels
-^^^^^^^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~~~~~~~
 
 We have too many location-based channels to list.
 Chances are we have a large group of folks in your area,
@@ -117,7 +117,7 @@ so join up and chat with them.
 They're a great way to get in touch with your local meetup organizer and community.
 
 Creating channels
-^^^^^^^^^^^^^^^^^
+~~~~~~~~~~~~~~~~~
 
 If you didn't see a channel that matches your interests, make sure to browse the complete channel list in Slack.
 


### PR DESCRIPTION
Does what it says on the tin, mostly. It also rearranges things a little, so that all the channel stuff sits together.

[Direct link to the built preview](https://writethedocs-www--1632.org.readthedocs.build/slack/)