### PR TITLE
Portland CFP WIP

### DIFF
--- a/docs/_data/portland-2022-config.yaml
+++ b/docs/_data/portland-2022-config.yaml
@@ -208,7 +208,7 @@ sponsors:
 
 
 # Things that change over time, listed in order of change
-flaglanding: False
+flaglanding: True
 flaghassponsors: False
 flagcfp: True
 flagticketsonsale: False

--- a/docs/_data/portland-2022-config.yaml
+++ b/docs/_data/portland-2022-config.yaml
@@ -19,6 +19,8 @@ buttons:
   top:
     - text: Welcome to our conference
       link: /news/welcome
+    - text: Submit a Talk
+      link: /cfp
     # - text: Sponsor us
     #   link: /sponsors/prospectus
     # - text: Date and ticket information
@@ -29,8 +31,6 @@ buttons:
     #   link: /schedule
     # - text: Buy a Ticket!
     #   link: /tickets
-    #- text: Submit a Talk
-    #  link: /cfp
     #- text: See the talks!
     #   link: /speakers
 #    - text: See the Schedule!

--- a/docs/_data/portland-2022-config.yaml
+++ b/docs/_data/portland-2022-config.yaml
@@ -165,6 +165,9 @@ cfp:
 unconf:
   url: http://bit.ly/wtd-schedule-pdx-2022
 
+hike:
+  date: Sunday, May 22, 1 PM
+
 sponsors:
   keystone:
   patron:

--- a/docs/_data/portland-2022-config.yaml
+++ b/docs/_data/portland-2022-config.yaml
@@ -158,9 +158,9 @@ about:
 
 cfp:
   url: https://pretalx.com/write-the-docs-portland-2022/cfp
-  ends: "March 1, 2022"          # 2 weeks to review and get confirmnations
-  notification: "March 15, 2022" # leaves 6 weeks to write and record
-  video_by: "May 1, 2022"        # 3 weeks before the conf
+  ends: "February 15, 2022"          # 2 weeks to review and get confirmnations
+  notification: "March 1, 2022"      # 8 weeks to write and record
+  video_by: "May 1, 2022"            # 3 weeks before the conf
 
 unconf:
   url: http://bit.ly/wtd-schedule-pdx-2022

--- a/docs/_data/portland-2022-config.yaml
+++ b/docs/_data/portland-2022-config.yaml
@@ -77,11 +77,11 @@ tickets:
 
 sponsorship:
   second_draft:
-    price: $2,000
+    price: $2,500
   publisher:
-    price: $4,000
+    price: $5,000
   patron:
-    price: $8,500
+    price: $9,500
   keystone:
     price: $15,000
 

--- a/docs/_data/portland-2022-config.yaml
+++ b/docs/_data/portland-2022-config.yaml
@@ -205,7 +205,7 @@ sponsors:
 
 
 # Things that change over time, listed in order of change
-flaglanding: True
+flaglanding: False
 flaghassponsors: False
 flagcfp: True
 flagticketsonsale: False
@@ -220,7 +220,8 @@ flaglivestreaming: False
 flagpostconf: False
 
 # Truthy things that don't change
-flaghashike: False
+flaghashike: True
+flaghasfood: True
 flaghasboat: False
 flaghaswritingday: False
 flaghasjobfair: False

--- a/docs/_data/portland-2022-config.yaml
+++ b/docs/_data/portland-2022-config.yaml
@@ -158,9 +158,9 @@ about:
 
 cfp:
   url: https://pretalx.com/write-the-docs-portland-2022/cfp
-  ends: "February 1, 2022"          # 2 weeks to review and get confirmnations
-  notification: "February 15, 2022" # leaves 6 weeks to write and record
-  video_by: "March 31, 2022"        # 3 weeks before the conf
+  ends: "March 1, 2022"          # 2 weeks to review and get confirmnations
+  notification: "March 15, 2022" # leaves 6 weeks to write and record
+  video_by: "May 1, 2022"        # 3 weeks before the conf
 
 unconf:
   url: http://bit.ly/wtd-schedule-pdx-2022
@@ -207,7 +207,7 @@ sponsors:
 # Things that change over time, listed in order of change
 flaglanding: True
 flaghassponsors: False
-flagcfp: False
+flagcfp: True
 flagticketsonsale: False
 flagsoldout: False
 flagspeakersannounced: False

--- a/docs/_data/schema-config.yaml
+++ b/docs/_data/schema-config.yaml
@@ -58,6 +58,8 @@ flaghashike: bool()
 flaghasboat: bool()
 flaglanding: bool()
 flaghasbadgeflair: bool(required=False)
+flaghasfood: bool(required=False)
+
 
 ---
 

--- a/docs/_data/schema-config.yaml
+++ b/docs/_data/schema-config.yaml
@@ -34,6 +34,8 @@ grants: include('grants-details', required=False)
 shirts: include('shirts-details', required=False)
 unconf: include('unconf-details', required=False)
 lightning_talks: include('lightning_talks-details', required=False)
+hike: include('hike-details', required=False)
+
 
 flaghassponsors: bool()
 flagcfp: bool()
@@ -59,6 +61,7 @@ flaghasboat: bool()
 flaglanding: bool()
 flaghasbadgeflair: bool(required=False)
 flaghasfood: bool(required=False)
+
 
 
 ---
@@ -178,6 +181,9 @@ shirts-details:
 
 unconf-details:
   url: str(required=True)
+
+hike-details:
+  date: str(required=False)
 
 lightning_talks-details:
   signup_url: str(required=True)

--- a/docs/_templates/2022/menu-desktop.html
+++ b/docs/_templates/2022/menu-desktop.html
@@ -79,7 +79,7 @@
                                     <div class="uk-navbar-dropdown">
                                         <ul class="uk-nav uk-navbar-dropdown-nav">
                                             {% if flaghashike %}
-                                            <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/ticket-choices') }}">Online Ticket Options</a></li>
+                                            <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/tickets') }}">Online Ticket Options</a></li>
                                             {% endif %}
                                             <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/opportunity-grants') }}">Opportunity Grants</a></li>
                                         </ul>

--- a/docs/_templates/2022/menu-mobile.html
+++ b/docs/_templates/2022/menu-mobile.html
@@ -53,7 +53,7 @@
                     <a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/tickets') }}">Tickets</a>
                     <ul class="uk-nav-sub">
                         {% if flaghashike %}
-                        <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/ticket-choices') }}">Online Ticket Options</a></li>
+                        <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/tickets') }}">Online Ticket Options</a></li>
                         {% endif %}
                         <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/opportunity-grants') }}">Opportunity Grants</a></li>
 

--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -67,12 +67,6 @@
       <div class="sponsor-name">Read the Docs</div>
       <div class="sponsor-description">Donated Hosting</div>
     </a>
-    <a class="sponsor" href="http://stickermule.com" rel="noopener" target="_blank">
-      <img src="{{ pathto('/_static/img/sponsors/stickermule.png', 1) }}" alt="Sticker Mule" class="sponsor-image">
-      <div class="sponsor-name">Sticker Mule</div>
-      <div class="sponsor-description">Donated Stickers</div>
-    </a>
-
     {% for sponsor in global_sponsors %}
     <a class="sponsor" href="{{ sponsor.link }}" rel="noopener" target="_blank">
       <img src="{{ sponsor.name|sponsor_photo }}" alt="{{ sponsor.brand }}" class="sponsor-image">

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -134,23 +134,15 @@ suppress_warnings = ['image.nonlocal_uri']
 # Our additions
 
 global_sponsors = yaml.safe_load("""
-- name: microsoft
-  link: https://microsoft.com
-  brand: Microsoft
-  comment: Keystone sponsor
 - name: google
   link: https://www.google.com
   brand: Google
-  comment: Patron sponsor
-- name: redocly
-  link: https://redoc.ly/
-  brand: Redocly
   comment: Patron sponsor
 """)
 
 html_context = {
     'conf_py_root': os.path.dirname(os.path.abspath(__file__)),
-    'newsletter_subs': '5,000',
+    'newsletter_subs': '6,500',
     'website_visits': '30,000',
     'global_sponsors': global_sponsors,
 }

--- a/docs/conf/portland/2022/about.rst
+++ b/docs/conf/portland/2022/about.rst
@@ -1,0 +1,14 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/team.png
+
+About the Conference
+====================
+
+We invite you to join hundreds of other folks for a three-day event to explore the art and science of documentation.
+The Write the Docs conference covers any topic related to documentation in the software industry.
+Past talks have also covered such diverse topics as empathy, the history of math symbols, and using emoji to keep your users' attention.
+
+Write the Docs brings *everyone* who writes the docs together in the same room: Writers, developers, support engineers, community managers, developer relations, and more.
+We all have things to learn, and there's no better way than coming together in the same room and getting to know each other.
+
+{{about.summary}}

--- a/docs/conf/portland/2022/badge-flair.rst
+++ b/docs/conf/portland/2022/badge-flair.rst
@@ -1,0 +1,6 @@
+:template: {{year}}/generic.html
+
+Badge Flair Contest
+===================
+
+{% include "conf/events/badge-flair.rst" %}

--- a/docs/conf/portland/2022/cfp.rst
+++ b/docs/conf/portland/2022/cfp.rst
@@ -1,0 +1,186 @@
+:template: {{year}}/generic.html
+
+Call for Proposals
+==================
+
+Hello hello, fellow documentarians! It's that time of year again: We’re very excited to announce that we are now accepting talk proposals for our next {{ city }} conference, coming up on {{date.main}}. We're running a `hybrid conference <https://www.writethedocs.org/conf/portland/2022/news/welcome/>`__ this year, so you can speak or attend from anywhere, but folks will also be there in person in {{ city }}. We will use regular {{ city }} conference times for the scheduling.
+
+.. note::
+    For speakers this means you'll be writing and recording talk before the event, as if for our virtual conference. And we'll have a videographer around to help with that if you want it. we're working on the exact details of a moderated remote live Q&A after your talk.
+
+Every year, Write the Docs invites people from all across our community to come up on stage to share their insights and experience. Whether you've worked on documentation for decades or you've just started this year, we want to hear from you!
+Read on to learn more about the goals of the conference and what we look for in talk proposals.
+
+{% if flagcfp %}
+In the meantime, mark your calendars:
+
+**The deadline for submitting proposals is Midnight {{tz}} on {{cfp.ends}}.**
+
+We'll let you know if your proposal has been accepted by the end of {{cfp.notification}}.
+{% else %}
+We will announce the CFP soon.
+{% endif %}
+
+.. contents::
+    :local:
+    :depth: 1
+    :backlinks: none
+
+Ready to submit your talk?
+You can do that here:
+
+.. raw:: html
+
+    <div class="announcement" style="background-color:white;">
+        <div class="uk-container">
+        <a style="border-bottom: none; font-size: .875rem;" class="uk-button uk-button-announcement uk-text-center" href="{{ cfp.url }}">Submit your proposal</a>
+        </div>
+    </div>
+
+Conference goals
+----------------
+
+Write the Docs conferences are our chance to get together to explore and celebrate the craft of documentation in a positive, inclusive environment.
+
+Between the talks on stage, the discussions in the unconference, the collaboration on the writing day and other conversations, 100% of the content for our conferences comes from our community! Whether your job title is writer, developer, product manager, support advocate, librarian, or one of a hundred others, your perspective on what makes good docs is what this conference is all about.
+
+Our goal is to give documentarians a chance to connect and learn from each other. You'll have the chance to compare notes on what's happening in the industry, dig into questions of convention and good practice, and generally nerd out about all the things we love about documentation.
+
+This year, as usual, we're trying to iterate on our tried and tested processes, both to improve our program and to give you, the speakers, a better idea of what to expect.
+
+Who we're looking for
+---------------------
+
+The short description here is "if you care about documentation and have something to say about it, we want you to speak"!
+
+That said, there are some more helpful and concrete pointers below.
+
+**Diverse group of speakers**
+
+We welcome talks from first-time speakers, from industry experts, and from everyone in between.
+Whatever your background and experience, we prefer hearing about new approaches rather than about tried-and-tested technology.
+We especially welcome talks from underrepresented groups within the tech community.
+We want to hear a variety of viewpoints, so we limit speakers to two talks in any four year period at each location.
+If you're a WTD conference organizer, please only submit talks to conferences you're not actively organizing.
+
+**Mix of roles and perspectives**
+
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+
+**Diverse audience**
+
+Likewise, we love the diversity of our community, and we encourage support-folks to attend talks about programming, developers to attend talks about writing, writers to attend talks about data, and so on and so forth.
+
+**Past speakers**
+
+Past speaker roles include but are not limited to
+
+* Writers
+* Developers
+* Designers
+* Testers
+* Support folks
+* Developer advocates
+* Community managers
+* Scientists
+* Librarians
+* Teachers
+
+What we’re looking for
+----------------------
+
+**Diverse topics**
+
+The focus of Write the Docs is software documentation, but we actively seek talks that address a wide range of related subjects, at various levels of expertise.
+Documentation perspectives from other fields are welcome, as are topics from adjacent fields!
+
+**Practicality and positivity**
+
+We prefer talks backed by experience and experimentation to talks about theory, and we definitely don't like talks that bad-mouth technologies or approaches.
+Don't tell us why you hate something – tell us how you overcame the problems it was causing.
+
+**Process over tooling**
+
+We tend to avoid talks about specific tools, which often turn into marketing pitches or tutorials.
+We would much rather hear about process, culture, data, people, or the metaphysical side effects of spending your life thinking about docs.
+
+**Audience awareness**
+
+When crafting talk proposals, remember that you're going to be talking to a mix of levels of expertise, skill sets, and professions.
+Your talk doesn't have to be relevant to everyone, but it should be relevant to most people and shouldn't make too many assumptions about what people already know.
+If you are making those assumptions about what your audience knows, it helps everyone if you state them up front explicitly.
+
+It can be  helpful to check out topics that might be related to your talk from previous years as well:
+
+* `Portland {{year-1}} <https://www.writethedocs.org/conf/portland/{{year-1}}/speakers/>`_
+* `Prague {{year-1}} <https://www.writethedocs.org/conf/prague/{{year-1}}/speakers/>`_
+* `Portland {{year-2}} <https://www.writethedocs.org/conf/portland/{{year-2}}/speakers/>`_
+* `Prague {{year-2}} <https://www.writethedocs.org/conf/prague/{{year-2}}/speakers/>`_
+
+Not sure about speaking?
+------------------------
+
+Don't worry too much about whether we will accept your talk proposal, just submit it anyway, and leave the selection up to us. Just because you're not sure whether your topic is a good fit, feel you don't have enough speaking experience for a conference, or you think someone else may be able to give a better talk on your topic does not mean you don't have awesome things to say.
+
+If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
+
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `http://slack.writethedocs.org/ <http://slack.writethedocs.org/>`_.)
+* **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
+
+Because the conference is virtual this year, there is no need for travel, and we're hoping this will make our CFP accessible to more documentarians. We will also provide resources and support for recording your talk.
+
+Selection process
+------------------
+
+We have a small panel of proposal reviewers, and make sure to have a similar diversity in the panel as we're aiming for in our speakers.
+We rate talks out of five, and then discuss the top rated proposals.
+
+We actively balance for diversity in as many ways as we can, which means that we do not review talks anonymously. Maybe one day the industry will be in a place where can do that, but we're certainly not there yet.
+
+Presentation format
+-------------------
+
+Presentations will be scheduled in 30-minute blocks. As the conference is virtual, all talks will be pre-recorded. We will offer resources and support for making your talk recording. After your talk, there will be a live Q&A session. You can opt out of the Q&A if you do not feel comfortable, but please let us know well in advance.
+
+Speaker benefits & logistics
+----------------------------
+
+If you are selected to speak at Write the Docs, we will waive your attendance fee. As the conference is virtual, there are no travel costs.
+If speaking incurs any costs that are difficult for you to cover, please `let us know <mailto:{{email}}>`_ and we'll do our best to help out.
+
+If you already have a ticket, we will of course refund it - just drop us an email at `{{email}} <mailto:{{email}}>`_.
+
+{% if flagcfp %}**You’ll hear from us with our proposal decisions by the end of {{cfp.notification}}.**{% endif %}
+
+All talks will be shown prerecorded, and we'll be asking for a **completed video from you by {{cfp.video_by}}**. We have a host of options to support you in making this happen, including the possibility of a live recording call with our videographer. During the conference we'll ask you to participate in a moderated Q&A video session after your talk recording is shown.
+
+Note that all Speakers must read, understand, and agree to our :doc:`/code-of-conduct`. All talks and slides will need to follow our Code of Conduct. If you are unsure about any aspect of this, please ask us for clarification.
+
+Example proposal
+----------------
+
+If you'd like some guidance on how to create a talk proposal, take a look at our :doc:`Example proposal <example-proposal>`.
+
+Questions?
+----------
+
+If you have any questions, please email us at `{{email}} <mailto:{{email}}>`_ and let us know.
+
+{% if flagcfp %}
+
+Submit your proposal
+--------------------------
+
+Submit your proposal at {{cfp.url}}. You'll need to sign up for a Pretalx account, unless you already have one from a previous conference.
+
+.. raw:: html
+
+    <div class="announcement" style="background-color:white;">
+        <div class="uk-container">
+        <a style="border-bottom: none; font-size: .875rem;" class="uk-button uk-button-announcement uk-text-center" href="{{ cfp.url }}">Submit your proposal</a>
+        </div>
+    </div>
+
+{% endif %}

--- a/docs/conf/portland/2022/cfp.rst
+++ b/docs/conf/portland/2022/cfp.rst
@@ -5,8 +5,7 @@ Call for Proposals
 
 Hello hello, fellow documentarians! It's that time of year again: We’re very excited to announce that we are now accepting talk proposals for our next {{ city }} conference, coming up on {{date.main}}. We're running a `hybrid conference <https://www.writethedocs.org/conf/portland/2022/news/welcome/>`__ this year, so you can speak or attend from anywhere, but folks will also be there in person in {{ city }}. We will use regular {{ city }} conference times for the scheduling.
 
-.. note::
-    For speakers this means you'll be writing and recording talk before the event, as if for our virtual conference. And we'll have a videographer around to help with that if you want it. we're working on the exact details of a moderated remote live Q&A after your talk.
+    For speakers this means you'll be writing and recording your talk *before the event*, the same as for our virtual conference. We'll have a videographer around to help with that if you want it. we're working on the exact details of a moderated remote live Q&A after your talk.
 
 Every year, Write the Docs invites people from all across our community to come up on stage to share their insights and experience. Whether you've worked on documentation for decades or you've just started this year, we want to hear from you!
 Read on to learn more about the goals of the conference and what we look for in talk proposals.

--- a/docs/conf/portland/2022/cfp.rst
+++ b/docs/conf/portland/2022/cfp.rst
@@ -3,7 +3,7 @@
 Call for Proposals
 ==================
 
-Hello hello, fellow documentarians! It's that time of year again: We’re very excited to announce that we are now accepting talk proposals for our next {{ city }} conference, coming up on {{date.main}}. We're running a `hybrid conference <https://www.writethedocs.org/conf/portland/2022/news/welcome/>`__ this year, so you can speak or attend from anywhere, but folks will also be there in person in {{ city }}. We will use regular {{ city }} conference times for the scheduling.
+Hello hello, fellow documentarians! It's that time of year again: We’re very excited to announce that we are now accepting talk proposals for our next {{ city }} conference, coming up on {{date.main}}. We're running a `hybrid conference <https://www.writethedocs.org/conf/portland/2022/news/welcome/>`__ this year, so you can speak or attend from anywhere, but folks will also be there in person in {{ city }}. Schedules will be in {{ tz }}.
 
     For speakers, this means you'll be writing and recording your talk *before the event*, the same as for our virtual conference. Our video producer will be available to help with recording if you want it. We're working on the exact details of a moderated remote live Q&A after your talk.
 

--- a/docs/conf/portland/2022/cfp.rst
+++ b/docs/conf/portland/2022/cfp.rst
@@ -5,7 +5,7 @@ Call for Proposals
 
 Hello hello, fellow documentarians! It's that time of year again: We’re very excited to announce that we are now accepting talk proposals for our next {{ city }} conference, coming up on {{date.main}}. We're running a `hybrid conference <https://www.writethedocs.org/conf/portland/2022/news/welcome/>`__ this year, so you can speak or attend from anywhere, but folks will also be there in person in {{ city }}. We will use regular {{ city }} conference times for the scheduling.
 
-    For speakers this means you'll be writing and recording your talk *before the event*, the same as for our virtual conference. We'll have a videographer around to help with that if you want it. we're working on the exact details of a moderated remote live Q&A after your talk.
+    For speakers, this means you'll be writing and recording your talk *before the event*, the same as for our virtual conference. Our video producer will be available to help with recording if you want it. We're working on the exact details of a moderated remote live Q&A after your talk.
 
 Every year, Write the Docs invites people from all across our community to come up on stage to share their insights and experience. Whether you've worked on documentation for decades or you've just started this year, we want to hear from you!
 Read on to learn more about the goals of the conference and what we look for in talk proposals.
@@ -41,7 +41,7 @@ Conference goals
 
 Write the Docs conferences are our chance to get together to explore and celebrate the craft of documentation in a positive, inclusive environment.
 
-Between the talks on stage, the discussions in the unconference, the collaboration on the writing day and other conversations, 100% of the content for our conferences comes from our community! Whether your job title is writer, developer, product manager, support advocate, librarian, or one of a hundred others, your perspective on what makes good docs is what this conference is all about.
+Between the talks on the stage, the discussions in the unconference, the collaboration on the writing day and other conversations, 100% of the content for our conferences comes from our community! Whether your job title is writer, developer, product manager, support advocate, librarian, or one of a hundred others, your perspective on what makes good docs is what this conference is all about.
 
 Our goal is to give documentarians a chance to connect and learn from each other. You'll have the chance to compare notes on what's happening in the industry, dig into questions of convention and good practice, and generally nerd out about all the things we love about documentation.
 
@@ -128,7 +128,7 @@ If you need a hand preparing or honing your talk proposal, there are lots of goo
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `http://slack.writethedocs.org/ <http://slack.writethedocs.org/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 
-Because the conference is virtual this year, there is no need for travel, and we're hoping this will make our CFP accessible to more documentarians. We will also provide resources and support for recording your talk.
+ecause the talks are pre-recorded, you can submit your proposal even if you can't attend in person! We will use our virtual conference platform to allow folks to attend from home globally, and we hope that this will make our CFP accessible to more documentarians. We will also provide resources and support for recording your talk.
 
 Selection process
 ------------------
@@ -141,21 +141,21 @@ We actively balance for diversity in as many ways as we can, which means that we
 Presentation format
 -------------------
 
-Presentations will be scheduled in 30-minute blocks. As the conference is virtual, all talks will be pre-recorded. We will offer resources and support for making your talk recording. After your talk, there will be a live Q&A session. You can opt out of the Q&A if you do not feel comfortable, but please let us know well in advance.
+Presentations will be scheduled in 30-minute blocks, so your recording needs to fit within that time slot. After your talk, there will be a live Q&A session. You can opt out of the Q&A if you do not feel comfortable, but please let us know well in advance.
 
 Speaker benefits & logistics
 ----------------------------
 
-If you are selected to speak at Write the Docs, we will waive your attendance fee. As the conference is virtual, there are no travel costs.
-If speaking incurs any costs that are difficult for you to cover, please `let us know <mailto:{{email}}>`_ and we'll do our best to help out.
+If you are selected to speak at Write the Docs, we will waive your ticket cost. If you attend virtually, there are no travel costs.
+If you want to attend in person or if speaking incurs any costs that are difficult for you to cover, please `let us know <mailto:{{email}}>`_ and we'll do our best to help out.
 
 If you already have a ticket, we will of course refund it - just drop us an email at `{{email}} <mailto:{{email}}>`_.
 
 {% if flagcfp %}**You’ll hear from us with our proposal decisions by the end of {{cfp.notification}}.**{% endif %}
 
-All talks will be shown prerecorded, and we'll be asking for a **completed video from you by {{cfp.video_by}}**. We have a host of options to support you in making this happen, including the possibility of a live recording call with our videographer. During the conference we'll ask you to participate in a moderated Q&A video session after your talk recording is shown.
+All talks will be shown pre-recorded, and we'll be asking for a **completed video from you by {{cfp.video_by}}**. We have a host of options to support you in making this happen, including the possibility of a live recording call with our videographer. During the conference we'll ask you to participate in a moderated Q&A video session after your talk recording is shown.
 
-Note that all Speakers must read, understand, and agree to our :doc:`/code-of-conduct`. All talks and slides will need to follow our Code of Conduct. If you are unsure about any aspect of this, please ask us for clarification.
+Note that all speakers must read, understand, and agree to our :doc:`/code-of-conduct`. All talks and slides will need to follow our Code of Conduct. If you are unsure about any aspect of this, please ask us for clarification.
 
 Example proposal
 ----------------

--- a/docs/conf/portland/2022/cfp.rst
+++ b/docs/conf/portland/2022/cfp.rst
@@ -13,7 +13,7 @@ Read on to learn more about the goals of the conference and what we look for in 
 {% if flagcfp %}
 In the meantime, mark your calendars:
 
-**The deadline for submitting proposals is Midnight {{tz}} on {{cfp.ends}}.**
+**The deadline for submitting proposals is midnight {{tz}} on {{cfp.ends}}.**
 
 We'll let you know if your proposal has been accepted by the end of {{cfp.notification}}.
 {% else %}

--- a/docs/conf/portland/2022/cfp.rst
+++ b/docs/conf/portland/2022/cfp.rst
@@ -13,7 +13,7 @@ Read on to learn more about the goals of the conference and what we look for in 
 {% if flagcfp %}
 In the meantime, mark your calendars:
 
-**The deadline for submitting proposals is midnight {{tz}} on {{cfp.ends}}.**
+**The deadline for submitting proposals is 11:59PM {{tz}} on {{cfp.ends}}.**
 
 We'll let you know if your proposal has been accepted by the end of {{cfp.notification}}.
 {% else %}

--- a/docs/conf/portland/2022/contact.rst
+++ b/docs/conf/portland/2022/contact.rst
@@ -1,0 +1,10 @@
+
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/team.png
+
+Contact Us
+==========
+
+If you have any questions or concerns,
+the best way to reach us is via email.
+You can email us at {{ shortcode }}@writethedocs.org.

--- a/docs/conf/portland/2022/convince-your-manager.rst
+++ b/docs/conf/portland/2022/convince-your-manager.rst
@@ -1,0 +1,57 @@
+:template: {{year}}/generic.html
+
+Convince Your Manager
+=====================
+
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
+Feel free to adapt and share with your manager to show them the many benefits of attending!
+
+Sample email
+-------------
+
+Remember to change the things in `[brackets]`!
+
+----
+
+  FROM: [your name]
+
+  TO: [your employer or manager's name]
+
+  SUBJECT: Professional Development: Documentation Community Conference
+
+  I'd like to attend Write the Docs {{city}}, which takes place {{ date.main }}. This three-day online event explores the art and science of documentation, and covers a diverse range of topics related to documentation in the software industry.
+
+  Write the Docs conferences bring together everyone who writes the docs – Tech Writers, Developers, Developer Relations, Customer Support – making the events an ideal networking opportunity.
+  Each conference successfully combines a number of different event formats to deliver engaging, practical, and timely content.
+
+  There is a single track of talks, a parallel unconference event, and a community writing day. The `sessions from last year </conf/{{ shortcode }}/{{year-1}}/speakers/>`_ will give you a good idea of the kinds of topics covered, many of which are relevant to my work.
+
+  Costs:
+
+  * Conference ticket - {{tickets.corporate.price}}
+
+  Benefits:
+
+  * Discovering solutions to problems I'm facing at work
+  * Exposure to the latest ideas, techniques, and tools for software docs
+  * Opportunity to learn from the best doc teams in the industry
+  * Building professional connections with other documentarians
+
+  Thanks in advance,
+  [your name]
+
+----
+
+Resources
+---------
+
+When discussing how to pitch the conference, a few generally helpful tips emerged:
+
+* Highlight a few specific talks that relate to ongoing projects at work. (This one's dependent on pitching after the talk line up has been announced).
+* If your company is looking to hire another documentarian, the job fair and networking at the event are an excellent resource.
+* Don't forget that one of the benefits to your attendance is that it raises the visibility of your company in the community. If your team wants a reputation for caring about their docs, having people at Write the Docs is a great way to do that.
+
+In addition, it can be useful to share some info about previous conferences. You can find the websites for previous events on :doc:`/conf/index/`, and a quick list of last year's talks down below.
+But perhaps more useful might be some of the info in our :doc:`press-kit/`, which includes community testimonials, photos, and more.
+

--- a/docs/conf/portland/2022/example-proposal.rst
+++ b/docs/conf/portland/2022/example-proposal.rst
@@ -1,0 +1,60 @@
+:template: {{year}}/generic.html
+
+Example talk proposal title
+===========================
+
+Substitute a catchy title that promises practical lessons
+
+Abstract
+--------
+
+This is the content that Write the Docs would post on the conference schedule. To evaluate the quality of your proposal, the proposal committee also takes into account all of the other information that you provide.
+
+Include a brief story, typically two to four paragraphs, that describes your personal work experience with the topic. Make sure the abstract appeals to our audience of documentarians. We're suspicious of proposals that look like they belong at other conferences.
+
+Include a list of things that our audience can learn from your talk, such as:
+
+- Lessons that the audience can apply in their own work
+- Things that audiences should research further
+- Spoilers that provide details about the talk
+
+Help your audience think: "Oh yes, this talk could help me when I do X in my work!"
+
+Avoid walls of text. We recommend that you limit your proposal to a maximum of 300 words. If your proposal is accepted, this is what the audience will see in the program when they preview your talk.
+
+Who and Why
+-----------
+
+Use this opportunity to show the selection committee that you empathize with your audience. Help them think: "Oh yes, this talk could help me when I do X in my work!"
+
+Our audience creates documentation primarily for software. Given the variety of tools used for software documentation, we rarely accept talks that focus on a specific software tool or set of tools. Talks that discuss tools should also discuss the wider context, applications, and implications of implementing the tools.
+
+Our audience goes beyond the technical writing community. Here's a typical demographic distribution of people who attend our conferences:
+
+* Technical Writers (60%)
+* Developers (10%)
+* Support Staff (10%)
+* Managers (10%)
+* Community Contributors, Enthusiasts & Other Folks (10%)
+
+Only the proposal committee will see the information that you include here.
+ 
+Other Information
+-----------------
+
+Based on your background, use this section to describe your qualifications to the selection committee.
+
+We welcome talks from first-time speakers, from industry experts, and from everyone in between. Whatever your background and experience, we prefer hearing about new approaches rather than about tried-and-tested technology. We especially welcome talks from underrepresented groups within the tech community.
+
+We've accepted talks from people who work in a variety of roles, including:
+
+* Writers
+* Developers
+* Designers
+* Testers
+* Support
+* Developer advocates
+* Community managers
+* Scientists
+* Librarians
+* Teachers

--- a/docs/conf/portland/2022/hike.rst
+++ b/docs/conf/portland/2022/hike.rst
@@ -1,0 +1,78 @@
+:template: {{year}}/generic.html
+
+Write the Docs Hike
+===================
+
+Every year we have a conference hike, and at this point it's a fantastic tradition.
+We'll be doing the same hike again this year, because it's the best one easily accessible from downtown Portland.
+
+It's rained on us the past, but we have faith it will be beautiful this year! We shall see Mount Hood at the top :)
+
+Logistics
+---------
+
+.. **You can get your hike ticket here**: FIXME
+
+Tickets will be available from April 2020.
+
+- Date & Time: Leaves promptly at **Saturday, August 8, 2 PM**. Meet at **1:45**.
+- Duration: The hike normally takes around 3 hours. Along with transportation back to Portland, allow for up to 4 hours total, returning at 6pm.
+- Start: **Lower Macleay Park** (`Google Map <https://www.google.com/maps/place/Lower+Macleay+Park/@45.5359671,-122.7147082,17z/data=!3m1!4b1!4m5!3m4!1s0x549509e9f2adf02d:0x1b3668a7adc941d9!8m2!3d45.5359671!4d-122.7125142>`__. There is a pavilion at the park entrance where we will gather.
+- End: **Oregon Zoo** -- There is a MAX stop here to take us back downtown.
+- `Visual of the hike <https://maps.google.com/maps?saddr=MacLeay+Park+Entrance,+NW+Upshur+St,+Portland,+OR&daddr=45.527373,-122.718589+to:45.5225885,-122.717297+to:oregon+zoo&hl=en&ll=45.52448,-122.717757&spn=0.023933,0.032358&sll=45.522345,-122.712822&sspn=0.023934,0.032358&geocode=FYLStgIdMI6v-CGojI77DIHw4SnVqz2N6QmVVDGojI77DIHw4Q%3BFU2xtgIdg3av-CmRNoxzkQmVVDFxAN8jMh2eKQ%3BFZyetgIdj3uv-CnD2fb_jgmVVDHuWX9DnHsevQ%3BFZpttgIdAoGv-CEm_N2esCDn5ykFuFa4LgqVVDEm_N2esCDn5w&oq=macleay+park&gl=us&dirflg=w&mra=dpe&mrsp=2&sz=15&via=1,2&t=m&z=15>`__
+- **The hike is for conference attendees only**. We only have a limited number of spaces, so please don't bring non-attendees along.
+
+We will be hiking in the amazing `Forest Park <http://www.forestparkconservancy.org/>`__, the largest urban forested park in the country.
+It is conveniently located in Northwest Portland, not far from the conference venue. It's about a 35 minute walk
+from the venue to the park, or you can `take transit <https://www.google.com/maps/dir/Crystal+Ballroom,+1332+W+Burnside+St,+Portland,+OR+97209,+United+States/MacLeay+Park+Entrance,+Northwest+Upshur+Street,+Portland,+OR/@45.5290603,-122.707244,15z/data=!3m1!4b1!4m14!4m13!1m5!1m1!1s0x54950a02e43decb9:0xe289ad93ad758c66!2m2!1d-122.68483!2d45.522785!1m5!1m1!1s0x549509e98d3dabd5:0xe1f0810cfb8e8ca8!2m2!1d-122.712528!2d45.535874!3e3?hl=en>`__ to make it a bit quicker.
+
+
+What to bring
+~~~~~~~~~~~~~
+
+August in Portland can be interesting. It will probably be in the 60s, with a chance of rain. So, please bring:
+
+- Comfortable shoes, that you are comfortable getting a bit muddy.
+- 1 Liter of water. There is water available halfway through the hike.
+- A light rain jacket. It won't be cold, but it might drizzle on you.
+- High spirits!
+
+The hike
+--------
+
+The hike will be around 5 miles long, and have 1000 feet of elevation gain.
+This classifies as a *moderate* hike. We'll be going nice and slow so people can appreciate the views and forest.
+
+Meander
+~~~~~~~
+
+The hike will follow Balch Creek up from the entrance of `Forest Park <http://www.forestparkconservancy.org/>`__.
+
+.. figure:: /_static/img/2015/hike/balch.jpg
+   :alt: Balch Creek
+
+   Balch Creek
+
+Climb
+~~~~~
+
+Then we will switchback through beautiful forest until we get to Pittock Mansion.
+Pittock affords one of the best views of the city, and hopefully Mt. Hood & Mt. St. Helens if it's clear!
+
+.. figure:: /_static/img/2015/hike/pittock.jpg
+   :alt: The view from Pittock Mansion
+
+   The view from Pittock Mansion
+
+Admire
+~~~~~~
+
+After this we will descend into `Washington Park <http://washingtonparkpdx.org/>`__, and the beautiful `Hoyt Arboretum <http://www.hoytarboretum.org/>`__.
+There are a number of paths through Hoyt, and we can play that by ear.
+More than 5,800 specimens from around the world grow here, including more than 1,100 species, which are valuable in reforesting damaged habitats.
+
+Finish
+~~~~~~
+
+On the other side of Hoyt is the `Oregon Zoo <http://www.oregonzoo.org/>`__, where we can take the MAX back to downtown.
+People who wish to stay around in the park or zoo are more than welcome.

--- a/docs/conf/portland/2022/hike.rst
+++ b/docs/conf/portland/2022/hike.rst
@@ -11,12 +11,10 @@ It's rained on us the past, but we have faith it will be beautiful this year! We
 Logistics
 ---------
 
-.. **You can get your hike ticket here**: FIXME
+**WARNING: This hike has been modified this year because of construction on the Wildwood trail. Instead of ending at the Zoo, we are doing an "out and back" hike to Pittock Mansion, which will start and end at the same location.**
 
-Tickets will be available from April 2020.
-
-- Date & Time: Leaves promptly at **Saturday, August 8, 2 PM**. Meet at **1:45**.
-- Duration: The hike normally takes around 3 hours. Along with transportation back to Portland, allow for up to 4 hours total, returning at 6pm.
+- Date & Time: Leaves promptly at **Sunday, May 22, 1 PM**.
+- Duration: The hike normally takes around 3 hours. Along with transportation back to Portland, allow for up to 4 hours total.
 - Start: **Lower Macleay Park** (`Google Map <https://www.google.com/maps/place/Lower+Macleay+Park/@45.5359671,-122.7147082,17z/data=!3m1!4b1!4m5!3m4!1s0x549509e9f2adf02d:0x1b3668a7adc941d9!8m2!3d45.5359671!4d-122.7125142>`__. There is a pavilion at the park entrance where we will gather.
 - End: **Oregon Zoo** -- There is a MAX stop here to take us back downtown.
 - `Visual of the hike <https://maps.google.com/maps?saddr=MacLeay+Park+Entrance,+NW+Upshur+St,+Portland,+OR&daddr=45.527373,-122.718589+to:45.5225885,-122.717297+to:oregon+zoo&hl=en&ll=45.52448,-122.717757&spn=0.023933,0.032358&sll=45.522345,-122.712822&sspn=0.023934,0.032358&geocode=FYLStgIdMI6v-CGojI77DIHw4SnVqz2N6QmVVDGojI77DIHw4Q%3BFU2xtgIdg3av-CmRNoxzkQmVVDFxAN8jMh2eKQ%3BFZyetgIdj3uv-CnD2fb_jgmVVDHuWX9DnHsevQ%3BFZpttgIdAoGv-CEm_N2esCDn5ykFuFa4LgqVVDEm_N2esCDn5w&oq=macleay+park&gl=us&dirflg=w&mra=dpe&mrsp=2&sz=15&via=1,2&t=m&z=15>`__
@@ -30,7 +28,7 @@ from the venue to the park, or you can `take transit <https://www.google.com/map
 What to bring
 ~~~~~~~~~~~~~
 
-August in Portland can be interesting. It will probably be in the 60s, with a chance of rain. So, please bring:
+May in Portland can be interesting. It will probably be in the 60s, with a chance of rain. So, please bring:
 
 - Comfortable shoes, that you are comfortable getting a bit muddy.
 - 1 Liter of water. There is water available halfway through the hike.

--- a/docs/conf/portland/2022/hike.rst
+++ b/docs/conf/portland/2022/hike.rst
@@ -11,9 +11,7 @@ It's rained on us the past, but we have faith it will be beautiful this year! We
 Logistics
 ---------
 
-**WARNING: This hike has been modified this year because of construction on the Wildwood trail. Instead of ending at the Zoo, we are doing an "out and back" hike to Pittock Mansion, which will start and end at the same location.**
-
-- Date & Time: Leaves promptly at **Sunday, May 22, 1 PM**.
+- Date & Time: Leaves promptly at **{{ hike.date }}**.
 - Duration: The hike normally takes around 3 hours. Along with transportation back to Portland, allow for up to 4 hours total.
 - Start: **Lower Macleay Park** (`Google Map <https://www.google.com/maps/place/Lower+Macleay+Park/@45.5359671,-122.7147082,17z/data=!3m1!4b1!4m5!3m4!1s0x549509e9f2adf02d:0x1b3668a7adc941d9!8m2!3d45.5359671!4d-122.7125142>`__. There is a pavilion at the park entrance where we will gather.
 - End: **Oregon Zoo** -- There is a MAX stop here to take us back downtown.
@@ -28,7 +26,7 @@ from the venue to the park, or you can `take transit <https://www.google.com/map
 What to bring
 ~~~~~~~~~~~~~
 
-May in Portland can be interesting. It will probably be in the 60s, with a chance of rain. So, please bring:
+Weather in Portland can be interesting. It will probably be in the 60s, with a chance of rain. So, please bring:
 
 - Comfortable shoes, that you are comfortable getting a bit muddy.
 - 1 Liter of water. There is water available halfway through the hike.

--- a/docs/conf/portland/2022/job-fair.rst
+++ b/docs/conf/portland/2022/job-fair.rst
@@ -1,0 +1,39 @@
+:template: {{year}}/generic.html
+
+Job Fair
+========
+
+Connecting people with potential employers has always been a core benefit of attending Write the Docs, so we're excited to introduce some more structure to that connection.
+
+Documentarians looking for jobs will be able to talk to employers to learn about the company culture, ask about specific job openings, and talk to current employees.
+
+If you're an employer looking to fill a role, you can find information about :doc:`reserving a job fair spot <sponsors/prospectus/>` in the sponsorship prospectus.
+
+
+Schedule
+--------
+
+Scheduling information is available on our :doc:`/conf/{{shortcode}}/{{year}}/schedule` page.
+
+
+Tips for Attendees
+------------------
+
+If you're attending the Virtual Job Fair, make sure you're signed in to Hopin.
+
+* Select Expo in the left-hand pane.
+* Select the company of your choice.
+* You now have the following choices:
+
+  * Chat with attendees from the company under the Chat tab.
+  * Select the button to "Share Audio and Video". You can then chat "Face to Face" with company representatives.
+
+Tips for Sponsors
+-----------------
+
+If you want to maximize your contacts with potential new employees, make sure to:
+
+* Make sure your booth staff is registered in the online platform before the conference starts. All sponsor ticket holders will receive details about this a few days before the conference. These staff will be set up as moderators for your booth. As needed, you can also request additional moderators from the designated conference Job Fair volunteer.
+* When you're a moderator, you can always share your audio and video. Other attendees who want to "Share Audio and Video" will appear under the "Moderator Panel" at the bottom of the screen. When you select one or more persons, they'll join you in the video chat.
+
+You can also select users for 1:1 chats.

--- a/docs/conf/portland/2022/job-fair.rst
+++ b/docs/conf/portland/2022/job-fair.rst
@@ -13,6 +13,10 @@ If you're an employer looking to fill a role, you can find information about :do
 Schedule
 --------
 
+{% if not flaghasschedule %}
+**WARNING**: The conference schedule has not been finalized and is subject to major changes.
+{% endif %}
+
 Scheduling information is available on our :doc:`/conf/{{shortcode}}/{{year}}/schedule` page.
 
 

--- a/docs/conf/portland/2022/lightning-talks.rst
+++ b/docs/conf/portland/2022/lightning-talks.rst
@@ -1,0 +1,86 @@
+:template: {{year}}/generic.html
+
+Lightning Talks
+===============
+
+A lightning talk is a very short talk, up to 5 minutes, where you share an idea, concept, or a bit of information you find interesting.
+They’re quick, easy, and a great way to speak in front of an audience for the first time.
+Lightning talks allow people to discuss topics that were not covered fully or partially at the conference.
+
+Logistics
+---------
+
+**We're still planning to have plenty of lightning talks in the new online format, and are working on the exact details.**
+
+We have two categories for people who submit talks:
+
+* First-time speakers
+* Experienced speakers
+
+We do this so we have a mix of first time and experienced speakers.
+We also want first-time speakers to know that we care about them having a chance to get on stage.
+
+{% if lightning_talks and lightning_talks.signup_url %}
+**You can sign up for lightning talks each day of the conference** `on our Google Form <{{ lightning_talks.signup_url }}>`_.
+{% endif %}
+
+Planning: What goes into a lightning talk?
+------------------------------------------
+
+A lightning talk should be about **five minutes long**, just long enough to give an overview and make people curious about your topic. You can talk about anything that’s related to the event’s general theme (in the case of Write the Docs, anything even remotely related to documentation).
+
+First, you need a **topic**. Your topic might be:
+
+- A concept, process, or tool that you learned recently or are still learning
+- An idea for a website or product that would solve a problem you have
+- A retrospective, or what went right/wrong during a project you did or are doing
+- Anything relevant that the audience might be interested in knowing more about
+
+Next, you need an **outline** for the content. Think about the **audience**, and the **goal** of your talk. Choose points to make that will be understandable by the audience and achieve your presentation goal. Remember how quickly five minutes goes by when choosing what to include!
+
+Potential **points of interest** might be:
+
+- What could you use this for or when could you use it? Have you already used it? How?
+- When wouldn't it not be as useful? What are some contraindications to using it?
+- Resources related to the subject, including books, documentation, and URLs.
+- Are there any projects or companies that are using what you're sharing?
+- Is this something you'd like to collaborate with others on? Feel free to ASK!
+- What are some of the challenges related to using, building, or configuring what you're showing?
+
+Preparation: Slides are optional
+--------------------------------
+
+You absolutely don’t need slides. However, if you’d like to make slides, use anything that you are comfortable with.
+Don’t worry if it doesn’t look polished, lightning talks don’t need to be!
+You might use Microsoft Word, Keynote, a PDF, or a website.
+Even a simple terminal or console window where you enter commands can work well for presenting your ideas.
+
+If you're running code examples, have them written, debugged, and ready to go.
+Watching someone write code as they go can be great in a longer deep-dive type of talk, but it's not very well-suited to a lightning talk.
+
+Live Demos: Proceed at your own risk
+------------------------------------
+
+You may have the urge to do a live demonstration of the thing you’re talking about.
+It seems like an easy way to help the audience see your vision, and it is… if it works!
+Following Murphy’s Law, however, we can deduce that your live demo will go horribly wrong.
+A failed demo can derail all but the most skilled presenters, but if you choose to do a demo and it goes wrong don’t worry!
+Have a backup story to tell that explains what the demo would have shown and revert to it if necessary.
+
+Presenting: Your own five Minutes on stage!
+-------------------------------------------
+
+Take a deep breath and go for it. You are among friends, and nobody will mind if you make mistakes.
+Almost everyone starts out their public speaking career in the tech industry by giving lightning talks, so you can assume your audience has been in your shoes before. Throw caution to the wind and embrace your five minutes! :)
+
+Finishing up
+------------
+
+Curious people may follow up with you if they’d like to collaborate or have feedback about your presentation.
+
+License
+-------
+
+Thanks to the lovely Portland Python Users Group for use of this content.
+
+Lightning Talks: A Guide for Beginners by Michelle Rowley of PDX Python is licensed under a `Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License <http://creativecommons.org/licenses/by-nc-sa/4.0/>`__.

--- a/docs/conf/portland/2022/news/announcing-cfp.rst
+++ b/docs/conf/portland/2022/news/announcing-cfp.rst
@@ -1,0 +1,48 @@
+:template: {{year}}/generic.html
+
+.. post:: Jan 10, 2022
+   :tags: {{shortcode}}-{{year}}, website, cfp, tickets
+
+Announcing Call for Proposals
+=============================
+
+Today we are announcing our `Call for Proposals <https://www.writethedocs.org/conf/portland/{{year}}/cfp/>`_.
+
+Speaking at Write the Docs is a fantastic way to share your ideas with our inspiring community of documentarians.
+If there is something you’d really like to see a talk on this year, submit a proposal on it, or refer someone else who would be good!
+
+Call for Proposals
+------------------
+
+Every year, Write the Docs invites people from all across our community to come up on stage to share their insights and experience.
+We're looking for ideas and use-cases from all disciplines and roles, so whether you're a technical writer, developer, UX designer, community manager, or support professional who cares about content and communication, we want to hear from you!
+
+**All talks will be pre-recorded and you can present and attend from anywhere!** This year we are holding a hybrid event, and in order to maintain accessibility for folks who are unable to travel, we are going to broadcast the talks both on the stage in the venue and in Hopin, our virtual conference program.
+
+You can read our full `Call for Proposals <https://www.writethedocs.org/conf/portland/{{year}}/cfp/>`__ on the website.
+
+The Call for Proposals will be open until **Midnight {{cfp.ends}} PST**.
+
+Tickets
+-------
+
+Tickets will officially go on sale towards the end of **January 2021**.
+
+We are working out the final details on the conference format and the different price tiers for in-person and virtual tickets. 
+
+As always, we keep ticket prices low so that the event is accessible to the widest range of people possible.
+However, if you can't afford the tickets and still wish to attend, we will launch our grants program soon after opening ticket sales.
+
+Stay Updated
+------------
+
+Want to find out what's happening with the conference, or enjoy our monthly global community newsletter?
+Sign up to one or more of our `mailing lists <http://eepurl.com/cdWqc5>`_. Your information will never be shared with any third-parties, and you can unsubscribe at any time.
+
+Want to connect with other documentarians in real-time? Join our `Slack <http://slack.writethedocs.org/>`_.
+
+Thanks
+------
+
+We hope you will join us online for yet another Write the Docs conference.
+Whether as a speaker or attendee, you can bet it will be another delightful year.

--- a/docs/conf/portland/2022/news/announcing-cfp.rst
+++ b/docs/conf/portland/2022/news/announcing-cfp.rst
@@ -17,18 +17,19 @@ Call for Proposals
 Every year, Write the Docs invites people from all across our community to come up on stage to share their insights and experience.
 We're looking for ideas and use-cases from all disciplines and roles, so whether you're a technical writer, developer, UX designer, community manager, or support professional who cares about content and communication, we want to hear from you!
 
-**All talks will be pre-recorded and you can present and attend from anywhere!** This year we are holding a hybrid event, and in order to maintain accessibility for folks who are unable to travel, we are going to broadcast the talks both on the stage in the venue and in Hopin, our virtual conference program.
+**All talks will be pre-recorded allowing you to present and attend from anywhere!** This year we are holding a hybrid event, and in order to maintain accessibility for folks who are unable to travel, we are going to broadcast the talks both on the stage in the venue and in Hopin, our virtual conference program.
 
 You can read our full `Call for Proposals <https://www.writethedocs.org/conf/portland/{{year}}/cfp/>`__ on the website.
 
-The Call for Proposals will be open until **Midnight {{cfp.ends}} PST**.
+The Call for Proposals will be open until **11:59 PM {{cfp.ends}} PST**.
 
 Tickets
 -------
 
 Tickets will officially go on sale towards the end of **January 2021**.
 
-We are working out the final details on the conference format and the different price tiers for in-person and virtual tickets. 
+We are working out the final details on the conference format and the different price tiers for in-person and virtual tickets.
+We expect tickets to be similar to past prices, with virtual tickets similar to our `2021 pricing <https://www.writethedocs.org/conf/portland/2021/tickets/>_, and in-person tickets similar to our `2019 pricing <https://www.writethedocs.org/conf/portland/2019/tickets/>`_. 
 
 As always, we keep ticket prices low so that the event is accessible to the widest range of people possible.
 However, if you can't afford the tickets and still wish to attend, we will launch our grants program soon after opening ticket sales.

--- a/docs/conf/portland/2022/news/index.rst
+++ b/docs/conf/portland/2022/news/index.rst
@@ -1,0 +1,13 @@
+:template: {{year}}/generic.html
+
+News
+====
+
+Updates from the team.
+More here as it happens!
+
+ .. postlist:: 100
+   :date: %A, %B %d, %Y
+   :format: {title} - {date}
+   :list-style: none
+   :tags: {{ shortcode }}-{{ year }}

--- a/docs/conf/portland/2022/opportunity-grants.rst
+++ b/docs/conf/portland/2022/opportunity-grants.rst
@@ -1,0 +1,73 @@
+:template: {{year}}/generic.html
+
+Opportunity grants
+==================
+
+The grant program for WTD {{ name }} {{ year }} supports people who would otherwise not be able to attend the conference by covering attendance costs. Applications are open to anyone who wants to attend Write the Docs.
+
+{% if grants and grants.url %}
+To apply, fill in the form below.
+{% else %}
+We expect to open the grant program around the same time as ticket sales.
+{% endif %}
+As the conference is virtual this year, the grant offers you a single free ticket to the conference.
+
+We would like to encourage anyone to apply, who would otherwise have difficulties attending the conference.
+You are welcome to apply, even if you have received a grant before from our conferences or any others,
+regardless of the reason making it difficult for you to cover the cost, and with any experience
+level or background.
+
+Depending on the number of applications, we may not be able to provide every applicant with a free ticket. We prioritize applications based on the overall impact that granting an application will have on the applicant, the Write the Docs community, and the applicant's wider community and country, compared to others.
+
+Grant applicants, like all other participants in the Write the Documents community, are required to conform to the Code of Conduct: https://www.writethedocs.org/code-of-conduct/.
+
+{% if grants and grants.ends %}
+**Grant applications are open until {{ grants.ends }}, Midnight {{ tz }}.**
+{% endif %}
+
+.. contents::
+    :local:
+    :depth: 1
+    :backlinks: none
+
+What is covered
+----------------
+
+All grants include a free conference ticket for the virtual conference.
+
+Are you part of a marginalized or underrepresented group in tech?
+------------------------------------------------------------------
+
+Our grant program is open to anyone who wants to attend Write the Docs.
+However, we may prioritise applications from people who are part of a marginalized
+or underrepresented group in tech. If you are not part of any of these groups,
+you are still welcome to apply.
+
+These groups include, but are not limited to:
+
+* women and other gender minorities of all expressions and identities;  for example trans, agender and non-binary people
+* people of color
+* sexuality minorities, including asexual people
+* people with disabilities, both visible and invisible
+* neurodivergent people* people with chronic illnesses or diseases
+* religious and ethnic minorities
+* age minorities (under ~21, over ~50)
+* people experiencing poverty* homeless and home/food insecure people
+* caregivers of children or other dependents
+* people who have experienced trauma and its aftermath (PTSD, anxiety, etc)
+* people living with or recovering from substance abuse
+
+You do not have to tell us which underrepresented group(s) you are a part of.
+
+{% if grants and grants.url %}
+
+Submit your application
+--------------------------
+
+.. raw:: html
+
+	<iframe src="{{ grants.url }}?embedded=true" width="760" height="850" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+
+You can also view `the application form <{{ grants.url }}>`_ in its own page.
+
+{% endif %}

--- a/docs/conf/portland/2022/opportunity-grants.rst
+++ b/docs/conf/portland/2022/opportunity-grants.rst
@@ -22,7 +22,7 @@ Depending on the number of applications, we may not be able to provide every app
 Grant applicants, like all other participants in the Write the Documents community, are required to conform to the Code of Conduct: https://www.writethedocs.org/code-of-conduct/.
 
 {% if grants and grants.ends %}
-**Grant applications are open until {{ grants.ends }}, Midnight {{ tz }}.**
+**Grant applications are open until {{ grants.ends }}, 11:59PM {{ tz }}.**
 {% endif %}
 
 .. contents::

--- a/docs/conf/portland/2022/outing.rst
+++ b/docs/conf/portland/2022/outing.rst
@@ -1,0 +1,24 @@
+:template: {{year}}/generic.html
+
+{% if shortcode == '{{ shortcode }}'%}
+:banner: _static/conf/images/headers/group.png
+
+Write the Docs Boat Ride
+========================
+
+As this year's conference is virtual, we encourage you to go on a boat ride or walk in your own beautiful home town.
+
+{% elif shortcode == 'portland'%}
+
+:banner: _static/conf/images/headers/hike.png
+
+Write the Docs Hike
+===================
+
+{% include "conf/portland/hike.rst" %}
+
+{% else %}
+
+We don't have an outing yet.
+
+{% endif %}

--- a/docs/conf/portland/2022/press-kit.rst
+++ b/docs/conf/portland/2022/press-kit.rst
@@ -1,0 +1,60 @@
+:template: {{year}}/generic.html
+
+Press Kit
+=========
+
+We love that you're supporting Write the Docs by writing about the conference, sharing news about it on social media, telling people you're planning to attend.
+We're trying to make it as easy as possible for you to do any of the above, so here are some sample tweets, useful information, and handy images you can use.
+
+Sample tweets
+-------------
+
+Use these unedited, or tweak them as needed!
+
+
+.. raw:: html
+
+  <ul>
+    <li>I&#39;m attending Write the Docs {{date.main }} to discuss all things documentation. <br><a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="I&#39;m attending Write the Docs {{date.main }} to discuss all things documentation." data-url="https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/" data-hashtags="writethedocs" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></li>
+    <li>Join writers, programmers, librarians, scientists, developer advocates. and support humans at #writethedocs in {{ date.main }} to discuss all things documentation. <br><a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="Join writers, programmers, librarians, scientists, developer advocates. and support humans at #writethedocs in {{ date.main }} to discuss all things documentation." data-url="https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/" data-hashtags="writethedocs" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></li>
+  </ul>
+
+Good things people have said about us
+-------------------------------------
+
+.. raw:: html
+
+  <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">I&#39;m finding myself really sad that today isn&#39;t a <a href="https://twitter.com/hashtag/writethedocs?src=hash&amp;ref_src=twsrc%5Etfw">#writethedocs</a> day today too. I mean yes, today I can literally write the docs, but still.</p>&mdash; Diana Potter (@drpotter) <a href="https://twitter.com/drpotter/status/601133512205291520?ref_src=twsrc%5Etfw">May 20, 2015</a></blockquote>
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+  <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr"><a href="https://twitter.com/hashtag/writethedocs?src=hash&amp;ref_src=twsrc%5Etfw">#writethedocs</a> ended yesterday. It was such a great conference! <a href="https://t.co/uhyEIYrbTV">https://t.co/uhyEIYrbTV</a></p>&mdash; 🌟 Aleen vs. the Forces of Evil 🌟 (@Aleen) <a href="https://twitter.com/Aleen/status/601111911791534081?ref_src=twsrc%5Etfw">May 20, 2015</a></blockquote>
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+  <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">On my way home from another great <a href="https://twitter.com/hashtag/writethedocs?src=hash&amp;ref_src=twsrc%5Etfw">#writethedocs</a>. Already working on ways to apply what I learned. If you care about docs, be here next time!</p>&mdash; Daniel D. Beck (@ddbeck) <a href="https://twitter.com/ddbeck/status/601042665744957440?ref_src=twsrc%5Etfw">May 20, 2015</a></blockquote>
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+Useful numbers
+---------------
+
+We have some stats about attendees, membership, and website hits over on the following blog posts:
+
+{% include "conf/events/current-stats.rst" %}
+
+Images and logos
+-------------------
+
+We're working on getting our new logos and images up here, in the meantime you can use any of the Creative Commons licensed images from our `Flickr gallery <https://www.flickr.com/photos/writethedocs/>`_ or take a look at the `logo and other assets stylesheet <https://github.com/writethedocs/resources/blob/master/conf/2020/STYLE%20SHEET%202020-2020.pdf>`_.
+
+In particular, we encourage you to use these three photos in your tweets and blog posts, which we think are especially representative of Write the Docs Portland.
+
+.. raw:: html
+
+  <a data-flickr-embed="true"  href="https://www.flickr.com/photos/writethedocs/34495135662/in/album-72157683817839465/" title="All quiet"><img src="https://farm5.staticflickr.com/4162/34495135662_664eaf3870_k.jpg" width="1024" height="683" alt="All quiet"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+
+  <hr>
+
+  <a data-flickr-embed="true"  href="https://www.flickr.com/photos/writethedocs/33849416753/in/album-72157683817839465/" title="Settling in to work"><img src="https://farm5.staticflickr.com/4194/33849416753_acf46120e6_b.jpg" width="1024" height="683" alt="Settling in to work"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+
+  <hr>
+
+  <a data-flickr-embed="true"  href="https://www.flickr.com/photos/writethedocs/33856825394/in/album-72157683817839465/" title="Group shot!"><img src="https://farm5.staticflickr.com/4193/33856825394_27fe2d0b6b_b.jpg" width="1024" height="393" alt="Group shot!"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>

--- a/docs/conf/portland/2022/schedule.rst
+++ b/docs/conf/portland/2022/schedule.rst
@@ -1,0 +1,6 @@
+:template: {{year}}/generic.html
+
+Schedule
+========
+
+{% include "conf/schedule-2022.rst" %}

--- a/docs/conf/portland/2022/speakers.rst
+++ b/docs/conf/portland/2022/speakers.rst
@@ -1,0 +1,17 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/speakers.jpg
+
+Conference Speakers
+===================
+
+**All talk videos will be published on our YouTube channel no later than 1 week after the conference.**
+
+{% if flagspeakersannounced %}
+
+.. datatemplate::
+   :source: /_data/{{shortcode}}-{{year}}-sessions.yaml
+   :template: {{year}}/speakers.rst
+
+{% else %}
+  Nothing to see yet. The speakers for the conference will be announced shortly after the call for papers ends.
+{% endif %}

--- a/docs/conf/portland/2022/speaking-tips.rst
+++ b/docs/conf/portland/2022/speaking-tips.rst
@@ -1,0 +1,7 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/writing-day.png
+
+Speaking Tips
+=================
+
+{% include "conf/virtual/speaking-tips.rst" %}

--- a/docs/conf/portland/2022/sponsors/index.rst
+++ b/docs/conf/portland/2022/sponsors/index.rst
@@ -1,0 +1,4 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/{{ shortcode }}-group.png
+
+{% include "include/sponsors.jinja" with context %}

--- a/docs/conf/portland/2022/sponsors/prospectus.rst
+++ b/docs/conf/portland/2022/sponsors/prospectus.rst
@@ -12,9 +12,11 @@ Online Sponsorship Prospectus
 Introduction
 ============
 
-Welcome to our brand new **Online Conference Sponsorship Prospectus**.
-This document has been adapted for our new virtual conference format,
+Welcome to our **2022 Conference Sponsorship Prospectus**.
+This document has been adapted for our hybrid conference format,
 including new benefits and increased value across our community.
+Our new hybrid format has brought many questions,
+and we're working to create innovative solutions where possible.
 
 We're excited to work with the organizations in our community to build the best possible event in {{ year }}.
 In particular, we would love your feedback on sponsorship levels and benefits.
@@ -46,11 +48,12 @@ Second Draft
 
 The **Second Draft** package is great for companies looking to hire or to promote a product.
 
-- Three (3) tickets_
-- Two (2) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
+- Two (2) tickets
+- A small table at our **job fair**
+- One (1) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
 - A short description (250 characters) and logo of your company on the conference website
-- A table at our **virtual job fair**
 - Name included in welcome announcement in email newsletters and social media
+- Display 1 promotional (“Swag”) item on the conference swag table (provided by sponsor)
 
 The **Second Draft** package costs **{{sponsorship.second_draft.price}}**.
 
@@ -59,12 +62,12 @@ Publisher
 
 The **Publisher** package is great for sending a team and getting to know the community.
 
-- Seven (7) tickets_
-- Four (4) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
-- A short description (250 characters) and logo of your company on the conference website
-- A table at our **virtual job fair**
+- Five (5) tickets
+- A table at our **job fair**
+- Two (2) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
+- A medium description (500 characters) and logo of your company on the conference website
 - Name included in welcome announcement in email newsletters and social media
-- A small logo on all Write the Docs website pages for 3 months
+- Display 2 promotional (“Swag”) items on the conference swag table (provided by sponsor)
 
 The **Publisher** package costs **{{sponsorship.publisher.price}}**.
 
@@ -75,17 +78,16 @@ Patron
 
 The **Patron** package highlights your company as a force in the industry and community:
 
-- Thirteen (13) tickets_
-- Seven (7) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
-- A medium description (750 characters and logo of your company on the conference website
-- A **virtual sponsorship booth**
-- A featured table at our **virtual job fair**
-- Small logo included in intermission slides and on talk videos
-- Name included in welcome announcement in email newsletters and social media
-- 5 minute sponsored lightning talk on main stage of the conference
-- One newsletter sponsorship (logo & 300 characters) in our newsletter ({{ newsletter_subs }}+ subscribers)
+- Ten (10) tickets
+- A **sponsorship booth**
+- A featured table at our **job fair**
+- Four (4) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
+- A long description (750 characters) and logo of your company on the conference website
+- Small logo included **livestream & talk videos**
+- 5 minute **sponsored lightning talk**
 - A logo on all Write the Docs website pages until the end of {{ year }}. (30,000 pageviews/mo)
-- A :doc:`small ad </sponsorship/website>` displayed on all non-conferences pages of the Write the Docs website (240x180px, 180 characters, 10,000 pageviews/mo) for 3 months.
+- Display unlimited promotional ("Swag") items
+- Name included in welcome announcement in email newsletters and social media
 
 The **Patron** package costs **{{sponsorship.patron.price}}**.
 
@@ -94,17 +96,16 @@ Keystone
 
 The **Keystone** package highlights you as our main community partner:
 
-- Twenty (20) tickets_
-- Ten (10) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
-- A large description (750 characters) and logo of your company on the conference website
-- A featured **virtual sponsorship booth**
-- A featured table at our **virtual job fair**
-- Large logo included in intermission slides and on talk videos
-- Name included in welcome announcement in email newsletters and social media
-- 5 minute sponsored lightning talk on main stage of the conference
-- Two newsletter sponsorships (logo & 300 characters) in our newsletter ({{ newsletter_subs }}+ subscribers)
+- Fifteen (15) tickets
+- A featured **sponsorship booth**
+- A featured table at our **job fair**
+- Eight (8) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
+- Large logo included **livestream & talk videos**
+- 5 minute **sponsored lightning talk**
+- A long description (750 characters) and logo of your company on the conference website
 - A logo on all Write the Docs website pages until the end of {{ year }}. (30,000 pageviews/mo)
-- A :doc:`small ad </sponsorship/website>` on the Write the Docs website (240x180px, 180 characters, 10,000 pageviews/mo) for 3 months
+- Display unlimited promotional ("Swag") items
+- Name included in welcome announcement in email newsletters and social media
 
 The **Keystone** package costs **{{sponsorship.keystone.price}}**.
 
@@ -134,12 +135,10 @@ Benefits
 Writing Day
 -----------
 
-Sponsor the Writing Day on Sunday, where we get together to help improve the documentation of many projects.
+Sponsor the Writing Day, where we get together to help improve the documentation of many projects.
 This is great for any company that is looking for contributors to their open source projects.
 
 **{{sponsorship.second_draft.price}}**
-
-- **Logistics**: The Writing Day is during the day Sunday.
 
 Inquiries
 =========
@@ -151,7 +150,7 @@ Please direct all inquiries to our sponsorship team at:
 Payment
 =======
 
-Invoices must be paid **within 30 days of invoice receipt**, or no later than one (1) week before the virtual conference.
+Invoices must be paid **within 30 days of invoice receipt**, or no later than one (1) week before the conference.
 
 .. _ticket: https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}/
 .. _tickets: https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}/
@@ -170,8 +169,6 @@ Please let us know if there is any information missing that would be useful for 
 
 Sponsorship schedule
 --------------------
-
-* **SUNDAY**: The conference online platform is open. You are welcome to hang out at your sponsorship booth and attend the Writing Day, but no formal sponsorship events are happening. You're also encouraged to lead a Writing Day project if your documentation is open source.
 
 * **MONDAY**: The conference platform opens at 8am, so we recommend arriving around this time to get the most interaction with attendees. The conference will run until around 5pm.
 

--- a/docs/conf/portland/2022/sponsors/prospectus.rst
+++ b/docs/conf/portland/2022/sponsors/prospectus.rst
@@ -15,7 +15,7 @@ Introduction
 Welcome to our **2022 Conference Sponsorship Prospectus**.
 This document has been adapted for our hybrid conference format,
 including new benefits and increased value across our community.
-Our new hybrid format has brought many questions,
+Our new hybrid format has brought on many questions,
 and we're working to create innovative solutions where possible.
 
 We're excited to work with the organizations in our community to build the best possible event in {{ year }}.
@@ -208,7 +208,7 @@ You can also offer attendees a link to your website or a way to register interes
 Writing day
 ~~~~~~~~~~~
 
-On Sunday we hold our Writing Day.
+We're still working out the details for the Writing Day, we will update this page when we know the schedule and details.
 This is a place where the community gathers to get actual work done.
 This generally involved communities and organizations hosting a documentation sprint on some piece of documentation that is open source and needs improvements.
 

--- a/docs/conf/portland/2022/sponsors/prospectus.rst
+++ b/docs/conf/portland/2022/sponsors/prospectus.rst
@@ -1,0 +1,270 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/{{ shortcode }}-group.png
+
+Online Sponsorship Prospectus
+#############################
+
+.. contents:: Sections
+   :local:
+   :depth: 1
+   :backlinks: none
+
+Introduction
+============
+
+Welcome to our brand new **Online Conference Sponsorship Prospectus**.
+This document has been adapted for our new virtual conference format,
+including new benefits and increased value across our community.
+
+We're excited to work with the organizations in our community to build the best possible event in {{ year }}.
+In particular, we would love your feedback on sponsorship levels and benefits.
+We expanded the offerings and introduced a lot of new things,
+but please let us know if there are other points of interaction with our community that would be valuable for you.
+
+Concept
+=======
+
+{% include "conf/sponsorship/concept.rst" %}
+
+Demographics
+============
+
+{% include "conf/sponsorship/demographics.rst" %}
+
+Why Sponsor
+===========
+
+{% include "conf/sponsorship/why.rst" %}
+
+Sponsorship Packages
+====================
+
+The following options are suggested sponsorship levels. We are happy to discuss adjustments and custom packages.
+
+Second Draft
+------------
+
+The **Second Draft** package is great for companies looking to hire or to promote a product.
+
+- Three (3) tickets_
+- Two (2) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
+- A short description (250 characters) and logo of your company on the conference website
+- A table at our **virtual job fair**
+- Name included in welcome announcement in email newsletters and social media
+
+The **Second Draft** package costs **{{sponsorship.second_draft.price}}**.
+
+Publisher
+---------
+
+The **Publisher** package is great for sending a team and getting to know the community.
+
+- Seven (7) tickets_
+- Four (4) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
+- A short description (250 characters) and logo of your company on the conference website
+- A table at our **virtual job fair**
+- Name included in welcome announcement in email newsletters and social media
+- A small logo on all Write the Docs website pages for 3 months
+
+The **Publisher** package costs **{{sponsorship.publisher.price}}**.
+
+Patron
+------
+
+**Limit 3**
+
+The **Patron** package highlights your company as a force in the industry and community:
+
+- Thirteen (13) tickets_
+- Seven (7) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
+- A medium description (750 characters and logo of your company on the conference website
+- A **virtual sponsorship booth**
+- A featured table at our **virtual job fair**
+- Small logo included in intermission slides and on talk videos
+- Name included in welcome announcement in email newsletters and social media
+- 5 minute sponsored lightning talk on main stage of the conference
+- One newsletter sponsorship (logo & 300 characters) in our newsletter ({{ newsletter_subs }}+ subscribers)
+- A logo on all Write the Docs website pages until the end of {{ year }}. (30,000 pageviews/mo)
+- A :doc:`small ad </sponsorship/website>` displayed on all non-conferences pages of the Write the Docs website (240x180px, 180 characters, 10,000 pageviews/mo) for 3 months.
+
+The **Patron** package costs **{{sponsorship.patron.price}}**.
+
+Keystone
+--------
+
+The **Keystone** package highlights you as our main community partner:
+
+- Twenty (20) tickets_
+- Ten (10) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
+- A large description (750 characters) and logo of your company on the conference website
+- A featured **virtual sponsorship booth**
+- A featured table at our **virtual job fair**
+- Large logo included in intermission slides and on talk videos
+- Name included in welcome announcement in email newsletters and social media
+- 5 minute sponsored lightning talk on main stage of the conference
+- Two newsletter sponsorships (logo & 300 characters) in our newsletter ({{ newsletter_subs }}+ subscribers)
+- A logo on all Write the Docs website pages until the end of {{ year }}. (30,000 pageviews/mo)
+- A :doc:`small ad </sponsorship/website>` on the Write the Docs website (240x180px, 180 characters, 10,000 pageviews/mo) for 3 months
+
+The **Keystone** package costs **{{sponsorship.keystone.price}}**.
+
+Other Sponsorship Opportunities
+===============================
+
+The following a la carte offerings are available either independently or
+combined with one of the previous packages to increase visibility at the event.
+
+Opportunity Grants
+------------------
+
+Provide additional money for our Opportunity Grant program,
+which provides funding for people to attend the conference.
+
+**{{sponsorship.second_draft.price}}**
+
+This sponsorship helps people attend the conference that couldn't otherwise attend.
+It's great to show your support to the community.
+
+Benefits
+~~~~~~~~
+
+* Your sponsor logo will be shown on the stage during all staff presentations as a grant sponsor (opening, closing).
+* We will mention your company as a grant sponsor on Twitter from the official Write the Docs account
+
+Writing Day
+-----------
+
+Sponsor the Writing Day on Sunday, where we get together to help improve the documentation of many projects.
+This is great for any company that is looking for contributors to their open source projects.
+
+**{{sponsorship.second_draft.price}}**
+
+- **Logistics**: The Writing Day is during the day Sunday.
+
+Inquiries
+=========
+
+Please direct all inquiries to our sponsorship team at:
+
+- sponsorship@writethedocs.org
+
+Payment
+=======
+
+Invoices must be paid **within 30 days of invoice receipt**, or no later than one (1) week before the virtual conference.
+
+.. _ticket: https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}/
+.. _tickets: https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}/
+
+
+Run of Show
+===========
+{% if not flagrunofshow %}
+
+The Run of Show will be published closer to the event.
+
+{% else %}
+
+This Run of Show provides more context about the event and answers some common questions you may have.
+Please let us know if there is any information missing that would be useful for you.
+
+Sponsorship schedule
+--------------------
+
+* **SUNDAY**: The conference online platform is open. You are welcome to hang out at your sponsorship booth and attend the Writing Day, but no formal sponsorship events are happening. You're also encouraged to lead a Writing Day project if your documentation is open source.
+
+* **MONDAY**: The conference platform opens at 8am, so we recommend arriving around this time to get the most interaction with attendees. The conference will run until around 5pm.
+
+* **TUESDAY**: The Job Fair will be on Tuesday morning in the Expo area of the online platform. It will take place in existing sponsorship booths. If you do not have a booth, a temporary booth will be set up for the job fair, and then removed during lunch.
+
+See the :doc:`full schedule </conf/{{ shortcode }}/{{ year }}/schedule>` for exact timing details.
+
+Sponsorship platform
+--------------------
+
+We will be using `Hopin <https://hopin.to/>`_ as our online conference platform. It has multiple unique spaces for attendees during the conference, and we hope it will allow for a good amount of interaction between attendees and sponsors. The conference platform won't become fully active until the Sunday of the conference.
+
+Sponsorship spaces
+------------------
+
+A quick overview of the important spaces in the "venue":
+
+* The *Main stage* is where the talks happen. This is also where Lightning talks will be given.
+* The *Sessions area* is where the Writing Day and Unconference will happen.
+* The *Expo area* is where the Job Fair will happen. You can chat in text or video directly with attendees.
+
+Sponsorship events
+------------------
+
+Job Fair
+~~~~~~~~
+
+On Tuesday morning we hold our Job Fair,
+which is a wonderful place to connect with our over {{ about.attendees }} attendees.
+Many of them are looking for jobs now or will be in the near future,
+so it's a great chance to talk more about your company culture and open positions.
+
+**Logistics**: You will be assigned a sponsor booth in the *Expo area* where you can engage with attendees and answer questions.  We recommend that you answer general questions in the main session and then break off into private calls or chats to talk in more depth with specific people.
+
+You can also offer attendees a link to your website or a way to register interest in your job postings.
+
+Writing day
+~~~~~~~~~~~
+
+On Sunday we hold our Writing Day.
+This is a place where the community gathers to get actual work done.
+This generally involved communities and organizations hosting a documentation sprint on some piece of documentation that is open source and needs improvements.
+
+If you want to participate in the Writing Day,
+it helps to do a bit of work up front.
+The best way to prepare is to have a set of issues that you've already picked as "easy for beginners".
+Starting with these issues will make it much easier for people to start,
+and feel productive.
+Make sure you also have good installation instructions and other helpful beginners content as well.
+
+**Logistics**: We will send a signup sheet to the general attendee list a week before the conference, where you can sign up. You can introduce your project to attendees on Sunday morning during the Writing Day Introduction.
+
+How do I get the most out of my sponsorship?
+--------------------------------------------
+
+Come prepared to engage with our community, and to learn just as much as you teach. Engage with our event as attendees as well as sponsors. Send technical staff who can chat with people on the interesting things your company is doing, and get value from the vast amount of insight in the room. We do have some decision makers in the room, but soft sells will work better than hard sales in the environment we strive for.
+
+Who is my primary contact?
+--------------------------
+
+Eric Holscher will be your primary contact, but our team is available at sponsorship@writethedocs.org. If you have a time sensitive inquiry, please email the entire team to ensure a timely response.
+
+During the conference itself, we will also have a *help desk* available on the Hopin platform.
+You can find staff members there to ask any additional questions you might have.
+
+How do I use my sponsorship tickets?
+------------------------------------
+
+You should have received a unique URL with a discount code for your sponsorship tickets. We are happy to send it over again, just ask!
+
+How do I use my job postings?
+-----------------------------
+
+You can post your jobs to our `job board <https://jobs.writethedocs.org/>`_.
+You will be given a discount code that will let you post them for free,
+please ask us for this if you don't have it!
+They will be published in our :doc:`Newsletter </newsletter>` every month,
+and displayed on our website as well.
+
+What do I need for the job fair?
+--------------------------------
+
+The job fair will be a low key event. Generally we recommend having links available to your job descriptions, and ways for attendees to engage with you online after the event.
+
+What does the platform look and feel like?
+------------------------------------------
+
+You can see a demo of the platform in this video.
+It's currently linked to the expo hall demo,
+but it has demos of all the other areas as well:
+
+.. raw:: html
+
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/JgGVOlbOPUU?start=465" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+{% endif %}

--- a/docs/conf/portland/2022/talk-recording-guidelines.rst
+++ b/docs/conf/portland/2022/talk-recording-guidelines.rst
@@ -1,0 +1,6 @@
+:template: {{year}}/generic.html
+
+Guidelines for recording talks
+==============================
+
+{% include "conf/virtual/talk-recording-guide.rst" %}

--- a/docs/conf/portland/2022/team.rst
+++ b/docs/conf/portland/2022/team.rst
@@ -1,0 +1,85 @@
+:template: {{year}}/generic.html
+
+
+Meet the Team
+=============
+
+Our conference is run by a dedicated team consisting mostly of volunteers.
+This page outlines the folks who are helping get things done, and what their roles are.
+
+Folks
+-----
+
+Eric Holscher
+~~~~~~~~~~~~~
+
+{% include "bios/eric.rst" %}
+
+Samuel Wright
+~~~~~~~~~~~~~
+
+{% include "bios/sam.rst" %}
+
+Mo Nishiyama
+~~~~~~~~~~~~
+
+{% include "bios/mo.rst" %}
+
+Alicia Duncan
+~~~~~~~~~~~~~
+
+{% include "bios/alicia.rst" %}
+
+Christy Lutz
+~~~~~~~~~~~~
+
+{% include "bios/christy.rst" %}
+
+Rose Williams
+~~~~~~~~~~~~~
+
+{% include "bios/rose.rst" %}
+
+Jennifer Rondeau
+~~~~~~~~~~~~~~~~
+
+{% include "bios/jennifer.rst" %}
+
+Sasha Romijn
+~~~~~~~~~~~~
+
+{% include "bios/sasha.rst" %}
+
+Mikey Ariel
+~~~~~~~~~~~~~
+
+{% include "bios/mikey.rst" %}
+
+Hillary Fraley
+~~~~~~~~~~~~~~~
+
+{% include "bios/hillary.rst" %}
+
+Bio coming soon
+
+Primary Roles
+-------------
+
+* **Conference chair** - Eric Holscher
+* **Conference co-chair** - *TBD*
+* **Code of conduct response** - See `code of conduct </code-of-conduct/#reporting-and-contact-information>`_ page
+* **Speaker coordinator** - Samuel Wright
+* **Unconference coordinator** - TBD
+* **Lightning Talk coordinator** - TBD
+* **Infrastructure coordinator** - TBD
+* **Swag coordinator** - TBD
+* **Communication coordinator** - TBD
+* **Job Fair coordinator** - TBD
+* **Welcome Wagon coordinators** - TBD
+* **Sponsorship coordinator** - TBD
+* **Writing Day coordinator** - TBD
+* **Volunteer coordinator** - TBD
+* **Emcee** - TBD
+* **Social media coordinator** - TBD
+
+You can read descriptions of all the roles in our :doc:`/organizer-guide/confs/event-roles` doc.

--- a/docs/conf/portland/2022/team.rst
+++ b/docs/conf/portland/2022/team.rst
@@ -55,11 +55,6 @@ Mikey Ariel
 
 {% include "bios/mikey.rst" %}
 
-Hillary Fraley
-~~~~~~~~~~~~~~~
-
-{% include "bios/hillary.rst" %}
-
 Bio coming soon
 
 Primary Roles

--- a/docs/conf/portland/2022/tickets.rst
+++ b/docs/conf/portland/2022/tickets.rst
@@ -1,0 +1,111 @@
+:template: {{year}}/generic.html
+
+Tickets
+=======
+
+Ticket Information
+------------------
+
+{% if flagticketsonsale %}
+
+**Tickets are on sale now!**
+
+{% elif flagsoldout %}
+
+Ticket status
+~~~~~~~~~~~~~
+
+**Tickets are sold out!**
+
+{% else %}
+
+**Tickets will be available in {{ date.tickets_live }}.**
+
+{% endif %}
+
+Ticket details
+~~~~~~~~~~~~~~
+
+Write the Docs {{ name }} {{ year }} is a virtual conference. Each ticket includes:
+
+* Live streaming of all talks
+* Q&A with speakers after each talk (may not be available for all speakers)
+* Access to the conference chat with all other attendees, speakers and sponsors
+* Access to the writing day
+* The virtual job fair
+
+**All talk videos will be published on our YouTube channel no later than 1 week after the conference.**
+
+Refund Policy
+-------------
+
+Refunds will be offered with a 10% processing fee until 2 weeks before the conference.
+Refunds after this date are not possible.
+
+Ticket Types
+------------
+
+
+{% if shirts and flaghasshirts %}
+
+.. class:: ticket
+
+**Official Conference Shirts**
+------------------------------------
+
+You can now visit our Write the Docs {{ name }} {{ year }} Pop-Up Shop and order this year’s branded shirt. The campaign will run until **{{ shirts.ends }}**.
+
+* `Buy {{ name }} {{ year }} Shirt <{{ shirts.url }}>`_
+
+{% endif %}
+
+.. class:: ticket
+
+**Corporate Tickets** *{{tickets.corporate.price}}*
+--------------------------------------------
+
+Purchase this ticket if a company is paying for your attendance. Companies interested in sponsorship can also receive tickets to the conference with a sponsorship package.
+
+{% if flagticketsonsale %}
+
+* `Buy Corporate Ticket <https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}>`__
+
+{% endif %}
+
+.. class:: ticket
+
+**Independent Tickets** *{{tickets.independent.price}}*
+--------------------------------------------
+
+Purchase this ticket if you are paying for yourself, or if you work at a non-profit, a government, or a company with fewer than 10 employees.
+
+{% if flagticketsonsale %}
+
+* `Buy Independent Ticket <https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}>`__
+
+{% endif %}
+
+.. class:: ticket
+
+**Student or Unemployed Tickets** *{{tickets.student.price}}*
+--------------------------------------------
+
+Purchase this ticket if you are currently enrolled as a student, or don't currently have a source of income.
+
+{% if flagticketsonsale %}
+
+* `Buy Student or Unemployed Ticket <https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}>`__
+
+{% endif %}
+
+.. class:: ticket
+
+**None of the above**
+---------------------
+
+If you can't afford these prices and still wish to attend, you can apply for our grant program.
+{% if grants and grants.ends and grants.url %}
+You can apply until **{{ grants.ends }}, Midnight {{ tz }}** on `our website <https://www.writethedocs.org/conf/{{ shortcode }}/{{ year }}/opportunity-grants/>`_.
+{% else %}
+Grant applications will open soon.
+{% endif %}

--- a/docs/conf/portland/2022/tickets.rst
+++ b/docs/conf/portland/2022/tickets.rst
@@ -106,7 +106,7 @@ Purchase this ticket if you are currently enrolled as a student, or don't curren
 
 If you can't afford these prices and still wish to attend, you can apply for our grant program.
 {% if grants and grants.ends and grants.url %}
-You can apply until **{{ grants.ends }}, Midnight {{ tz }}** on `our website <https://www.writethedocs.org/conf/{{ shortcode }}/{{ year }}/opportunity-grants/>`_.
+You can apply until **{{ grants.ends }}, 11:59PM {{ tz }}** on `our website <https://www.writethedocs.org/conf/{{ shortcode }}/{{ year }}/opportunity-grants/>`_.
 {% else %}
 Grant applications will open soon.
 {% endif %}

--- a/docs/conf/portland/2022/tickets.rst
+++ b/docs/conf/portland/2022/tickets.rst
@@ -33,6 +33,7 @@ Write the Docs {{ name }} {{ year }} is a virtual conference. Each ticket includ
 * Access to the conference chat with all other attendees, speakers and sponsors
 * Access to the writing day
 * The virtual job fair
+* Snacks and drinks will be provided, but meals will be found in the local neighbhorhood.
 
 **All talk videos will be published on our YouTube channel no later than 1 week after the conference.**
 
@@ -40,7 +41,7 @@ Refund Policy
 -------------
 
 Refunds will be offered with a 10% processing fee until 2 weeks before the conference.
-Refunds after this date are not possible.
+All COVID-related refunds will be refunded in full with no time limit.
 
 Ticket Types
 ------------

--- a/docs/conf/portland/2022/tickets.rst
+++ b/docs/conf/portland/2022/tickets.rst
@@ -33,7 +33,7 @@ Write the Docs {{ name }} {{ year }} is a virtual conference. Each ticket includ
 * Access to the conference chat with all other attendees, speakers and sponsors
 * Access to the writing day
 * The virtual job fair
-* Snacks and drinks will be provided, but meals will be found in the local neighbhorhood.
+* Snacks and drinks will be provided, but not breakfast or lunch. We'll provide a list of local eateries before the conference.
 
 **All talk videos will be published on our YouTube channel no later than 1 week after the conference.**
 
@@ -41,7 +41,7 @@ Refund Policy
 -------------
 
 Refunds will be offered with a 10% processing fee until 2 weeks before the conference.
-All COVID-related refunds will be refunded in full with no time limit.
+All refund requests for COVID-related reasons will be refunded in full, with no time limit.
 
 Ticket Types
 ------------

--- a/docs/conf/portland/2022/unconference-cheatsheet.rst
+++ b/docs/conf/portland/2022/unconference-cheatsheet.rst
@@ -1,0 +1,7 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/writing-day.png
+
+Unconference Cheat Sheet
+========================
+
+{% include "conf/virtual/unconference-cheatsheet.rst" %}

--- a/docs/conf/portland/2022/unconference.rst
+++ b/docs/conf/portland/2022/unconference.rst
@@ -1,0 +1,81 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/writing-day.png
+
+Unconference
+============
+
+Unconference sessions create an opportunity for conference attendees to share ideas, solve problems, and participate in discussions in different ways than we can on the main stage of the conference.
+
+Anyone can suggest and lead a session on a topic -- sessions can be organized as a group discussion on a particular issue, a Q&A, show-and-tell, or anything in between.
+
+If you've never attended an unconference, expect to interact closely with others from the community.
+
+Unconference sessions run all day on Monday, and Tuesday afternoon after the Job Fair.
+
+How does an unconference session work?
+--------------------------------------
+
+There is no stage in an unconference, and sessions instead focus on small group interaction.
+
+Whether you have a topic in mind, or a problem you would like to pose to the rest of the community, there is no wrong way to lead an unconference session. Good sessions emphasize group participation, however, so if you choose a format that includes a lot of your own ideas or material, be prepared to dial it back and use what you have as a starting point, not as the focal point.
+
+Here are a few ideas for how to structure an unconf session, borrowed from `Scott Berkun's post on unconference sessions <http://scottberkun.com/2006/how-to-run-a-great-unconference-session/>`__:
+
+-  **Group discussion** - Pick a topic and facilitate a group discussion.
+-  **The semi-talk** - Use a short presentation to lead into a group discussion on a topic.
+-  **Show and tell** - Show off your latest project, a new tool, or anything else you are excited about.
+-  **Presentation** - Because sessions are meant to be small and inclusive, this is a difficult format to lead a session with. The conference is virtual, so you can share your screen, but expect more interaction from others joining the session, and break often for questions and discussion.
+
+Lead a session
+--------------
+
+To lead an unconf session, propose a topic and pick a time; unconf sessions are scheduled for the same time slots as talks on the main stage.
+
+{% if unconf and unconf.url %}
+
+Sessions take place in Hopin, but you propose a session by adding your topic to a timeslot and table number in the  `Unconference sign-up sheet <{{unconf.url}}>`__.
+
+{% else %}
+
+Sessions take place in Hopin, but you propose a session by adding your topic to a timeslot and table number in the  Unconference sign-up sheet, which will be linked here closer to the event.
+
+{% endif %}
+
+When it's time for your session to begin, join the session in Hopin that corresponds to the table number you signed up for. There's a 15 minute break between sessions, but the previous session might still be running, so let them know it's time to switch. Give attendees a few minutes to join, then start the conversation!
+
+When the next session leader joins your session, it's time to finish up the conversation and let the next session begin. Or your group can end with time to take a break before the next session.
+
+We will start promoting the unconference sessions early in the day on the days of the conference, so post your topic early if you want a particular time slot, or to make sure that there's room.
+
+Keep in mind the following tips (inspired by the “Open Space Technology” infographic):
+
+* Whoever comes is the right people. You can get great results with 5 people or 20 people (the maximum size of sessions in Hopin). Sometimes it can be to have a smaller, but more engaged group in your session; sometimes your proposed topic will be very popular, and you'll need to pay attention to make sure that everyone has a chance to participate as they want.
+
+* Whenever it starts within your allotted time slot is the right time. People might come and go during the session and that’s ok! If you are worried about lack of attendance, see the previous tip.
+
+* Whatever happens is the only thing that could have happened. Even though the session starts out with a topic, keep an open mind to the discussions that occur, and you might end up with a totally different outcome.
+
+* When it’s over, it’s over. The time slots help organize the sessions, but you can finish early if that's how things develop. If a group of you wants to continue the conversation after your time slot is over, you can organize your own session in Hopin, but be aware that it won't appear on the Hopin schedule, so it's up to the group that wants to keep talking to make sure everyone winds up in the right session.
+
+Attend a session
+----------------
+
+{% if unconf and unconf.url %}
+
+* Starting Monday morning, check the `Unconference sign-up sheet <{{ unconf.url }}>`__ to see whether there are any sessions you want to join. New sessions are added all the time, so check back periodically.
+
+{% endif %}
+
+* At the time your chosen sessions start, join the session in Hopin that correspsond to the table number of the session. Sessions are limited to 20 participants, but you can check out a session without joining it too.
+
+* It's fine to join a session, decide it's not right for you, bow out politely, and join another session.
+
+* It's fine to join late if you needed a longer break.
+
+* Feel free to just listen or add your voice to the discussion.
+
+During the conference
+---------------------
+
+Check out the :doc:`/conf/{{shortcode}}/{{year}}/unconference-cheatsheet` for a quick reference that you can use during the conference to make the most out of the unconference. 
+

--- a/docs/conf/portland/2022/venue.rst
+++ b/docs/conf/portland/2022/venue.rst
@@ -1,0 +1,8 @@
+:template: {{year}}/generic.html
+
+About the Venue
+===============
+
+Our venue this year will be online!
+We're currently working to figure out the exact platform we'll be using.
+This page will be updated once we figure it out.

--- a/docs/conf/portland/2022/visiting.rst
+++ b/docs/conf/portland/2022/visiting.rst
@@ -1,0 +1,7 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/hike.png
+
+Visiting {{ city }}
+=======================
+
+{% include "conf/" + shortcode + "/visiting.rst" %}

--- a/docs/conf/portland/2022/welcome-wagon.rst
+++ b/docs/conf/portland/2022/welcome-wagon.rst
@@ -1,0 +1,6 @@
+:template: {{ year }}/generic.html
+
+Welcome Wagon Guide
+===================
+
+{% include "conf/virtual/welcome-wagon.rst" %}

--- a/docs/conf/portland/2022/writing-day-cheatsheet.rst
+++ b/docs/conf/portland/2022/writing-day-cheatsheet.rst
@@ -1,0 +1,7 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/writing-day.png
+
+Writing Day Cheat Sheet
+=======================
+
+{% include "conf/virtual/writing-day-cheatsheet.rst" %}

--- a/docs/conf/portland/2022/writing-day.rst
+++ b/docs/conf/portland/2022/writing-day.rst
@@ -1,0 +1,46 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/writing-day.png
+
+Writing Day
+===========
+
+{% include "conf/events/writing-day.rst" %}
+
+Schedule
+--------
+
+- Date & Time: **{{date.day_two.dotw}}, {{date.day_two.date}}, {{date.day_two.writing_day_time}} {{tz}}**.
+- Location: **{{about.venue}}**.
+
+Your Project Here
+-----------------
+
+Open Web Docs and MDN
+^^^^^^^^^^^^^^^^^^^^^
+`Open Web Docs <https://openwebdocs.org>`_ was created to ensure the long-term health of web platform documentation independent of any single vendor or organization. It's supported by various organizations and individuals, and employs technical writers who create and maintain open documentation for the web platform. At the moment we’re focused on maintaining and improving `MDN Web Docs <https://developer.mozilla.org/>`_.
+
+We are happy to announce that, on the Writing Day, we will collaborate with writers from Mozilla, who will be joining us to improve MDN Web Docs.
+
+We'd love to collaborate with you on some of our projects. To get started, you’ll need a GitHub account. Here are some of the projects we’ll be working on:
+
+- **Markdown conversion**: we're in the middle of a project to convert the authoring format for MDN - all 11,000 pages of it - from HTML to Markdown. As part of this we need to clean up our content to make it Markdown-compatible.
+
+- **HTTP documentation editorial reviews**: we've recently started a revamp of the HTTP documentation on MDN, to include newer technologies like HTTP 2 and 3, and generally bring everything up to date. So it's a great time to get editorial reviews of this area!
+
+- **GitHub issues**: we'd love help fixing issues with MDN content that have been filed on GitHub. We've labeled issues that we think are especially suitable for new contributors, but we'd encourage you to work on anything that seems suitable. We have issues that are editorial fixes, technical fixes, and requests for new pages, so choose the bugs that suit you best.
+
+- We will lead a brainstorming session about **Documenting how to document** (expected time to start at 2pm).
+
+It’s an explicit goal of *Open Web Docs* to create and support a community around web documentation. So if you do join us for Writing Day, please tell us about it - what worked and what didn’t, what was easy and what wasn’t - so we can improve the experience for contributors.
+
+
+Write the Docs Meetups
+----------------------
+
+Organizing local Write the Docs meetup communities is a rewarding way to participate. During Writing Day, we'll have a table where we can share tips and best practices, especially in this time where all of our meetups are virtual.
+
+During the conference
+---------------------
+
+Check out the :doc:`/conf/{{shortcode}}/{{year}}/writing-day-cheatsheet` for a quick reference that you can use during the conference to make the most out of Writing Day. 
+

--- a/docs/include/conf/schedule-2022.rst
+++ b/docs/include/conf/schedule-2022.rst
@@ -1,3 +1,7 @@
+{% if not flaghasschedule %}
+**WARNING**: This schedule has not been finalized and is subject to major changes.
+{% endif %}
+
 Write the Docs is more than a conference.
 Each year we organize a wide range of events so that people can come together, collaborate, and learn from each other in different ways.
 

--- a/docs/include/conf/schedule-2022.rst
+++ b/docs/include/conf/schedule-2022.rst
@@ -77,7 +77,7 @@ We're hoping to have some fun activities planned for the evening online.
 
 {% if flaghasfood %}
 
-*Snacks and drinks will be provided, but meals will be found in the local neighbhorhood.*
+* Snacks and drinks will be provided, but not breakfast or lunch. We'll provide a list of local eateries before the conference.
 
 {% endif %}
 
@@ -141,7 +141,7 @@ and bring your favorite beverage to your computer :)
 
 {% if flaghasfood %}
 
-*Snacks and drinks will be provided, but meals will be found in the local neighbhorhood.*
+* Snacks and drinks will be provided, but not breakfast or lunch. We'll provide a list of local eateries before the conference.
 
 {% endif %}
 

--- a/docs/include/conf/schedule-2022.rst
+++ b/docs/include/conf/schedule-2022.rst
@@ -73,7 +73,7 @@ We're hoping to have some fun activities planned for the evening online.
 
 {% if flaghasfood %}
 
-*Breakfast and lunch will be provided, as well as snacks and drinks all day.*
+*Snacks and drinks will be provided, but meals will be found in the local neighbhorhood.*
 
 {% endif %}
 
@@ -137,7 +137,7 @@ and bring your favorite beverage to your computer :)
 
 {% if flaghasfood %}
 
-*Breakfast and lunch will be provided, as well as snacks and drinks all day.*
+*Snacks and drinks will be provided, but meals will be found in the local neighbhorhood.*
 
 {% endif %}
 

--- a/docs/include/conf/schedule-2022.rst
+++ b/docs/include/conf/schedule-2022.rst
@@ -1,0 +1,191 @@
+Write the Docs is more than a conference.
+Each year we organize a wide range of events so that people can come together, collaborate, and learn from each other in different ways.
+
+All times are in `{{ tz }} <https://time.is/{{ tz }}>`_.
+
+.. contents::
+    :local:
+    :depth: 1
+    :backlinks: none
+
+
+{% if flaghashike or flaghasboat %}
+
+{{date.day_one.dotw}}, {{date.day_one.date}}
+--------------------------------------------------
+
+{% endif %}
+
+{% if flaghashike %}
+
+Hike
+~~~~
+
+The only event scheduled on Saturday is the :doc:`annual hike to Pittock Mansion </conf/{{shortcode}}/{{year}}/outing>`.
+If you get into town early, join us on the hike and take the chance to explore Portland in all of its glory.
+
+* **Where**: Lower Macleay Park or Macleay Park Entrance.
+{% if not flaghasschedule %}
+* **When**: **{{ date.day_two.hike_time }} {{ tz }}**
+{% endif %}
+* **Details**: :doc:`Annual hike to Pittock Mansion </conf/{{shortcode}}/{{year}}/outing>`
+
+{% endif %}
+
+{% if flaghasboat %}
+
+Boat Ride
+~~~~~~~~~
+
+The only event scheduled on Saturday is the :doc:`Prague Boat Ride </conf/{{shortcode}}/{{year}}/outing>`.
+If you get into town early, join us and experience Prague from the water.
+
+Further details will be announced later.
+
+{% endif %}
+
+
+{% if flaghasfood %}
+
+Reception
+~~~~~~~~~
+
+We encourage everyone to drop by on Sunday evening for the conference reception.
+We're hoping to have some fun activities planned for the evening online.
+
+* **Where**: {{about.venue}}, {{about.mainroom}}
+{% if not flaghasschedule %}
+* **When**: TBD **{{ date.day_one.reception_time }} {{ tz }}**
+{% endif %}
+
+{% endif %}
+
+
+.. raw:: html
+
+   <hr>
+
+
+{{date.day_two.dotw}}, {{date.day_two.date}}
+-----------------------------------------
+
+{{ date.day_two.summary }}
+
+{% if flaghasfood %}
+
+*Breakfast and lunch will be provided, as well as snacks and drinks all day.*
+
+{% endif %}
+
+Conference Talks
+~~~~~~~~~~~~~~~~
+
+* **Where**: {{about.venue}}
+{% if not flaghasschedule %}
+* **When**: **{{ date.day_two.talk_time }} {{ tz }}**
+{% endif %}
+* **Details**: :doc:`/conf/{{shortcode}}/{{year}}/speakers`
+
+Talks are around 30 minutes. Most speakers will have a live, moderated Q&A session at the end of their talk.
+
+.. separator to fix list formatting
+
+{% if flaghasschedule %}
+
+{% with day_schedule=schedule.talks_day1 %}
+{% include "include/schedule2021.rst" %}
+{% endwith %}
+
+{% else %}
+    A detailed schedule will be announced soon.
+{% endif %}
+
+Unconference
+~~~~~~~~~~~~
+
+The unconference sessions run in parallel to the main conference talks.
+
+* **Where**: {{about.venue}}, {{about.unconfroom}}
+{% if not flaghasschedule %}
+* **When**: **{{ date.day_three.unconference_time }} {{ tz }}**
+{% endif %}
+* **Details**: :doc:`/conf/{{shortcode}}/{{year}}/unconference`
+
+Social Event
+~~~~~~~~~~~~
+
+The official Write the Docs social!
+Further details will be announced later,
+but expect some music and games,
+and bring your favorite beverage to your computer :)
+
+* **Where**: {{ about.social_venue }}
+{% if not flaghasschedule %}
+* **When**: **{{ date.day_three.social_time }} {{ tz }}**
+{% endif %}
+
+
+.. raw:: html
+
+   <hr>
+
+
+{{date.day_three.dotw}}, {{date.day_three.date}}
+-----------------------------------------
+
+{{ date.day_three.summary }}
+
+{% if flaghasfood %}
+
+*Breakfast and lunch will be provided, as well as snacks and drinks all day.*
+
+{% endif %}
+
+Conference Talks
+~~~~~~~~~~~~~~~~
+
+* **Where**: {{about.venue}}
+{% if not flaghasschedule %}
+* **When**: **{{ date.day_three.talk_time }} {{ tz }}**
+{% endif %}
+* **Details**: :doc:`/conf/{{shortcode}}/{{year}}/speakers`
+
+Talks are around 30 minutes. Most speakers will have a live, moderated Q&A session at the end of their talk.
+
+.. separator to fix list formatting
+
+{% if flaghasschedule %}
+
+{% with day_schedule=schedule.talks_day2 %}
+{% include "include/schedule2021.rst" %}
+{% endwith %}
+
+{% else %}
+  A detailed schedule will be announced soon.
+{% endif %}
+
+{% if flaghasjobfair %}
+
+Job Fair
+~~~~~~~~
+
+We'll be holding a job fair on Tuesday morning!
+
+* **Where**: {{about.venue}}, {{about.job_fair_room }}
+{% if not flaghasschedule %}
+* **When**: **{{ date.day_three.job_fair_time }} {{ tz }}**
+{% endif %}
+* **Details**: :doc:`/conf/{{shortcode}}/{{year}}/job-fair`
+
+{% endif %}
+
+Unconference
+~~~~~~~~~~~~
+
+The unconference sessions run in parallel to the main conference talks.
+
+* **Where**: {{about.venue}}, {{about.unconfroom}}
+{% if not flaghasschedule %}
+* **When**: **{{ date.day_three.unconference_time }} {{ tz }}**
+{% endif %}
+* **Details**: :doc:`/conf/{{shortcode}}/{{year}}/unconference`


### PR DESCRIPTION
- [x] Finalize and enable pretalx
- [x] Fix SMTP settings
- [x] Triple check dates (if we change them update in Pretalx also)
- [x] Add rest of the site... 
- [x] Validate YAML
- [x] Fix hike page (day)

## I think we can skip these and get the CFP out

- [ ] Fix ticket page (virtual tickets)
- [ ] Update ticket and sponsorship prices in config

## TODO

- [x] Blog post

-----

Specific things to look at:

* `docs/_data/portland-2022-config.yaml`
* `docs/include/conf/schedule-2022.rst`
* `docs/conf/portland/2022/tickets.rst`
* _the rest_ :-p