### PR TITLE
Fix #1311 - Limit file name length by limiting talk slug length

### DIFF
--- a/docs/_data/portland-2022-sessions.yaml
+++ b/docs/_data/portland-2022-sessions.yaml
@@ -1,6 +1,6 @@
 - title: 'Measuring Documentation Success in Open Source: Findings from Google''s
     Season of Docs Program'
-  slug: measuring-documentation-success-in-open-source-findings-from-google-s-season-of-docs-program-kassandra-dhillon
+  slug: measuring-documentation-success-in-open-source-findings-from-google-s-season-of-kassandra-dhillon
   series: Write the Docs Portland
   series_slug: portland
   year: 2022
@@ -94,7 +94,7 @@
     community groups, and seventeen years of documentation management.</p>'
 - title: 'Beating the Virginia Blues: Thru-hiking strategies to help you survive your
     next big project'
-  slug: beating-the-virginia-blues-thru-hiking-strategies-to-help-you-survive-your-next-big-project-kate-mueller
+  slug: beating-the-virginia-blues-thru-hiking-strategies-to-help-you-survive-your-next-kate-mueller
   series: Write the Docs Portland
   series_slug: portland
   year: 2022
@@ -224,7 +224,7 @@
     </ul>'
 - title: Peer writing and beyond - An experimental approach to a sustainable open-source
     projects
-  slug: peer-writing-and-beyond-an-experimental-approach-to-a-sustainable-open-source-projects-chris-ganta
+  slug: peer-writing-and-beyond-an-experimental-approach-to-a-sustainable-open-source-chris-ganta
   series: Write the Docs Portland
   series_slug: portland
   year: 2022

--- a/docs/_scripts/pretalx2wtd.py
+++ b/docs/_scripts/pretalx2wtd.py
@@ -28,6 +28,8 @@ CONTENT_TYPE_EXTENSIONS = {
     'image/jpg': 'jpg',
     'image/png': 'png',
 }
+MAX_TITLE_LENGTH_FOR_SLUG = 80  # For #1311
+
 def convert_to_yaml(year, series, series_slug, yaml_output, pretalx_slug):
     if not os.environ.get('PRETALX_TOKEN'):
         print('Error: PRETALX_TOKEN not found in environment variables.')
@@ -41,7 +43,7 @@ def convert_to_yaml(year, series, series_slug, yaml_output, pretalx_slug):
         return
 
     for index, talk in enumerate(submissions.json()['results']):
-        slug = slugify(talk['title'] + '-' + talk['speakers'][0]['name'])
+        slug = slugify(talk['title'][:MAX_TITLE_LENGTH_FOR_SLUG] + '-' + talk['speakers'][0]['name'])
         print(f'Processing talk {slug}...')
 
         speaker_info = retrieve_speaker_info([s['code'] for s in talk['speakers']], http_headers, pretalx_slug)


### PR DESCRIPTION
This also trims the slugs for some Portland 2022 talks, but those should only have anchor links, if anything at all.
This will be reflected in the video archive once we produce that.

Historical long filenames for videos are unchanged because that would break external links.

Our longest historical slug is no-community-members-were-harmed-in-the-making-of-this-doc-sprint-how-we-ran-a-48-hour-event-to-collect-community-wisdom-into-a-guidebook-for-newsroom-developers-ryan-pitts-lindsay-muscato which is now 161 characters, and will be limited now to 91 (we also include one speaker name in the slug since last year).