### PR TITLE
Book list: updates, adds, and reorganizes

### DIFF
--- a/docs/books.rst
+++ b/docs/books.rst
@@ -14,7 +14,6 @@ Technical communication
 * `Modern Technical Writing <https://www.goodreads.com/book/show/28433138-modern-technical-writing>`_, by Andrew Etter
 * `Practical Strategies for Technical Communication <https://www.goodreads.com/book/show/15875185-practical-strategies-for-technical-communication>`_, by Mike Markel and Stuart Selber
 * `The Product is Docs <https://www.splunk.com/en_us/blog/splunklife/the-product-is-docs.html>`_, by Christopher Gales - **1st edition read in our book club**
-* `Strategic Writing for UX <https://www.oreilly.com/library/view/strategic-writing-for/9781492049388/>`_, by Torrey Podmojersky
 * `Wicked, Incomplete, and Uncertain: User Support in the Wild and the Role of Technical Communication <https://www.goodreads.com/book/show/37864792-wicked-incomplete-and-uncertain>`_, by Jason Swarts
 
 Content strategy
@@ -35,6 +34,7 @@ Design and information architecture
 * `How to Make Sense of Any Mess <http://www.howtomakesenseofanymess.com/>`_, by Abby Covert - **Read in our book club**
 * `Information Architecture: For the Web and Beyond <https://www.goodreads.com/book/show/70132.Information_Architecture_for_the_World_Wide_Web>`_, by Lou Rosenfeld
 * `Information Development: Managing Your Documentation Projects, Portfolio, and People <https://www.goodreads.com/book/show/884914.Information_Development>`_, by JoAnn T. Hackos
+* `Strategic Writing for UX <https://www.oreilly.com/library/view/strategic-writing-for/9781492049388/>`_, by Torrey Podmojersky
 * `Think Like a UX Researcher <https://www.routledge.com/Think-like-a-UX-Researcher-How-to-Observe-Users-Influence-Design-and/Travis-Hodgson/p/book/9781138365292>`_, by David Travis and Philip Hodgson
 
 The craft of writing
@@ -42,10 +42,11 @@ The craft of writing
 
 * `Artful Sentences: Syntax as Style <https://www.edwardtufte.com/tufte/books_vt>`_, by Virginia Tufte
 * `Bugs in Writing: A Guide to Debugging Your Prose <https://www.goodreads.com/book/show/601222.Bugs_in_Writing>`_, by Lyn Dupre
+* `The Gotham Grammarian <https://www.calamaripress.com/Gotham_Grammarian.htm>`_, by Garielle Lutz
 * `It Was the Best of Sentences, It Was the Worst of Sentences <https://www.penguinrandomhouse.com/books/198856/it-was-the-best-of-sentences-it-was-the-worst-of-sentences-by-june-casagrande/>`_ , by June Casagrande
 * `Nicely Said <http://www.nicelysaid.co/>`_, by Nicole Fenton and Kate Kiefer Lee
 * `On Writing <https://stephenking.com/works/nonfiction/on-writing-a-memoir-of-the-craft.html>`_, by Stephen King
-* `The Organised Writer <http://organised-writer.com/>`_, by Antony Johnston - **Upcoming book club read August 2021**
+* `The Organised Writer <http://organised-writer.com/>`_, by Antony Johnston - **Read in our book club**
 * `The Subversive Copy Editor <https://press.uchicago.edu/ucp/books/book/chicago/S/bo23530364.html>`_, by Carol Fisher Saller
 
 Other Lists


### PR DESCRIPTION
This commit:
- Labels a past book-club read
- Moves *Strategic Writing for UX* to the "Design" section.
- Adds *The Gotham Grammarian* to the "Craft" section, and links to the online version,
  which is free and full of great reference information about grammar and punctuation.