### PR TITLE
Disable CFP flag for Prague

### DIFF
--- a/docs/_data/prague-2022-config.yaml
+++ b/docs/_data/prague-2022-config.yaml
@@ -187,7 +187,7 @@ sponsors:
 
 
 # Things that change over time, listed in order of change
-flagcfp: True
+flagcfp: False
 flaglanding: False
 flaghassponsors: True
 flagticketsonsale: True


### PR DESCRIPTION
Somehow we forgot this and it causes the "speak" button to still appear in our nav.