### PR TITLE
Add Open Web Docs to the Writing Day

### DIFF
--- a/docs/conf/portland/2022/writing-day.rst
+++ b/docs/conf/portland/2022/writing-day.rst
@@ -17,8 +17,25 @@ Your Project Here
 
 Add your project via a `PR on GitHub <https://github.com/writethedocs/www/blob/main/docs/conf/{{shortcode}}/{{year}}/writing-day.rst>`_ or `mailing us <mailto:{{ shortcode }}@writethedocs.org>`_! You can always reach out to us if you have any questions or concerns before signing up.
 
+Open Web Docs
+^^^^^^^^^^^^^
+`Open Web Docs <https://openwebdocs.org>`_ was created to ensure the long-term health of web platform documentation independent of any single vendor or organization. It's supported by various organizations and individuals, and employs technical writers who create and maintain open documentation for the web platform. At the moment we’re focused on maintaining and improving `MDN Web Docs <https://developer.mozilla.org/>`_.
+
+At the Writing Day we'll be working on MDN Web Docs and we'd love you to join us. Here are some of the projects we'll be working on:
+
+- Content bug fixes: we'll bring a list of issues that are suitable for first-time contributors to MDN.
+
+- Adding missing sidebars: we have a number of pages (30-100) in the Web API reference with no sidebar or with the wrong sidebar. To fix this we need to add the right macro call at the start of the page.
+
+- Writing some API overview pages: on MDN we have pages that provide an overview of a particular API. At a minimum, these need to list all the objects that make up the API and link to them.
+
+- Updating JavaScript code samples: many of our code samples use JavaScript features that are now considered outdated. We'd love to go through these and update them to use the modern style.
+
+The MDN content is maintained in Markdown in a GitHub repository: https://github.com/mdn/content, so to get started, you'll need a GitHub account.
+
+We'll be available to help you understand exactly what's needed for all these tasks and to help work through any problems. We're also really interested in understanding where people have problems contributing to MDN and how we can make it easier. So if you do join us for Writing Day, please tell us about it - what worked and what didn’t, what was easy and what wasn’t - so we can improve the experience for contributors.
+
 During the conference
 ---------------------
 
-Check out the :doc:`/conf/{{shortcode}}/{{year}}/writing-day-cheatsheet` for a quick reference that you can use during the conference to make the most out of Writing Day. 
-
+Check out the :doc:`/conf/{{shortcode}}/{{year}}/writing-day-cheatsheet` for a quick reference that you can use during the conference to make the most out of Writing Day.

--- a/docs/conf/portland/2022/writing-day.rst
+++ b/docs/conf/portland/2022/writing-day.rst
@@ -31,7 +31,9 @@ At the Writing Day we'll be working on MDN Web Docs and we'd love you to join us
 
 - Updating JavaScript code samples: many of our code samples use JavaScript features that are now considered outdated. We'd love to go through these and update them to use the modern style.
 
-The MDN content is maintained in Markdown in a GitHub repository: https://github.com/mdn/content, so to get started, you'll need a GitHub account.
+The MDN content is maintained in Markdown in a GitHub repository: https://github.com/mdn/content, and updates are made as GitHub pull requests, so to get started, you'll need a GitHub account.
+
+However, we'll start with a session for complete beginners about how to write a pull request for a GitHub repository.
 
 We'll be available to help you understand exactly what's needed for all these tasks and to help work through any problems. We're also really interested in understanding where people have problems contributing to MDN and how we can make it easier. So if you do join us for Writing Day, please tell us about it - what worked and what didn’t, what was easy and what wasn’t - so we can improve the experience for contributors.
 


### PR DESCRIPTION
Open Web Docs (https://github.com/openwebdocs/) would like to participate in the Writing Day for the Portland 2022 edition of Write the Docs, and here's a PR to add us to the page.

Thanks!