### PR TITLE
Fix some issues in Prague Sunday/Monday schedule

### DIFF
--- a/docs/_data/prague-2022-schedule.yaml
+++ b/docs/_data/prague-2022-schedule.yaml
@@ -1,9 +1,9 @@
 writing_day:
   - time: '9:00'
     title: 'Platform opens'
-  - time: '9:00'
+  - time: '10:00'
     title: Morning introduction - Introduction to Sprints & Project Introductions
-  - time: '9:30'
+  - time: '10:30'
     title: Team up and start working
   - time: '11:00'
     title: Welcome Wagon conference introduction and platform tour
@@ -17,9 +17,9 @@ writing_day:
 talks_day1:
   - time: '9:00'
     title: Platform opens
-  - time: '8:15'
+  - time: '9:15'
     title: Welcome Wagon conference introduction and platform tour
-  - time: '9:00'
+  - time: '10:00'
     duration: '0:25'
     title: Write the Docs Team - Community update
   - duration: '0:05'


### PR DESCRIPTION
Note that the move in Monday introduction shifts the entire schedule by 1 hour even though those YAML lines didn't change. Maybe we should also move up the social event? My change leaves only 30 minutes between wrap up and start of social.

[Current live](https://www.writethedocs.org/conf/prague/2022/schedule/) / [This PR](https://writethedocs-www--1780.org.readthedocs.build/conf/prague/2022/schedule/)