### PR TITLE
POC for a better spreadsheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ docs/meetups/events.rst
 .vscode
 docs/_data/mc-info.yaml
 docs/_scripts/mc-info.md
+*-cfp-reviews.csv

--- a/docs/_scripts/pretalx2cfpsheet.py
+++ b/docs/_scripts/pretalx2cfpsheet.py
@@ -11,13 +11,7 @@ sys.path.insert(1, '../_ext')
 
 import os
 from collections import OrderedDict
-from utils import slugify
 import requests
-from ruamel import yaml
-from ruamel.yaml.representer import RoundTripRepresenter
-import markdown
-
-SPEAKER_IMAGE_PATH = '../_static/img/speakers/'
 
 def get_review_scores(pretalx_slug):
     if not os.environ.get('PRETALX_TOKEN'):

--- a/docs/_scripts/pretalx2cfpsheet.py
+++ b/docs/_scripts/pretalx2cfpsheet.py
@@ -1,0 +1,66 @@
+# Generate a sessions YAML from Pretalx talk selections.
+# To use:
+# - Get an API token from https://pretalx.com/orga/me
+# - Update the parameters at the end of this file, if needed (e.g. conference name)
+# - Do: export PRETALX_TOKEN=<your token>
+# - Go to directory docs/_scripts
+# - Run this script
+import shutil
+import sys
+sys.path.insert(1, '../_ext')
+
+import os
+from collections import OrderedDict
+from utils import slugify
+import requests
+from ruamel import yaml
+from ruamel.yaml.representer import RoundTripRepresenter
+import markdown
+
+SPEAKER_IMAGE_PATH = '../_static/img/speakers/'
+
+def get_review_scores(pretalx_slug):
+    if not os.environ.get('PRETALX_TOKEN'):
+        print('Error: PRETALX_TOKEN not found in environment variables.')
+        return
+    http_headers = {'Authorization': 'Token ' + os.environ['PRETALX_TOKEN']}
+
+    submissions_url = f'https://pretalx.com/api/events/{pretalx_slug}/submissions/?state=submitted'
+    print(f'Loading submissions from {submissions_url}...')
+
+    while(submissions_url):
+        submissions = requests.get(submissions_url, headers=http_headers)
+        if submissions.status_code != 200:
+            print(f'Error: submissions request failed: {submissions.status_code}: {submissions.text}')
+            return
+
+        for index, talk in enumerate(submissions.json()['results']):
+            print(talk['code']+'    '+talk['title'])
+
+        if submissions.json()['next']:
+            submissions_url = submissions.json()['next']
+        else:
+            submissions_url=False
+
+    reviews_url = f'https://pretalx.com/api/events/{pretalx_slug}/reviews'
+    print(f'Loading reviews from {reviews_url}...')
+
+    while(reviews_url):
+        reviews = requests.get(reviews_url, headers=http_headers)
+        if reviews.status_code != 200:
+            print(f'Error: reviews request failed: {reviews.status_code}: {reviews.text}')
+            return
+
+        for index, review in enumerate(reviews.json()['results']):
+            if isinstance(review['score'], str):
+                print(review['submission']+'    '+review['score'])
+
+        if reviews.json()['next']:
+            reviews_url = reviews.json()['next']
+        else:
+            reviews_url=False
+
+if __name__ == '__main__':
+    get_review_scores(
+        pretalx_slug='wtd-portland-2022'
+    )

--- a/docs/_scripts/pretalx2cfpsheet.py
+++ b/docs/_scripts/pretalx2cfpsheet.py
@@ -1,60 +1,77 @@
-# Generate a sessions YAML from Pretalx talk selections.
+# Generate a CFP review sheet from Pretalx
 # To use:
 # - Get an API token from https://pretalx.com/orga/me
 # - Update the parameters at the end of this file, if needed (e.g. conference name)
 # - Do: export PRETALX_TOKEN=<your token>
 # - Go to directory docs/_scripts
 # - Run this script
-import shutil
-import sys
-sys.path.insert(1, '../_ext')
-
 import os
-from collections import OrderedDict
+import csv
 import requests
+import statistics
 
-def get_review_scores(pretalx_slug):
+
+def get_review_scores(pretalx_slug, output_file):
     if not os.environ.get('PRETALX_TOKEN'):
         print('Error: PRETALX_TOKEN not found in environment variables.')
         return
     http_headers = {'Authorization': 'Token ' + os.environ['PRETALX_TOKEN']}
 
-    submissions_url = f'https://pretalx.com/api/events/{pretalx_slug}/submissions/?state=submitted'
+    submissions_url = f'https://pretalx.com/api/events/{pretalx_slug}/submissions/'
     print(f'Loading submissions from {submissions_url}...')
-
-    while(submissions_url):
-        submissions = requests.get(submissions_url, headers=http_headers)
-        if submissions.status_code != 200:
-            print(f'Error: submissions request failed: {submissions.status_code}: {submissions.text}')
-            return
-
-        for index, talk in enumerate(submissions.json()['results']):
-            print(talk['code']+'    '+talk['title'])
-
-        if submissions.json()['next']:
-            submissions_url = submissions.json()['next']
-        else:
-            submissions_url=False
+    submissions_list = load_pretalx_resource(submissions_url, http_headers)
+    submissions = {submission['code']: submission for submission in submissions_list}
 
     reviews_url = f'https://pretalx.com/api/events/{pretalx_slug}/reviews'
-    print(f'Loading reviews from {reviews_url}...')
 
-    while(reviews_url):
-        reviews = requests.get(reviews_url, headers=http_headers)
-        if reviews.status_code != 200:
-            print(f'Error: reviews request failed: {reviews.status_code}: {reviews.text}')
+    reviews = load_pretalx_resource(reviews_url, http_headers)
+    for review in reviews:
+        try:
+            submissions[review['submission']].setdefault("scores", []).append(float(review['score']))
+        except KeyError:
+            print(f"WARNING: Ignoring review {review['id']} for unknown submission {review['submission']}")
+        except TypeError:
+            print(f"WARNING: Ignoring review {review['id']} for missing/invalid score {review['score']}")
+
+    with open(output_file, 'w') as f:
+        csvwriter = csv.writer(f)
+        csvwriter.writerow(["Mean", "Median", "Pvar", "Title", "Speaker", "Tags", "URL"])
+        for code, submission in submissions.items():
+            speakers = ', '.join([speaker['name'] for speaker in submission['speakers']])
+            url = f"https://pretalx.com/orga/event/{pretalx_slug}/submissions/{code}/reviews/"
+            scores = submission.get('scores', [0])
+            csvwriter.writerow([
+                "%.1f" % statistics.mean(scores),
+                "%.1f" % statistics.median(scores),
+                "%.1f" % statistics.pvariance(scores),
+                submission['title'],
+                speakers,
+                ', '.join(submission['tags']),
+                url,
+            ])
+    print(f'Wrote {len(submissions)} submissions to {output_file}')
+
+
+# Might be reusable in other pretalx interfaces
+def load_pretalx_resource(url, http_headers):
+    results = []
+    while url:
+        response = requests.get(url, headers=http_headers)
+        if response.status_code != 200:
+            print(f'Error: request failed: {response.status_code}: {response.text}')
             return
 
-        for index, review in enumerate(reviews.json()['results']):
-            if isinstance(review['score'], str):
-                print(review['submission']+'    '+review['score'])
+        results += response.json()['results']
 
-        if reviews.json()['next']:
-            reviews_url = reviews.json()['next']
+        if response.json()['next']:
+            url = response.json()['next']
         else:
-            reviews_url=False
+            break
+    return results
+
 
 if __name__ == '__main__':
     get_review_scores(
-        pretalx_slug='wtd-portland-2022'
+        pretalx_slug='wtd-portland-2022',
+        output_file='wtd-portland-2022-reviews.csv',
     )

--- a/docs/_scripts/pretalx2cfpsheet.py
+++ b/docs/_scripts/pretalx2cfpsheet.py
@@ -14,48 +14,7 @@ import requests
 import statistics
 
 
-def get_all_speakers(pretalx_slugs, output_file):
-    if not os.environ.get('PRETALX_TOKEN'):
-        print('Error: PRETALX_TOKEN not found in environment variables.')
-        return
-    http_headers = {'Authorization': 'Token ' + os.environ['PRETALX_TOKEN']}
-
-    events_list = []
-    for slug in pretalx_slugs:
-        url = f'https://pretalx.com/api/events/{slug}'
-        print(f'Loading event from {url}...')
-        response = requests.get(url, headers=http_headers)
-        if response.status_code != 200:
-            print(f'Error: request failed: {response.status_code}: {response.text}')
-            return
-        events_list.append(response.json())
-
-    submissions_list = []
-    for event in events_list:
-        submissions_url = f'https://pretalx.com/api/events/{event["slug"]}/submissions/'
-        print(f'Loading submissions from {submissions_url}...')
-        event_submissions = load_pretalx_resource(submissions_url, http_headers)
-        for submission in event_submissions:
-            submission['event'] = event['name']['en']
-            submission['year'] = event['date_from'].split('-')[0]
-        submissions_list += event_submissions
-
-    with open(output_file, 'w') as f:
-        csvwriter = csv.writer(f)
-        csvwriter.writerow(["Speaker", "Talk", "Conference", "Year", "Status"])
-        for submission in submissions_list:
-            speakers = ', '.join([speaker['name'] for speaker in submission['speakers']])
-            csvwriter.writerow([
-                speakers,
-                submission['title'],
-                submission['event'].replace(submission['year'], '').strip(),
-                submission['year'],
-                submission['state'],
-            ])
-    print(f'Wrote {len(submissions_list)} submissions to {output_file}')
-
-
-def get_review_scores(pretalx_slug, output_file):
+def get_review_scores(pretalx_slug, previous_slugs, output_file):
     if not os.environ.get('PRETALX_TOKEN'):
         print('Error: PRETALX_TOKEN not found in environment variables.')
         return
@@ -66,9 +25,11 @@ def get_review_scores(pretalx_slug, output_file):
     submissions_list = load_pretalx_resource(submissions_url, http_headers)
     submissions = {submission['code']: submission for submission in submissions_list}
 
-    reviews_url = f'https://pretalx.com/api/events/{pretalx_slug}/reviews'
+    previous_submissions = get_previous_submissions(previous_slugs, http_headers)
 
+    reviews_url = f'https://pretalx.com/api/events/{pretalx_slug}/reviews'
     reviews = load_pretalx_resource(reviews_url, http_headers)
+
     for review in reviews:
         try:
             submissions[review['submission']].setdefault("scores", []).append(float(review['score']))
@@ -79,21 +40,56 @@ def get_review_scores(pretalx_slug, output_file):
 
     with open(output_file, 'w') as f:
         csvwriter = csv.writer(f)
-        csvwriter.writerow(["Mean", "Median", "Pvar", "Title", "Speaker", "Tags", "URL"])
+        csvwriter.writerow(["Mean", "Median", "Pvar", "Title", "Speaker", "Tags", "Previous submissions", "URL"])
         for code, submission in submissions.items():
+            previous_for_speaker = {}
+            for speaker in submission['speakers']:
+                previous_for_speaker.update(previous_submissions.get(speaker['code'], {}))
+            previous_for_speaker_str = '; '.join([
+                f'{state.title()}: {", ".join(sorted(events))}'
+                for state, events in
+                sorted(previous_for_speaker.items())
+            ])
             speakers = ', '.join([speaker['name'] for speaker in submission['speakers']])
             url = f"https://pretalx.com/orga/event/{pretalx_slug}/submissions/{code}/reviews/"
-            scores = submission.get('scores', [0])
+            scores = submission.get('scores', [])
             csvwriter.writerow([
-                "%.1f" % statistics.mean(scores),
-                "%.1f" % statistics.median(scores),
-                "%.1f" % statistics.pvariance(scores),
+                "%.1f" % statistics.mean(scores) if scores else '-',
+                "%.1f" % statistics.median(scores) if scores else '-',
+                "%.1f" % statistics.pvariance(scores) if scores else '-',
                 submission['title'],
                 speakers,
                 ', '.join(submission['tags']),
+                previous_for_speaker_str,
                 url,
             ])
     print(f'Wrote {len(submissions)} submissions to {output_file}')
+
+
+def get_previous_submissions(pretalx_slugs, http_headers):
+    events_list = []
+    for slug in pretalx_slugs:
+        url = f'https://pretalx.com/api/events/{slug}'
+        print(f'Loading event from {url}...')
+        response = requests.get(url, headers=http_headers)
+        if response.status_code != 200:
+            print(f'Error: request failed: {response.status_code}: {response.text}')
+            return
+        events_list.append(response.json())
+
+    speakers_submissions = {}
+    for event in events_list:
+        submissions_url = f'https://pretalx.com/api/events/{event["slug"]}/submissions/'
+        print(f'Loading submissions from {submissions_url}...')
+        event_submissions = load_pretalx_resource(submissions_url, http_headers)
+        for submission in event_submissions:
+            for speaker in submission['speakers']:
+                event_name = event['name']['en'].replace('Write the Docs', '').strip()
+                state = submission['state']
+                speakers_submissions.setdefault(speaker['code'], {}).setdefault(state, set()).add(event_name)
+
+
+    return speakers_submissions
 
 
 # Might be reusable in other pretalx interfaces
@@ -115,20 +111,17 @@ def load_pretalx_resource(url, http_headers):
 
 
 if __name__ == '__main__':
-    # get_review_scores(
-    #     pretalx_slug='wtd-portland-2022',
-    #     output_file='wtd-portland-2022-reviews.csv',
-    # )
-    get_all_speakers(
-        pretalx_slugs=[
+    get_review_scores(
+        pretalx_slug='wtd-prague-2022',
+        previous_slugs=[
             'wtd-portland-2020',
             'write-the-docs-portland-2021',
             'wtd-portland-2022',
             'wtd-prague-2020',
             'write-the-docs-prague-2021',
-            'wtd-prague-2022',
+            # 'wtd-prague-2022',
             'write-the-docs-australia-2020',
             'wtd-australia-and-india-2021',
         ],
-        output_file='wtd-speakers.csv',
+        output_file='wtd-portland-2022-reviews.csv',
     )

--- a/docs/_scripts/pretalx2cfpsheet.py
+++ b/docs/_scripts/pretalx2cfpsheet.py
@@ -6,9 +6,53 @@
 # - Go to directory docs/_scripts
 # - Run this script
 import os
+import sys
+sys.path.append(os.path.join(os.path.dirname(__file__), "_ext"))
+
 import csv
 import requests
 import statistics
+
+
+def get_all_speakers(pretalx_slugs, output_file):
+    if not os.environ.get('PRETALX_TOKEN'):
+        print('Error: PRETALX_TOKEN not found in environment variables.')
+        return
+    http_headers = {'Authorization': 'Token ' + os.environ['PRETALX_TOKEN']}
+
+    events_list = []
+    for slug in pretalx_slugs:
+        url = f'https://pretalx.com/api/events/{slug}'
+        print(f'Loading event from {url}...')
+        response = requests.get(url, headers=http_headers)
+        if response.status_code != 200:
+            print(f'Error: request failed: {response.status_code}: {response.text}')
+            return
+        events_list.append(response.json())
+
+    submissions_list = []
+    for event in events_list:
+        submissions_url = f'https://pretalx.com/api/events/{event["slug"]}/submissions/'
+        print(f'Loading submissions from {submissions_url}...')
+        event_submissions = load_pretalx_resource(submissions_url, http_headers)
+        for submission in event_submissions:
+            submission['event'] = event['name']['en']
+            submission['year'] = event['date_from'].split('-')[0]
+        submissions_list += event_submissions
+
+    with open(output_file, 'w') as f:
+        csvwriter = csv.writer(f)
+        csvwriter.writerow(["Speaker", "Talk", "Conference", "Year", "Status"])
+        for submission in submissions_list:
+            speakers = ', '.join([speaker['name'] for speaker in submission['speakers']])
+            csvwriter.writerow([
+                speakers,
+                submission['title'],
+                submission['event'].replace(submission['year'], '').strip(),
+                submission['year'],
+                submission['state'],
+            ])
+    print(f'Wrote {len(submissions_list)} submissions to {output_file}')
 
 
 def get_review_scores(pretalx_slug, output_file):
@@ -71,7 +115,20 @@ def load_pretalx_resource(url, http_headers):
 
 
 if __name__ == '__main__':
-    get_review_scores(
-        pretalx_slug='wtd-portland-2022',
-        output_file='wtd-portland-2022-reviews.csv',
+    # get_review_scores(
+    #     pretalx_slug='wtd-portland-2022',
+    #     output_file='wtd-portland-2022-reviews.csv',
+    # )
+    get_all_speakers(
+        pretalx_slugs=[
+            'wtd-portland-2020',
+            'write-the-docs-portland-2021',
+            'wtd-portland-2022',
+            'wtd-prague-2020',
+            'write-the-docs-prague-2021',
+            'wtd-prague-2022',
+            'write-the-docs-australia-2020',
+            'wtd-australia-and-india-2021',
+        ],
+        output_file='wtd-speakers.csv',
     )

--- a/docs/_scripts/pretalx2cfpsheet.py
+++ b/docs/_scripts/pretalx2cfpsheet.py
@@ -14,7 +14,8 @@ import requests
 import statistics
 
 
-def get_review_scores(pretalx_slug, previous_slugs, output_file):
+def get_review_scores(pretalx_slug, previous_slugs):
+    output_file = pretalx_slug + '-cfp-reviews.csv'
     if not os.environ.get('PRETALX_TOKEN'):
         print('Error: PRETALX_TOKEN not found in environment variables.')
         return
@@ -88,7 +89,6 @@ def get_previous_submissions(pretalx_slugs, http_headers):
                 state = submission['state']
                 speakers_submissions.setdefault(speaker['code'], {}).setdefault(state, set()).add(event_name)
 
-
     return speakers_submissions
 
 
@@ -123,5 +123,4 @@ if __name__ == '__main__':
             'write-the-docs-australia-2020',
             'wtd-australia-and-india-2021',
         ],
-        output_file='wtd-portland-2022-reviews.csv',
     )


### PR DESCRIPTION
For the CFP review meeting, we copy-pasta a spreadsheet that looks a bit like this:

```
Median;[Title](link);Speakers;Tags
4;Talk title; Good people; Tags
3;ANother good one; Folks;
```

While the Median is useful, often you end up with 30 identically scored talks with no secondary sorting. I think it would be more useful to us to have not only Median, but within that Sort by Average. 

This gets all of the talk codes (from which you can build the URL) and titles, as well as all of the scores, associated by talk code.

I ran out of time and motivation to mash the two together, made a separate call for Speakers name info, calculate the average and median, and spit out a sorted spreadsheet.

@mxsasha I don't know if you fancy pushing it over the line? There is no rush, that is for sure. But I can also have another poke when I have a moment.

