### PR TITLE
Migrate to a signup form instead of an invite link to reduce spam

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -159,6 +159,7 @@ global_sponsors = yaml.safe_load("""
 html_context = {
     'conf_py_root': os.path.dirname(os.path.abspath(__file__)),
     'newsletter_subs': '6,500',
+    'slack_members': '15,000',
     'website_visits': '30,000',
     'global_sponsors': global_sponsors,
     'cfp_variables': cfp_variables,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -164,6 +164,7 @@ html_context = {
     'global_sponsors': global_sponsors,
     'cfp_variables': cfp_variables,
     'slack_join': "https://join.slack.com/t/writethedocs/shared_invite/zt-12k7dh46o-eNMS1sHejK2OiiBfnBf6hw",
+    'slack_form': "https://docs.google.com/forms/d/e/1FAIpQLSdq4DWRphVt1qVqH8NsjNnS0Szu_NljjZRUvyYqR7mdc00zKQ/viewform?usp=sf_link",
 }
 
 if build_videos:

--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -26,7 +26,7 @@ If you want to get involved you can:
     If you think these may be unpleasant for you, you can `disable all animations`_
     in your Slack client.
 
-.. _short form: https://docs.google.com/forms/d/e/1FAIpQLSdq4DWRphVt1qVqH8NsjNnS0Szu_NljjZRUvyYqR7mdc00zKQ/viewform?usp=sf_link
+.. _signup form: {{ slack_form }}
 .. _this page: https://github.com/writethedocs/www/blob/master/docs/slack.rst
 .. _disable all animations: https://get.slack.help/hc/en-us/articles/228023907-Manage-animated-images-and-emoji
 

--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -1,7 +1,7 @@
 Slack
 =====
 
-.. tip:: Due to an increase in spammers, we now have a short `signup form`__ that you must fill out to join our Slack network.
+.. tip:: Due to an increase in spammers, we now have a short `signup form`_ that you must fill out to join our Slack network.
 
 Thanks for your interest in our Slack network.
 We have over {{ slack_members }} people who have joined,
@@ -18,7 +18,7 @@ Please also read the Slack guidelines carefully, and remember that our
 
 If you want to get involved you can:
 
-* Fill out our `signup form`__ to join our network.
+* Fill out our `signup form`_ to join our network.
 * Feel free to send a Pull Request to update `this page`_, if you want to include other channels you enjoy.
 
 .. note::

--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -1,8 +1,11 @@
 Slack
 =====
 
-You can `join our Slack`_ network if you aren't already a member.
-Requests to join Slack are processed automatically.
+.. tip:: Due to an increase in spammers, we now have a short `signup form`__ that you must fill out to join our Slack network.
+
+Thanks for your interest in our Slack network.
+We have over {{ slack_members }} people who have joined,
+and you can be one of them.
 
 Our Slack network has lots of people hanging out and chatting about documentation.
 It's the best way to connect with our community,
@@ -13,14 +16,17 @@ This should help you get connected to people with similar interests.
 Please also read the Slack guidelines carefully, and remember that our
 :doc:`/code-of-conduct` also applies to our Slack.
 
-Feel free to send a Pull Request to update `this page`_, if you want to include other channels.
+If you want to get involved you can:
+
+* Fill out our `signup form`__ to join our network.
+* Feel free to send a Pull Request to update `this page`_, if you want to include other channels you enjoy.
 
 .. note::
     Our Slack includes animated emoji, and other animations are sometimes posted.
     If you think these may be unpleasant for you, you can `disable all animations`_
     in your Slack client.
 
-.. _join our slack: {{slack_join}}
+.. _short form: https://docs.google.com/forms/d/e/1FAIpQLSdq4DWRphVt1qVqH8NsjNnS0Szu_NljjZRUvyYqR7mdc00zKQ/viewform?usp=sf_link
 .. _this page: https://github.com/writethedocs/www/blob/master/docs/slack.rst
 .. _disable all animations: https://get.slack.help/hc/en-us/articles/228023907-Manage-animated-images-and-emoji
 
@@ -50,6 +56,7 @@ Here are a few ways to preserve what you've learned for yourself and others:
 
 Autoresponders
 --------------
+
 We have some helpful Slackbot responses that you can summon in any channel, at any time.
 
 * ``?invite`` / ``?join``


### PR DESCRIPTION
This is the first step towards our spam-fighting efforts.
Currently we're giving people the info on form completion,
but if that doesn't stop things we'll need to actually moderate joining.