### PR TITLE
Add OSCON YouTube to origin story

### DIFF
--- a/docs/origin-story.rst
+++ b/docs/origin-story.rst
@@ -139,7 +139,7 @@ over 1,500 :doc:`meetup </meetups/index>` members that have joined meetup groups
 The community keeps growing larger and larger,
 and we're happy to welcome everyone into this wonderful group of documentarians.
 
-For a video testimonial, see this interview of [Why You Should Doc Code with Write the Docs' Eric Holscher & Marcia Riefer Johnston](https://www.youtube.com/watch?v=j6rQpO_6XUU).
+For a video testimonial, see this interview of Why You Should Doc Code with Write the Docs' Eric Holscher & Marcia Riefer Johnston:
 
 .. raw:: html
 
@@ -149,6 +149,6 @@ For a video testimonial, see this interview of [Why You Should Doc Code with Wri
 
     <div class="talk">
       <div class="embed-container">
-        <iframe src="https://www.youtube.com/watch?v=j6rQpO_6XUU }}" frameborder="0" allowfullscreen></iframe>
+        <iframe src="https://www.youtube.com/embed/watch?v=j6rQpO_6XUU }}" frameborder="0" allowfullscreen></iframe>
       </div>
     </div>

--- a/docs/origin-story.rst
+++ b/docs/origin-story.rst
@@ -145,6 +145,6 @@ For a video testimonial, see this interview of Why You Should Doc Code with Writ
 
     <div class="talk">
       <div class="embed-container">
-        <iframe src="https://www.youtube.com/embed/watch?j6rQpO_6XUU" frameborder="0" allowfullscreen></iframe>
+        <iframe src="https://www.youtube.com/embed/j6rQpO_6XUU" frameborder="0" allowfullscreen></iframe>
       </div>
     </div>

--- a/docs/origin-story.rst
+++ b/docs/origin-story.rst
@@ -145,6 +145,6 @@ For a video testimonial, see this interview of Why You Should Doc Code with Writ
 
     <div class="talk">
       <div class="embed-container">
-        <iframe src="https://www.youtube.com/embed/watch?v=j6rQpO_6XUU }}" frameborder="0" allowfullscreen></iframe>
+        <iframe src="https://www.youtube.com/embed/watch?v=j6rQpO_6XUU" frameborder="0" allowfullscreen></iframe>
       </div>
     </div>

--- a/docs/origin-story.rst
+++ b/docs/origin-story.rst
@@ -145,6 +145,6 @@ For a video testimonial, see this interview of Why You Should Doc Code with Writ
 
     <div class="talk">
       <div class="embed-container">
-        <iframe src="https://www.youtube.com/embed/watch?v=j6rQpO_6XUU" frameborder="0" allowfullscreen></iframe>
+        <iframe src="https://www.youtube.com/embed/watch?j6rQpO_6XUU" frameborder="0" allowfullscreen></iframe>
       </div>
     </div>

--- a/docs/origin-story.rst
+++ b/docs/origin-story.rst
@@ -143,9 +143,7 @@ For a video testimonial, see this interview of Why You Should Doc Code with Writ
 
 .. raw:: html
 
-    <style type="text/css">
     @import url('http://fontawesome.io/assets/font-awesome/css/font-awesome.css');
-    </style>
 
     <div class="talk">
       <div class="embed-container">

--- a/docs/origin-story.rst
+++ b/docs/origin-story.rst
@@ -138,3 +138,17 @@ over 1,500 :doc:`meetup </meetups/index>` members that have joined meetup groups
 
 The community keeps growing larger and larger,
 and we're happy to welcome everyone into this wonderful group of documentarians.
+
+For a video testimonial, see this interview of [Why You Should Doc Code with Write the Docs' Eric Holscher & Marcia Riefer Johnston](https://www.youtube.com/watch?v=j6rQpO_6XUU).
+
+.. raw:: html
+
+    <style type="text/css">
+    @import url('http://fontawesome.io/assets/font-awesome/css/font-awesome.css');
+    </style>
+
+    <div class="talk">
+      <div class="embed-container">
+        <iframe src="https://www.youtube.com/watch?v=j6rQpO_6XUU }}" frameborder="0" allowfullscreen></iframe>
+      </div>
+    </div>

--- a/docs/origin-story.rst
+++ b/docs/origin-story.rst
@@ -145,6 +145,6 @@ For a video testimonial, see this interview of Why You Should Doc Code with Writ
 
     <div class="talk">
       <div class="embed-container">
-        <iframe src="https://www.youtube.com/embed/j6rQpO_6XUU" frameborder="0" allowfullscreen></iframe>
+        <iframe src="https://www.youtube-nocookie.com/embed/j6rQpO_6XUU" frameborder="0" allowfullscreen></iframe>
       </div>
     </div>

--- a/docs/origin-story.rst
+++ b/docs/origin-story.rst
@@ -143,8 +143,6 @@ For a video testimonial, see this interview of Why You Should Doc Code with Writ
 
 .. raw:: html
 
-    @import url('http://fontawesome.io/assets/font-awesome/css/font-awesome.css');
-
     <div class="talk">
       <div class="embed-container">
         <iframe src="https://www.youtube.com/embed/watch?v=j6rQpO_6XUU }}" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
After re-listening to the interview of Marcia and Eric at OSCON 2015, I'm thinking that it might help more of our audience understand the Write the Docs Origin Story.

Here's the PR that adds the the [YouTube,](https://www.youtube.com/watch?v=j6rQpO_6XUU). ATM, the build doesn't seem to work.... 

And the result from the build via PR is a little uncertain:

![Screenshot from 2022-03-27 12-07-00](https://user-images.githubusercontent.com/3287976/160296708-2272d6db-9b3b-4bf4-96c4-80006b5ed393.png)


(When I try to build locally, I get errors -- see attached error.message.txt, so I've been building via PR)

[error.message.txt](https://github.com/writethedocs/www/files/8358277/error.message.txt)
