### PR TITLE
Change sphinx-notfound-page dependency from master to 0.8

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ sphinxemoji==0.2.0
 # For atom feed support
 Werkzeug==0.16.1 # pyup: <1.0
 # For fancy 404 pages
-git+https://github.com/rtfd/sphinx-notfound-page@master#egg=sphinx-notfound-page
+git+https://github.com/rtfd/sphinx-notfound-page@0.8#egg=sphinx-notfound-page
 


### PR DESCRIPTION
This broke because they renamed from master to main, but depending
on main is not great anyways, because it will break randomly one
day. 0.8 is very recent and should work for us too, obsoleting
the need to depend on main.