### PR TITLE
Add Atlantic 2023 landing page

### DIFF
--- a/docs/_data/atlantic-2023-config.yaml
+++ b/docs/_data/atlantic-2023-config.yaml
@@ -1,0 +1,194 @@
+name: Atlantic
+
+shortcode: atlantic
+year: 2023
+city: Atlantic
+local_area: Atlantic
+area: Atlantic
+area_adj: Atlantic
+tz: CEST & EDT
+email: atlantic@writethedocs.org
+color: green
+rgb: 61, 217, 74
+hex: 3dd94a
+time_format: 24h
+
+photos:
+  default: _static/conf/images/headers/prague-group.png
+
+buttons:
+  top:
+    # - text: Welcome to our conference
+    #   link: /news/welcome
+    # - text: Date and ticket information
+    #   link: /news/announcing-virtual-conf-dates-tickets
+    #- text: Read our conference guide
+    #  link: /welcome-wagon
+    #- text: See the Schedule!
+    #  link: /schedule
+    #- text: Buy a Ticket!
+    #  link: /tickets
+    #- text: Sponsor us
+    #  link: /sponsors/prospectus
+    #- text: Submit a Talk
+    #  link: /cfp
+#    - text: See the talks!
+#      link: /speakers
+    #- text: See the Schedule!
+    #  link: /schedule
+    # - text: Watch the Live Stream
+    #   link: /livestream
+    # - text: See the sketchnotes
+    #   link_absolute: https://www.flickr.com/photos/writethedocs/albums/72157720128594755
+    # - text: Watch the videos!
+    #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHpnaoiOQyd9BYbQbprDGQjQ9
+  bottom:
+    # - text: Welcome to our conference
+    #   link: /news/welcome
+    #- text: See the Schedule!
+    #  link: /schedule
+    #- text: Sponsor the conference
+    #  link: /sponsors/prospectus
+#    - text: See the talks!
+#      link: /speakers
+    #- text: Buy a Ticket!
+    #  link: /tickets
+    # - text: Prepare with the Welcome Wagon
+    #   link: /welcome-wagon
+    # - text: See the schedule!
+    #   link: /schedule
+    # - text: Watch the Live Stream
+    #   link: /livestream
+    # - text: Browse the photos
+    #   link_absolute: https://www.flickr.com/photos/writethedocs/albums/72157691507514803
+    # - text: Watch the videos!
+    #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHpkBJAPYFrob6gqdiBuePwGJ
+
+tickets:
+  concierge:
+    price: €250
+  corporate:
+    price: €150
+  independent:
+    price: €100
+  student:
+    price: €25
+
+sponsorship:
+  second_draft:
+    price: €1,500
+  publisher:
+    price: €3,000
+  patron:
+    price: €6,500
+  keystone:
+    price: €12,500
+
+
+date:
+  main: "**September 10-12, 2022, online**"
+  short: Sep 10-12, 2022
+  tickets_live: "June 2022"
+  month: September
+  # Conference is special for the index to show the combined conference days
+  conference:
+    event: Main Conference
+    date: September 11-12
+    summary: The main days of the conference. We will be running one main track, and an <a href="/conf/atlantic/2023/unconference/">Unconference</a>.
+    icon: conference
+  # These are listed in the schedule
+  day_one:
+    event: Hike
+    date: On your own
+    summary: We encourage you to go on a hike in your own beautiful home town.
+    #summary: If you're in town early, join us for the Hike. prague has excellent access to the woods right in the city, and we'll be exploring Forest Park and the Hoyt Arboretum.
+    icon: hike
+    dotw: Saturday
+  day_two:
+    event: Writing Day
+    date: September 10
+    summary: Join us for the <a href="/conf/atlantic/2023/writing-day/">Writing Day</a> and Welcome Reception. The first official day of the conference is full of chances to interact with other documentarians.
+    #summary: Join us for the Writing Day and Welcome Reception. The first official day of the conference is full of chances to interact with other documentarians.
+    icon: writing
+    dotw: Sunday
+    writing_day_time: 10:00-18:00
+  day_three:
+    event: Conference Day 1
+    date: September 11
+    summary: This is the main event! Hear from lots of interesting folks about all things documentation. We will have talks all day, and unconference sessions running in parallel.
+    dotw: Monday
+    talk_time: 10:00-18:00
+    unconference_time: 10:45-18:00
+    social_time: 19:00-21:00
+  day_four:
+    event: Conference Day 2
+    date: September 12
+    summary: And the conference goes on! We are already starting to miss you. |:heart:|
+    dotw: Tuesday
+    talk_time: 10:00-18:00
+    job_fair_time: 10:00-12:00
+    unconference_time: 15:15-18:00
+  total_talk_days: 2
+
+about:
+  attendees: 300
+  summary:
+    "The main presentation track takes place on **September 11-12 (Monday and Tuesday) from 10:00 to 18:00**.
+    During the main event we also run an :doc:`/conf/prague/2022/unconference`."
+  #social_venue: "Spatial chat platform"
+  venue: "Online conference platform"
+  photos:
+  mainroom: "Video area"
+  unconfroom: "Chat area"
+  projector_ratio: "16:9"
+  job_fair_room: "Sponsor area"
+
+#cfp:
+#  url: https://pretalx.com/wtd-prague-2022/cfp
+#  ends: "June 30, 2022"           # 2 weeks to review and get confirmnations
+#  notification: "July 15, 2022"     #  5 weeks to write and record
+#  video_by: "August 20, 2022"   # 3 weeks before the conf
+#  slides_by: "August 27, 2022"  # 2 weeks before the conf
+#  preview: "https://writethedocs-www--1777.org.readthedocs.build/conf/prague/2022/schedule/"
+
+#grants:
+#  url: https://docs.google.com/forms/d/e/1FAIpQLSf-kI51jdU9e85AV-ipQR3524IsKsFffSHQFgO-DupAAaqCPQ/viewform?usp=sf_link
+#  ends: "August 15, 2022"
+#  notification: "August 25, 2022"
+
+#unconf:
+#  url: https://bit.ly/wtd-prg-2022-ro
+
+#lightning_talks:
+#  signup_url: https://forms.gle/BjeN5BkdTPg9n3nAA
+
+sponsors:
+  keystone:
+  patron:
+  publisher:
+  second:
+  media:
+  in_kind:
+
+
+# Things that change over time, listed in order of change
+flagcfp: False
+flaglanding: True
+flaghassponsors: False
+flagticketsonsale: False
+flagsoldout: False
+flagspeakersannounced: False
+flagrunofshow: False
+flaghasschedule: False
+flaghasshirts: False
+flagvideos: False
+flaglivestreaming: False
+flagpostconf: False
+
+# Truthy things that don't change
+flaghashike: False
+flaghasboat: False
+flaghasunconf: True
+flaghaswritingday: True
+flaghasjobfair: True
+flaghasbadgeflair: False

--- a/docs/_static/conf/css/main-2023.min.css
+++ b/docs/_static/conf/css/main-2023.min.css
@@ -1,0 +1,1 @@
+main-2022.min.css

--- a/docs/_templates/2023/base.html
+++ b/docs/_templates/2023/base.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        {% if page_description %}
+        <meta name="description" content="{{ page_description }}">
+        {% else %}
+        <meta name="description" content="A conference for tech writers, documentarians, and all those who write the docs.">
+        {% endif %}
+
+        <meta name="author" content="Write the Docs">
+        <meta name="ROBOTS" content="ALL">
+
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+        <!-- Open Graph protocol -->
+        <meta property="og:type" content="conference">
+        <meta property="og:url" content="http://www.writethedocs.org">
+        <meta property="og:image" content="https://www.writethedocs.org/_static/img/stickers/sticker-wtd-colors.png">
+        <!-- /Open Graph protocol -->
+
+        <link rel="apple-touch-icon" sizes="57x57" href="{{ pathto('_static/favicon/apple-icon-57x57.png', 1) }}">
+        <link rel="apple-touch-icon" sizes="60x60" href="{{ pathto('_static/favicon/apple-icon-60x60.png', 1) }}">
+        <link rel="apple-touch-icon" sizes="72x72" href="{{ pathto('_static/favicon/apple-icon-72x72.png', 1) }}">
+        <link rel="apple-touch-icon" sizes="76x76" href="{{ pathto('_static/favicon/apple-icon-76x76.png', 1) }}">
+        <link rel="apple-touch-icon" sizes="114x114" href="{{ pathto('_static/favicon/apple-icon-114x114.png', 1) }}">
+        <link rel="apple-touch-icon" sizes="120x120" href="{{ pathto('_static/favicon/apple-icon-120x120.png', 1) }}">
+        <link rel="apple-touch-icon" sizes="144x144" href="{{ pathto('_static/favicon/apple-icon-144x144.png', 1) }}">
+        <link rel="apple-touch-icon" sizes="152x152" href="{{ pathto('_static/favicon/apple-icon-152x152.png', 1) }}">
+        <link rel="apple-touch-icon" sizes="180x180" href="{{ pathto('_static/favicon/apple-icon-180x180.png', 1) }}">
+        <link rel="icon" type="image/png" sizes="192x192"  href="{{ pathto('_static/favicon/android-icon-192x192.png', 1) }}">
+        <link rel="icon" type="image/png" sizes="32x32" href="{{ pathto('_static/favicon/favicon-32x32.png', 1) }}">
+        <link rel="icon" type="image/png" sizes="96x96" href="{{ pathto('_static/favicon/favicon-96x96.png', 1) }}">
+        <link rel="icon" type="image/png" sizes="16x16" href="{{ pathto('_static/favicon/favicon-16x16.png', 1) }}">
+        <link rel="manifest" href="{{ pathto('_static/favicon/manifest.json', 1) }}">
+        <meta name="msapplication-TileColor" content="#ffffff">
+        <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">
+
+        <link href="https://fonts.googleapis.com/css?family=Nunito+Sans:200,400,700" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css?family=Bree+Serif" rel="stylesheet">
+        <link href="//cdn.jsdelivr.net/jquery.slick/1.6.0/slick.css" rel="stylesheet">
+        <link href="//cdn.jsdelivr.net/jquery.slick/1.6.0/slick-theme.css" rel="stylesheet">
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/aos/2.2.0/aos.css" />
+        <link rel="stylesheet" href="{{ pathto('_static/conf/css/main-' + year_str + '.min.css', 1) }}" type="text/css">
+
+        <!-- things that change -->
+        {% block meta %}
+        <meta property="og:site_name" content="Write the Docs {% if cobrand is defined and cobrand %} + {{ cobrand.brand }} {% endif %} {{ name }} {{ year }}">
+        <meta name="dc.language" content="en">
+        <meta name="geo.placename" content="{{ city }}, {{ area }}">
+        {% endblock %}
+
+        <title>
+        {% block full_title %}
+        {% if title %}{{ title }}{% endif %} - Write the Docs {% if cobrand is defined and cobrand %} + {{ cobrand.brand }} {% endif %}  {{ name }} {{ year }}
+        {% endblock full_title %}
+        </title>
+
+        {% block head_link %}
+        {% endblock %}
+
+    </head>
+    <body>
+
+    {% block container %}
+    {% endblock %}
+
+    <div class="footer-head">
+        <div class="uk-container">
+        {% block footerhead %}
+         {% if buttons is defined and buttons.bottom %}
+             {% for callout in buttons.bottom %}
+               <a class="uk-button uk-button-secondary uk-text-center" href="{% if callout.link_absolute %}{{ callout.link_absolute }}{% else %}{{ pathto('conf/' + shortcode + '/' + year_str + callout.link ) }}{% endif %}">{{ callout.text }}</a>
+             {% endfor %}
+         {% endif %}
+        {% endblock %}
+        </div>
+    </div>
+
+    {# Show sponsors in footer of non-sponsor pages #}
+    {% if "sponsors/index" not in pagename and flaghassponsors %}
+    <div class="sponsors-footer">
+        <div class="uk-container">
+        <h2 class="uk-first-column"><a href="/conf/{{ shortcode }}/{{ year }}/sponsors/">Sponsors</a></h2>
+            {% include year_str  + "/sponsors.html" %}
+            {% include year_str  + "/sponsors-media.html" ignore missing %}
+            <div class="learn-more">
+                <a class="uk-align-right" href="/conf/{{ shortcode }}/{{ year }}/sponsors/prospectus/">Become a sponsor</a>
+            </div>
+        </div>
+    </div>
+    {% endif %}
+
+    <footer {% if cobrand is defined%}style="height: 500px;"{% endif %}>
+        <div class="footer-padding"></div>
+        <div class="uk-container">
+            <div class="footer-content">
+                <div class="footer-social-section">
+                    <div class="footer-logo">
+                    {% block footer_logo %}
+                            Write<br>
+                            the<br>
+                            Docs<br>
+                            {% if cobrand is defined and cobrand %}
+                            <em>+</em>
+                            {{ cobrand.brand_html }}
+                            {% endif %}
+                            <em>{{ name }}</em>
+                            <br><em style="top: -16px;">{{ year }}</em>
+                    {% endblock %}
+                    </div>
+
+                    <div class="footer-icon-list">
+                        <a href="https://github.com/writethedocs">
+                            <img src="{{ pathto('_static/conf/images/icons/github-footer-white.svg', 1) }}">
+                        </a>
+                        <a href="https://twitter.com/writethedocs">
+                            <img src="{{ pathto('_static/conf/images/icons/twitter-footer-white.svg', 1) }}">
+                        </a>
+                        <a href="https://www.flickr.com/photos/writethedocs/">
+                            <img src="{{ pathto('_static/conf/images/icons/flickr-footer-white.svg', 1) }}">
+                        </a>
+                        <a href="https://www.writethedocs.org/slack/">
+                            <img src="{{ pathto('_static/conf/images/icons/slack-footer-white.svg', 1) }}">
+                        </a>
+                    </div><!-- end footer icons list of  links -->
+                </div> <!-- end of footer social section -->
+
+                <ul>
+                    <li>© {{ year }} Write the Docs</li>
+                    <li>|</li>
+                    <li><a href="{{ pathto('/code-of-conduct') }}">Code of Conduct</a></li>
+                    <li>|</li>
+                    <li><a href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/80x15.png"></a></li>
+                </ul>
+
+            </div><!-- end of footer content  -->
+            <div class="footer-pics">
+                <div>
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-01.jpg', 1) }}">
+                </div>
+                <div>
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-02.jpg', 1) }}">
+                </div>
+                <div>
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-04.jpg', 1) }}">
+                </div>
+                <div>
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-03.jpg', 1) }}">
+                </div>
+            </div>
+        </div>
+    </footer><!-- end footer -->
+
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
+
+        <!-- Animate on scroll library -->
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/aos/2.2.0/aos.js"></script>
+
+        <!--- Slick Carousel -->
+
+        <script type="text/javascript" src="//cdn.jsdelivr.net/jquery.slick/1.6.0/slick.min.js"></script>
+
+        <script type="text/javascript">
+            AOS.init({
+                duration: 1200
+            });
+        </script>
+
+        <!-- UIkit JS -->
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-beta.25/js/uikit.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-beta.25/js/uikit-icons.min.js"></script>
+    </body>
+</html>

--- a/docs/_templates/2023/generic.html
+++ b/docs/_templates/2023/generic.html
@@ -1,0 +1,94 @@
+{% extends year_str + "/base.html" %}
+
+{% block head_link %}
+<style>
+.page-content h1 {
+    display: none;
+}
+</style>
+{% endblock %}
+
+{% block container %}
+<div class="header">
+        <nav class="uk-navbar-container uk-container uk-navbar-transparent" uk-navbar="offset: -18px">
+            <div class="uk-navbar-left">
+                <div class="header-logo uk-visible@s">
+                    <a href="{{ pathto('conf/' + shortcode + '/' + year_str) }}">
+                        Write<br>
+                        the<br>
+                        Docs<br>
+                        {% if cobrand is defined and cobrand %}
+                        <em>+</em>
+                        {{ cobrand.brand_html }}
+                        <br>
+                        {% endif %}
+                        <em>{{ name }}</em>
+                        <br><em style="top: -16px;">{{ year }}</em>
+                    </a>
+                </div>
+            </div>
+            <div class="uk-navbar-right">
+                <button class="uk-navbar-toggle uk-hidden@s"  type="button" uk-navbar-toggle-icon uk-toggle="target: #offcanvas-nav"></button>
+                <div id="offcanvas-nav" uk-offcanvas="overlay: true">
+                    <div class="uk-offcanvas-bar uk-flex uk-flex-column">
+                            <div class="menu-logo">
+                                    Write<br>
+                                    the<br>
+                                    Docs<br>
+                                    {% if cobrand is defined and cobrand %}
+                                    <em>+</em>
+                                    {{ cobrand.brand_html }}
+                                    {% endif %}
+                                    <em>{{ name }}</em>
+                                    <em style="top: -16px;">{{ year }}</em>
+                                </div>
+                              {% if not flaglanding %}
+                             {% include year_str + "/menu-mobile.html" %}
+                             {% endif %}
+                    </div>
+                </div>
+             {% if not flaglanding %}
+             {% include year_str + "/menu-desktop.html" %}
+             {% endif %}
+            </div>
+        </nav>
+
+    </div><!-- end header -->
+    <div class="mobile-post-header uk-hidden@s">
+        <div class="header-logo">
+                <a href="{{ pathto('conf/' + shortcode + '/' + year_str) }}">
+                    Write<br>
+                    the<br>
+                    Docs<br>
+                    {% if cobrand is defined and cobrand %}
+                    <em>+</em>
+                    {{ cobrand.brand_html }}
+                    {% endif %}
+                    <em>{{ name }}</em>
+                </a>
+        </div>
+    </div><!-- end post header -->
+
+    {% if 'banner' not in meta %}
+    <div class="page-banner" style="background-image: url({{ pathto(photos['default'], 1) }});">
+    {% else %}
+    <div class="page-banner" style="background-image: url({{ pathto(meta['banner'], 1) }});">
+    {% endif %}
+        <div class="uk-container">
+            <h1>{% block pagename %}{{ title }}{% endblock %}</h1>
+        </div>
+    </div>
+    <!-- end page-banner -->
+
+  {% if body %}
+    <div class="page-content">
+        <div class="uk-container">
+                {% block body %}
+                {{ body }}
+                {% endblock body %}
+                {# {% include "postcard.html" %} #}
+        </div>
+    </div>
+  {% endif %}
+
+{% endblock container %}

--- a/docs/_templates/2023/index.html
+++ b/docs/_templates/2023/index.html
@@ -1,0 +1,195 @@
+{% extends year_str + "/base.html" %}
+
+{% block full_title %}
+Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ cobrand.brand }} {% endif %} {{ year }}
+{% endblock %}
+
+{% block head_link %}
+<style>
+.page-content h1 {
+    display: none;
+}
+</style>
+{% endblock %}
+
+{% block container %}
+<div class="hero" style="background: linear-gradient(rgba({{ rgb }}, 1),  rgba({{ rgb }}, 0.5)), url({{ pathto(meta['banner'], 1) }}), no-repeat;background-position: bottom;background-size: cover;">
+    <nav class="uk-navbar-container uk-container uk-navbar-transparent" uk-navbar="offset: -18">
+      <div class="uk-navbar-right">
+        <button class="uk-navbar-toggle uk-hidden@s"  type="button" uk-navbar-toggle-icon uk-toggle="target: #offcanvas-nav"></button>
+        <div id="offcanvas-nav" uk-offcanvas="overlay: true">
+            <div class="uk-offcanvas-bar uk-flex uk-flex-column">
+                    <div class="menu-logo">
+                            Write<br>
+                            the<br>
+                            Docs<br>
+                            {% if cobrand is defined and cobrand %}
+                            <em>+</em>
+                            {{ cobrand.brand_html }}
+                            {% endif %}
+                            <em>{{ name }}</em> <br>
+                            <em style="top: -20px;">{{ year }}</em>
+                        </div>
+                      {% if not flaglanding %}
+                     {% include year_str + "/menu-mobile.html" %}
+                     {% endif %}
+            </div>
+        </div>
+       {% if not flaglanding %}
+       {% include year_str + "/menu-desktop.html" %}
+       {% endif %}
+      </div>
+    </nav>
+
+    <div class="hero-content uk-container">
+      <div class="logo-container">
+        <a class="hero-logo" data-proofer-ignore>
+          Write<br/>
+          the<br/>
+          Docs<br/>
+          {% if cobrand is defined and cobrand %}
+          <em>+</em>
+          {{ cobrand.brand_html }}
+          {% endif %}
+          <em>{{ name }}</em> <br>
+          <em style="top: -20px;">{{ year_str }}</em>
+        </a>
+      </div>
+      <div class="hero-text">
+        <p>The conference focused on all things related to software documentation.</p>
+        <p>
+          <b>
+            Online: {{ tz }} <br>
+            <!--{{ city }}, {{ local_area }}<br> -->
+            {{ date.short }}
+          </b>
+        </p>
+
+        <div class="ctas-block">
+
+         {% if buttons is defined and buttons.top %}
+         {% for callout in buttons.top %}
+           <a class="uk-button uk-button-secondary uk-text-center" href="{% if callout.link_absolute %}{{ callout.link_absolute }}{% else %}{{ pathto('conf/' + shortcode + '/' + year_str + callout.link ) }}{% endif %}">{{ callout.text }}</a>
+         {% endfor %}
+         {% endif %}
+
+        </div>
+      </div>
+    </div>
+  </div><!-- end hero -->
+
+  {% if flagcancelled %}
+
+  <div class="announcement">
+    <div class="uk-container">
+      <p style="vertical-align: middle;">
+        <strong>The {{ name}} {{year}} conference has been cancelled.</strong><br>
+        Please see our news post for more details.
+      </p>
+    </div>
+  </div>
+  <!--- end announcement -->
+  {% elif flagvideos or flagpostconf %}
+
+  <div class="announcement">
+    <div class="uk-container">
+      <p style="vertical-align: middle;">
+        The {{ city}} {{year}} conference is now over.
+        Thanks for coming!
+      </p>
+    </div>
+  </div><!--- end announcement -->
+
+  {% else %}
+
+  <div class="announcement">
+    <div class="uk-container">
+      <p style="vertical-align: middle;">Want to receive conference and community updates?</p>
+      <a class="uk-button uk-button-announcement" href="{{ pathto('conf/' + shortcode + '/' + year_str + '/mailing-list' ) }}">
+        Join our Mailing List
+      </a>
+    </div>
+  </div><!--- end announcement -->
+
+  {% endif %}
+
+  <div class="about">
+    <div class="uk-container">
+
+      <div class="about-content">
+        <h2>What is Write the Docs?</h2>
+        <p>
+          Write the Docs brings everyone who writes the docs together in the same room: Programmers, Tech Writers, Support, Designers, Developer Advocates, and more. We all have things to learn from each other, and there’s no better way than sitting together and talking.
+        </p>
+        <p>
+          We invite you to join {{ about.attendees }} other folks in our event to explore the art and science of documentation.
+        </p>
+        {% if flaglivestreaming %}
+        <p>
+          <a href="{{ pathto('conf/' + shortcode + '/' + year_str + '/livestream') }}">Live streaming is available</a> during the conference.
+          You do <strong>not</strong> need a ticket to watch the stream. Videos of talks will be published after the conference.
+        </p>
+        {% endif %}
+
+      </div>
+
+      <div class="picture-set">
+        <div data-aos="pictrue-03" data-aos-once="true">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-03.jpg', 1) }}">
+        </div>
+        <div data-aos="pictrue-02" data-aos-once="true">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-02.jpg', 1) }}">
+        </div>
+        <div data-aos="pictrue-01" data-aos-once="true">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-01.jpg', 1) }}">
+        </div>
+      </div>
+    </div>
+  </div><!-- end about -->
+
+  <div class="schedule-overview">
+    <div class="uk-container" uk-grid>
+      <h2>Schedule Overview</h2>
+      <div class="schedule-item uk-width-1-3@s">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_one.icon + '-' + color +  '.svg', 1) }}">
+        <h3>{{ date.day_one.event }} </h3>
+        <em>{{ date.day_one.date }} </em>
+        <p>{{ date.day_one.summary }} </p>
+      </div>
+
+      {% if date.day_two is defined %}
+      <div class="schedule-item uk-width-1-3@s">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_two.icon + '-' + color +  '.svg', 1) }}">
+        <h3>{{ date.day_two.event }} </h3>
+        <em>{{ date.day_two.date }} </em>
+        <p>{{ date.day_two.summary }} </p>
+      </div>
+      {% endif %}
+
+      {% if date.conference is defined %}
+      <div class="schedule-item uk-width-1-3@s">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.conference.icon + '-' + color +  '.svg', 1) }}">
+        <h3>{{ date.conference.event }} </h3>
+        <em>{{ date.conference.date }} </em>
+        <p>{{ date.conference.summary }} </p>
+      </div>
+      {% endif %}
+
+      {% if flagspeakersannounced %}
+
+      <div class="learn-more">
+        <a class="uk-align-right" href="{{ pathto('conf/' + shortcode + '/' + year_str + '/schedule') }}">See the Full Schedule</a>
+      </div>
+
+      {% endif %}
+
+    </div>
+  </div><!-- end schedule overview -->
+
+  {% if body %}
+    {% block body %}
+      {{ body }}
+    {% endblock body %}
+  {% endif %}
+
+{% endblock container %}

--- a/docs/_templates/2023/menu-desktop.html
+++ b/docs/_templates/2023/menu-desktop.html
@@ -1,0 +1,114 @@
+
+                <ul class="uk-nav uk-visible@s">
+                        <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/news') }}">News</a></li>
+                        <li>
+                          <ul class="uk-navbar-nav">
+                              <li>
+                                  <a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/schedule') }}">Program</a>
+                                  <div class="uk-navbar-dropdown">
+                                      <ul class="uk-nav uk-navbar-dropdown-nav">
+                                          {% if flaglivestreaming %}
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/livestream') }}">Live Stream</a></li>
+                                          {% endif %}
+                                          {% if flagspeakersannounced %}
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/speakers') }}">Speakers</a></li>
+                                          {% endif %}
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/schedule') }}">Schedule</a></li>
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/welcome-wagon') }}">Welcome Wagon</a></li>
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/lightning-talks') }}">Lightning Talks</a></li>
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/unconference') }}">Unconference</a></li>
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/job-fair') }}">Job Fair</a></li>
+                                          {% if flaghaswritingday %}
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/writing-day') }}">Writing Day</a></li>
+                                          {% endif %}
+                                          {% if flaghasbadgeflair %}
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/badge-flair') }}">Badge Flair Contest</a></li>
+                                          {% endif %}
+                                          {% if flaghashike %}
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/hike') }}">Hike</a></li>
+                                          {% endif %}
+                                          {% if flaghasboat %}
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/boat') }}">Boat Ride</a></li>
+                                          {% endif %}
+                                      </ul>
+                                  </div>
+                              </li>
+                          </ul>
+                        </li><!--- Parent element with it's children -->
+                        <!-- No visiting details this year
+                        <li>
+                          <ul class="uk-navbar-nav">
+                              <li>
+                                  <a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/visiting') }}">Visiting</a>
+                                  <div class="uk-navbar-dropdown">
+                                      <ul class="uk-nav uk-navbar-dropdown-nav">
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/visiting') }}">{{ city }}</a></li>
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/venue') }}">Venue</a></li>
+                                      </ul>
+                                  </div>
+                              </li>
+                          </ul>
+                        </li> -->
+                        <!--- Parent element with it's children -->
+                        <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/welcome-wagon') }}">Guide</a></li>
+                        <li>
+                             <ul class="uk-navbar-nav">
+                                <li>
+                                    <a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/tickets') }}">Tickets</a>
+                                    <div class="uk-navbar-dropdown">
+                                        <ul class="uk-nav uk-navbar-dropdown-nav">
+                                            {% if flaghasfood %}
+                                            <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/tickets') }}">Online Ticket Options</a></li>
+                                            {% endif %}
+                                            <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/opportunity-grants') }}">Opportunity Grants</a></li>
+                                            <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/convince-your-manager') }}">Convince Your Manager</a></li>
+                                        </ul>
+                                    </div>
+                                </li>
+                            </ul>
+                        </li>
+
+                        <li>
+                          <ul class="uk-navbar-nav">
+                              <li>
+                                  <a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/about') }}">About</a>
+                                  <div class="uk-navbar-dropdown">
+                                      <ul class="uk-nav uk-navbar-dropdown-nav">
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/about') }}">Overview</a></li>
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/press-kit') }}">Press Kit</a></li>
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/team') }}">Meet the Team</a></li>
+                                          {% if flaghasfood %}
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/speaking-tips') }}">Speaking Tips</a></li>
+                                          {% endif %}
+                                          <li><a href="{{ pathto('conf') }}">Past Events</a></li>
+                                          <li><a href="{{ pathto('code-of-conduct') }}">Code of Conduct</a></li>
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/contact') }}">Contact</a></li>
+
+                                      </ul>
+                                  </div>
+                              </li>
+                          </ul>
+                        </li><!--- Parent element with it's children -->
+
+                        <li>
+                            <ul class="uk-navbar-nav">
+                                <li>
+                                    <a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/sponsors') }}">Sponsors</a>
+                                    <div class="uk-navbar-dropdown">
+                                        <ul class="uk-nav uk-navbar-dropdown-nav">
+                                            <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/sponsors') }}">Our Sponsors</a></li>
+                                            {% if shortcode == 'portland' and year == 2020 %}
+                                              <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/sponsors/online-prospectus') }}">Online prospectus</a></li>
+                                            {% else %}
+                                              <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/sponsors/prospectus') }}">Prospectus</a></li>
+                                            {% endif %}
+                                        </ul>
+                                    </div>
+                                </li>
+                            </ul>
+                          </li><!--- Parent element with it's children -->
+
+                          {% if flagcfp %}
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/cfp') }}" class="uk-button uk-button-ghost uk-text-uppercase">Speak</a></li>
+                          {% endif %}
+                </ul>

--- a/docs/_templates/2023/menu-mobile.html
+++ b/docs/_templates/2023/menu-mobile.html
@@ -1,0 +1,77 @@
+                <ul class="uk-nav uk-nav-primary uk-nav-center uk-margin-auto-vertical">
+                  <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str) }}">Home</a></li>
+                  <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/news') }}">News</a></li>
+                  <li class="uk-parent">
+                      <a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/schedule') }}">Program</a>
+                      <ul class="uk-nav-sub">
+                          {% if flaglivestreaming %}
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/livestream') }}">Live Stream</a></li>
+                          {% endif %}
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/speakers') }}">Speakers</a></li>
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/schedule') }}">Schedule</a></li>
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/welcome-wagon') }}">Welcome Wagon</a></li>
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/lightning-talks') }}">Lightning Talks</a></li>
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/unconference') }}">Unconference</a></li>
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/job-fair') }}">Job Fair</a></li>
+                          {% if flaghaswritingday %}
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/writing-day') }}">Writing Day</a></li>
+                          {% endif %}
+                          {% if flaghasbadgeflair %}
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/badge-flair') }}">Badge Flair Contest</a></li>
+                          {% endif %}
+                          {% if flaghashike %}
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/hike') }}">Hike</a></li>
+                          {% endif %}
+                          {% if flaghasboat %}
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/boat') }}">Boat Ride</a></li>
+                          {% endif %}
+                      </ul>
+                  </li>
+                  <!--
+                  <li class="uk-parent">
+                      <a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/visiting') }}">Visit</a>
+                      <ul class="uk-nav-sub">
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/visiting') }}">{{ city }}</a></li>
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/venue') }}">Venue</a></li>
+                      </ul>
+                  </li>
+                  -->
+
+                  <li class="uk-parent">
+                    <a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/tickets') }}">Tickets</a>
+                    <ul class="uk-nav-sub">
+                        {% if flaghashike %}
+                        <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/tickets') }}">Online Ticket Options</a></li>
+                        {% endif %}
+                        <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/opportunity-grants') }}">Opportunity Grants</a></li>
+                        <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/convince-your-manager') }}">Convince Your Manager</a></li>
+                    </ul>
+                  </li>
+                  <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/welcome-wagon') }}">Guide</a></li>
+                  <li class="uk-parent">
+                      <a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/about') }}">About</a>
+                      <ul class="uk-nav-sub">
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/about') }}">Overview</a></li>
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/press-kit') }}">Press Kit</a></li>
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/team') }}">Meet the Team</a></li>
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/speaking-tips') }}">Speaking Tips</a></li>
+                          <li><a href="{{ pathto('conf') }}">Past Events</a></li>
+                          <li><a href="{{ pathto('code-of-conduct') }}">Code of Conduct</a></li>
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/contact') }}">Contact</a></li>
+                      </ul>
+                  </li>
+                  <li class="uk-parent">
+                      <a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/sponsors') }}">Sponsors</a>
+                      <ul class="uk-nav-sub">
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/sponsors') }}">Our Sponsors</a></li>
+                          {% if shortcode == 'portland' and year == 2020 %}
+                            <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/sponsors/online-prospectus') }}">Online prospectus</a></li>
+                          {% else %}
+                            <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/sponsors/prospectus') }}">Prospectus</a></li>
+                          {% endif %}
+                      </ul>
+                  </li>
+                  {% if flagcfp %}
+                  <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/cfp') }}" class="uk-button uk-button-ghost uk-text-uppercase">Speak</a></li>
+                  {% endif %}
+                </ul>

--- a/docs/_templates/2023/speakers-simple-list.rst
+++ b/docs/_templates/2023/speakers-simple-list.rst
@@ -1,0 +1,10 @@
+{% for talk in data %}
+
+{% for speaker in talk.speakers %}
+.. _speaker-{{ shortcode }}-{{ year }}-{{ speaker.slug }}:
+{% endfor %}
+
+.. Comment to break up reference issues
+.. * comment
+
+* {% for speaker in talk.speakers %}{{ speaker.name }}{{ ", " if not loop.last }} {% endfor %} – {{ talk.title }} {% endfor %}

--- a/docs/_templates/2023/speakers.rst
+++ b/docs/_templates/2023/speakers.rst
@@ -1,0 +1,47 @@
+{% for talk in data %}
+
+{% for speaker in talk.speakers %}
+.. _speaker-{{ speaker.slug }}:
+{% endfor %}
+
+.. Comment to break up reference issues
+
+.. raw:: html
+
+    <article class="talk">
+      {% for speaker in talk.speakers %}
+      <div class="speaker-info">
+        <img src="{{ speaker.slug|speaker_photo }}" class="speaker-picture">
+        <div class="speaker-contact-info">
+            <h2 class="speaker-name">{{ speaker.name }}</h2>
+            <!--
+            <ul class="speaker-social-contant">
+                <li>
+                    <a href="#">
+                        <img src="../../../../_static/conf/images/icons/twitter-brown.svg" class="twitter">
+                    </a>
+                </li>
+                <li>
+                    <a href="">
+                        <img src="../../../../_static/conf/images/icons/github-brown.svg" class="github">
+                    </a>
+                </li>
+                <li>
+                    <a href="">
+                        <img src="../../../../_static/conf/images/icons/worldwideweb-brown.svg" class="webpage">
+                    </a>
+                </li>
+            </ul>
+            -->
+        </div>
+      </div>
+     {% endfor %}
+      <div class="talk-content">
+        <h3 class="talk-title">{{ talk.title }}</h3>
+        <div class="talk-description">
+          {{ talk.abstract|indent(10) }}
+        </div>
+      </div>
+    </article>
+
+{% endfor %}

--- a/docs/_templates/2023/sponsors-in-kind.html
+++ b/docs/_templates/2023/sponsors-in-kind.html
@@ -1,0 +1,15 @@
+{% if sponsors.in_kind %}
+<div class="sponsors">
+
+  <div class="community-sponsors">
+    {% for sponsor in sponsors.in_kind %}
+    <div class="uk-width-1-2@s">
+      <a href="{{ sponsor.link }}">
+        <img src={{ sponsor.name|sponsor_photo }} style="max-width: {{ sponsor.width|default("150px", true) }};" />
+      </a>
+    </div>
+    {% endfor %}
+  </div><!-- end community sponsors section -->
+</div><!-- end sponsors section -->
+{% endif %}
+

--- a/docs/_templates/2023/sponsors-media.html
+++ b/docs/_templates/2023/sponsors-media.html
@@ -1,0 +1,15 @@
+{% if sponsors.media %}
+<div class="sponsors">
+  <div class="community-sponsors">
+    {% for sponsor in sponsors.media %}
+    <div class="uk-width-1-2@s">
+      <a href="{{ sponsor.link }}">
+        <img src={{ sponsor.name|sponsor_photo }} style="max-width: {{ sponsor.width|default("150px", true) }};" />
+      </a>
+    </div>
+    {% endfor %}
+  </div><!-- end community sponsors section -->
+</div><!-- end sponsors section -->
+{% endif %}
+
+

--- a/docs/_templates/2023/sponsors-simplelist.rst
+++ b/docs/_templates/2023/sponsors-simplelist.rst
@@ -1,0 +1,9 @@
+{% for key in ('keystone', 'patron', 'publisher', 'second', 'first') %}
+    {% if key in data.sponsors and data.sponsors[key] %}
+
+      {% for sponsor in data.sponsors[key] %}
+        * `{{ sponsor.brand }} <{{ sponsor.link }}>`__
+      {% endfor %}
+
+    {% endif %}
+{% endfor %}

--- a/docs/_templates/2023/sponsors.html
+++ b/docs/_templates/2023/sponsors.html
@@ -1,0 +1,97 @@
+<!-- Sponsor include for all 2020+ conferences -->
+
+<div class="sponsors">
+
+  {% if sponsors.keystone %}
+  <div class="gold-sponsors">
+    {% for sponsor in sponsors.keystone %}
+    <div class="uk-width-1-1@s" id="{{ sponsor.name }}">
+      <a href="{{ sponsor.link }}">
+        <img src={{ sponsor.name|sponsor_photo }} style="max-width: {{ sponsor.width|default("500px", true) }};" />
+      </a>
+    </div>
+      {% if include_text and sponsor.text %}
+      <div >
+      <span class="sponsor-text" style="display: block;">
+        {{ sponsor.text }}
+      </p>
+      </div>
+      {% endif %}
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if sponsors.patron %}
+  <div class="silver-sponsors">
+    {% for sponsor in sponsors.patron %}
+    <div class="uk-width-1-1@s" id="{{ sponsor.name }}">
+      <a href="{{ sponsor.link }}">
+        <img src={{ sponsor.name|sponsor_photo }} style="max-width: {{ sponsor.width|default("400px", true) }};" />
+      </a>
+    </div>
+      {% if include_text and sponsor.text %}
+      <span class="sponsor-text" style="display: block;">
+
+        {{ sponsor.text }}
+      </span>
+      {% endif %}
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if sponsors.publisher %}
+  <div class="silver-sponsors">
+    {% for sponsor in sponsors.publisher %}
+    {% if include_text %}
+    <div class="uk-width-1-1@s" id="{{ sponsor.name }}">
+      {% else %}
+    <div class="uk-width-1-2@s" id="{{ sponsor.name }}">
+    {% endif %}
+      <a href="{{ sponsor.link }}">
+        <img src={{ sponsor.name|sponsor_photo }} style="max-width: {{ sponsor.width|default("300px", true) }}; min-width: {{ sponsor.min_width|default("200px", true) }};" />
+      </a>
+    </div>
+      {% if include_text and sponsor.text %}
+      <span class="sponsor-text" style="display: block;">
+
+        {{ sponsor.text }}
+      </span>
+      {% endif %}
+    {% endfor %}
+  </div>
+  {% endif %}
+
+  {% if sponsors.second %}
+  <div class="bronze-sponsors">
+    {% for sponsor in sponsors.second %}
+    {% if include_text %}
+    <div class="uk-width-1-1@s" id="{{ sponsor.name }}">
+      {% else %}
+    <div class="uk-width-1-2@s" id="{{ sponsor.name }}">
+    {% endif %}
+      <a href="{{ sponsor.link }}">
+        <img src={{ sponsor.name|sponsor_photo }} style="width: {{ sponsor.width|default("200px", true) }};" />
+      </a>
+    </div>
+      {% if include_text and sponsor.text %}
+      <span class="sponsor-text" style="display: block;">
+        {{ sponsor.text }}
+      </span>
+      {% endif %}
+    {% endfor %}
+  </div> <!-- end bronze -->
+  {% endif %}
+
+  {% if sponsors.first %}
+  <div class="community-sponsors">
+    {% for sponsor in sponsors.first %}
+    <div class="uk-width-1-2@s">
+      <a href="{{ sponsor.link }}">
+        <img src={{ sponsor.name|sponsor_photo }} style="max-width: {{ sponsor.width|default("150px", true) }};" />
+      </a>
+    </div>
+    {% endfor %}
+  </div><!-- end community sponsors section -->
+  {% endif %}
+
+</div><!-- end sponsors section -->

--- a/docs/conf/atlantic/2023/about.rst
+++ b/docs/conf/atlantic/2023/about.rst
@@ -1,0 +1,14 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/team.png
+
+About the Conference
+====================
+
+We invite you to join hundreds of other folks for a three-day event to explore the art and science of documentation.
+The Write the Docs conference covers any topic related to documentation in the software industry.
+Past talks have also covered such diverse topics as empathy, the history of math symbols, and using emoji to keep your users' attention.
+
+Write the Docs brings *everyone* who writes the docs together in the same room: Writers, developers, support engineers, community managers, developer relations, and more.
+We all have things to learn, and there's no better way than coming together in the same room and getting to know each other.
+
+{{about.summary}}

--- a/docs/conf/atlantic/2023/badge-flair.rst
+++ b/docs/conf/atlantic/2023/badge-flair.rst
@@ -1,0 +1,6 @@
+:template: {{year}}/generic.html
+
+Badge Flair Contest
+===================
+
+{% include "conf/events/badge-flair.rst" %}

--- a/docs/conf/atlantic/2023/cfp-email-templates.rst
+++ b/docs/conf/atlantic/2023/cfp-email-templates.rst
@@ -1,0 +1,301 @@
+:template: {{year}}/generic.html
+:orphan:
+
+Speaker email templates
+=======================
+
+.. Make this whole file conditional
+
+{% if flagcfp and cfp_variables['print_templates'] and not flagpostconf %}
+
+.. contents::
+   :local:
+   :depth: 1
+   :backlinks: none
+
+.. note:: These templates use the following types of variables:
+
+      * Standard WTD conference variables {% raw %}``{{tz}}``{% endraw %} (which are expanded)
+      * Hidden environment variables {% raw %}``{{cfp_variables['upload']}}``{% endraw %} (which are expanded)
+      * Pretalx variables which are only expanded in Pretalx {% raw %}``{name}``{% endraw %}
+
+
+CFP - Acceptance template
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Subject:
+   WTD {{city}} {{year}} -- talk accepted!
+
+::
+
+   Hi {name},
+
+   The Write the Docs {{city}} talk selection committee has finished the review process and we'd love it if you could join us as a speaker!
+
+   Write the Docs {{city}} is held **online {{date.short}}** in {{tz}}.
+
+   We think your talk: '{proposal_title}' would be a great fit for the conference. We'd love to have you prepare it for a **30-minute** time slot.
+
+   Please click this link to confirm your attendance:
+
+   ○ {confirmation_link}
+
+   Please **reply to this email as soon as possible** if you need to let us know either of the following
+
+   ○ If you have a strong preference for presenting on Monday or Tuesday, or in the morning or afternoon due to timezones or other restrictions.
+   ○ If you already purchased a ticket so we can issue you a refund.
+
+   Okay, with all that out of the way, it's time for the fun part: preparing your talk! To make sure everybody's on the same page, here are a few important things to keep in mind:
+
+   * Remember that one of the biggest strengths of the Write the Docs community is that we come from a huge variety of professional and personal backgrounds.
+     When you're writing your talk (just like when you're writing documentation), think about the diverse needs and interests of your audience, avoid (or define) any jargon-y language, and make sure you clearly express what people are going to learn from your talk.
+   * Remember this is a community conference. If you're representing your employer it's okay to mention that, but please don't treat your talk as a marketing opportunity.
+   * If you would be interested in having another member of the Write the Docs community mentor you through the talk preparation process, please tell us! We'll do our best to connect you with someone to bounce ideas off, to review drafts, and to help you refine your talk before the conference.
+   * Make sure you plan your talk to fit in the allotted time.
+   * Please review our Code of Conduct (http://writethedocs.org/code-of-conduct/) and make sure your talk content adheres to it. As a rule of thumb, if you're on the fence about whether something in your talk could be considered inappropriate or offensive, leave it out. If you have a question about the code, feel free to email us and ask!
+
+   If you're concerned about expenses such as microphones or video cameras, let us know. We do have a budget for speaker expenses, but it can't cover all our speakers.
+   As we confirm your details, we'll publish your abstract, headshot, and information on the conference site. We'll also be emailing attendees so they can share in our excitement about the talks we'll be presenting this year!
+
+   Thanks again for submitting your talk, we look forward to seeing you up on the Write the Docs stage! As you share the good news, remember to tag your posts with #writethedocs. And in the meantime, feel free to email us with any questions, concerns, or ideas.
+
+   Thanks for helping make this year's conference another great one!
+
+   The Write the Docs Team
+
+CFP - Rejection template
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Subject:
+   WTD {{city}} {{year}} -- talk decision
+
+::
+
+   Hi {name},
+
+   Thanks so much for submitting a proposal to speak at this year's Write the Docs {{city}}. Every year we receive a growing number of proposals, and we're always blown away by the amazing breadth of knowledge that our community brings to the table.  Unfortunately, presentation spots are limited and the talk selection committee wasn't able to include your talk in our program this year.
+
+   During the review process, each member of the review committee considered each proposal carefully and then compared notes to make their final selections. We thought it might be useful to share a couple of the common themes for why talks may not have been included for this year's event:
+
+   * We had too many good talks. The quality of our submissions gets higher every year, and we always end up having to pass up on some talks that we're really excited by.
+   * The subject of the talk was too specific for a larger audience. One of the biggest strengths of the Write the Docs community is that we come from a huge variety of professional and personal backgrounds. The committee looks specifically for talks that appeal to a good mix of our attendees.
+   * The subject of the talk was too broad and didn't have a strong enough connection to the core interests of the community.
+   * The talk focused heavily on documentation tooling. We think these talks are important, but we tend to showcase higher-level concepts that progress the way we think in the documentation world.
+   * There were multiple talks on the same topic. We try to choose talks that cover a wide range of topics, which means making some hard choices between multiple great talks on similar topics.
+
+   Keep in mind that we do run several batches of lightning talks that you can sign up for at the event. We also have an unconference space which is a great chance for more informal discussions. We'd love to have you, your ideas, and your passion at the conference--on stage or not, they're what make this event great!
+
+   Thanks again for your proposal. We strongly encourage you to submit again, for future events, and in the meantime we hope to see you in {{city}} or online!
+
+   The Write the Docs Team
+
+
+CFP - Waitlist template
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Subject:
+   WTD {{city}} {{year}} -- talk decision
+
+::
+
+   Hi {name},
+
+   Thanks so much for submitting a proposal to speak at this year's Write the Docs {{city}} conference. Our selection committee has just wrapped up our review, and we had such a hard time choosing from so many awesome proposals. We'd like to ask if you'd be willing to be on the short list of alternate talks that we'd really like to see, but ran out of room for on the schedule.
+
+   Basically, what this entails is bearing with us for another week or two, while we get confirmations from our other speakers. If we have a speaker turn us down, their slot is yours! We'll let you know, one way or the other, in the next couple of weeks, so you won't have be in suspense for too long. Please reply as soon as you can and let us know if you'd be willing to stick it out.
+
+   Thanks again for your proposal, and either way, we hope to see you at the conference!
+
+   The Write the Docs Team
+
+
+01 - Speaker logistics template
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Subject:
+   WTD {{city}} {{year}} -- speaker logistics
+
+::
+
+   Hi {name},
+
+   Just wanted to drop you all a quick note covering some logistics. Talks are pre-recorded again this year, we'd love to get those recordings from you before {{cfp.video_by}}. We do have a videographer who can help you record remotely, drop us a line if that is something you're interested in. We're finalizing details on the live Q&A for each talk.
+
+   ○  I've added some questions to our [CFP tool (Pretalx)]({{cfp.url}}) about your pronouns, interesting facts, name pronunciation, and slack username. Please log in at {{cfp.url}} and answer those (although we'll only need them closer to the event).
+
+   ○ If you haven't done so already, please upload a speaker pic to your Pretalx account while you're there, it'll look so much better than the anonymous outline.
+
+   ○ Private speaker slack channel! If you're not on the slack already, [join the WTD slack]({{slack_join}}). Once you're signed up, or if you're already on there, ping me @plaindocs so I can add you to the private speaker channel. It contains all of our past speakers, who will be happy to offer advice or answer questions.
+
+   ○ [Speaker mentoring guidelines](https://www.writethedocs.org/organizer-guide/confs/cfp/#speaker-mentoring) -- let us know if you'd like to talk over your proposal or slide deck with a speaker from a previous year.
+
+   ○ While you're working on your talks, we'd love for you to check out our updated [speaking tips](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/speaking-tips/) page! It's got all sorts of details on talk format, tech specs, content guidelines, etc.
+
+   Also, if you're ever in doubt about whether something you're writing would be appropriate or not, we'd like to refer you to our conference Code of Conduct, which asks that you refrain from any sexually suggestive or harassing language of any kind. Check it out in full, drop me a line if you have questions: http://www.writethedocs.org/code-of-conduct/
+
+   Looking forward to emailing with you all over the coming months.
+
+   The Write the Docs Team
+
+02 - Video recording template
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Subject:
+   WTD {{city}} {{year}} -- talk recording
+
+::
+
+   Hi {name},
+
+   Here are the important details you've been waiting for! I'll get into specifics below, but first the important ones:
+
+   ○ We'd love you to upload your recorded talk by the **{{ cfp.video_by }}**, or soon after. If you're likely to need more time, please let me know in advance.
+   ○ We have folks who can help you record online, both in US and EU time zones, if this is of interest just let me know and I'll get a slot booked. [Recording guidelines](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/talk-recording-guidelines/).
+   ○ As well as the tips in the recording guidelines we've updated the [speaking tips](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/speaking-tips/) for virtual conferences.
+
+   Now those essentials are covered, a little more info about the event itself:
+
+   * We'll be using [Hopin](https://hopin.to/) for the event, over the coming weeks we'll get you account details so you can update head-shots and taglines on there.
+   * We'll be live captioning as usual, and if you can get copies of your slides to make the captioners work easier that would be delightful. We need those a week or so before the event, so no rush.
+   * In a change from our in person event, we'll be hosting moderated Q&A in a separate Hopin room, directly after each talk.
+
+   Next week I'll send over a provisional schedule, and if having a particular slot would make it easier to attend the Q&A, let me know and I'll see what I can do.
+
+   And while we're here, ;-) if you don't have a profile picture set in [Pretalx](https://pretalx.com/write-the-docs-{{shortcode}}-{{year}}/login/), now would be a great time to add one.
+
+   And I think that is it! I'm excited to see this taking shape and excited to see all of your hard work on the virtual stage!
+
+   Please get in touch if I can help with anything, if you have worries, thoughts or ideas.
+
+   The Write the Docs Team
+
+03 - Provisional schedule template
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Upload:
+   {{cfp_variables['upload']}}
+Video by:
+   {{cfp.video_by}}
+Slides by:
+   {{cfp.slides_by}}
+Provisional schedule:
+   {{cfp.preview}}
+
+----
+
+Subject:
+   WTD {{city}} {{year}} -- schedule and upload drive
+
+::
+
+   Hi {name},
+
+   Hope you're all well!
+
+   We're about five weeks out from the conference now, lots of stuff is happening behind the scenes, and I hope you're feeling good about recording.
+
+   We've got a [provisional schedule]({{cfp.preview}}) up, and I'd *love it* if you could check your time-slot and make sure you can do a live Q&A shortly after your talk is streamed. I've tried to cater to all timezone requirements, but if you can't make your Q&A slot let me know and I'll refactor. We'll be publishing the schedule on **Monday**.
+
+   We're trying something new this year, and doing one Q&A for two talks, so it'll be live call with the emcee, and two speakers (or more for talks with multiple speakers). A mini panel if you will. The exact format for each Q&A will be casual conversation style, the emcee passing moderated questions from the audience to one speaker or the other (or even both where applicable).
+
+   A few folks asked where to upload talk recordings when you have them (by **{{cfp.video_by}}** right?):
+
+   * [Talk recording upload]({{cfp_variables['upload']}})
+
+   If you'd like help recording that, let me know and I'll book you a slot with our videographer Bart.
+
+   You might find it useful to check out the [Recording guidelines](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/talk-recording-guidelines/) and [speaking tips](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/speaking-tips/) for virtual conferences.
+
+   And while we're here, 😉 if you don't have a profile picture set in [Pretalx](https://pretalx.com/write-the-docs-portland-2022/login/), now would be a great time to add one, and to fill out the questions on pronouns, name pronuniation and interests for our emcee intro.
+
+   As we've done for the past few years we'll be live captioning all talks, and it makes the [captioners](https://www.youtube.com/watch?v=xFnM6vmvWaI) lives *much* easier if you can send in a copy of your slides, or even a word list of unusual words that you might use. Please upload those to the [Talk recording drive]({{cfp_variables['upload']}}) by **{{cfp.slides_by}}**.
+
+   In a few weeks I'll be in touch with some calendar invites for a sound check during the conference, to make sure you're all sorted with Hopin logins, audio and video, and to answer any questions you might have.
+
+   And I think that is it! I'm excited to see this taking shape and excited to see all of your hard work on the virtual stage!
+
+   Please get in touch if I can help with anything, if you have worries, thoughts or ideas.
+
+   The Write the Docs Team
+
+04 - Hopin URL and calendly invites
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Tickets:
+   {{cfp_variables['ticket']}}
+Calendly:
+   {{cfp_variables['calendly']}}
+
+----
+
+Subject:
+   WTD {{city}} {{year}} -- hopin and calendly invites
+
+::
+
+   Hi {name},
+
+   The conference is almost upon us! First off, thank you all so much for all of the hard work you've put into getting the recordings done and uploaded. Most of the hard work is behind you, and you can settle in and enjoy the conference 😊, but before you relax entirely, please:
+
+   ○ confirm that you've [uploaded your slides or vocabulary](https://bartatwork.stack.storage/s/tITmETk0y4Zz2nv8) for the captioners, **and** [answered the questions]({proposal_url}) that the emcee uses to record your intro by May 15th.
+
+   ○ register your free [Hopin speaker ticket]({{cfp_variables['ticket']}}) -- the entire conference is held in Hopin, from writing day on Sunday, all talks, unconference sessions, chat, etc. Only the Monday evening social will be held in Spatial.chat.
+
+   ○ schedule an [audio-visual check]({{cfp_variables['calendly']}}) with me or our AV tech **the day before** your talk. This helps me know you're around 😉 and logged in to Hopin, and lets us clear up any audio or visual issues before your Q&A. We recommend you do this even if you're confident about your setup. The audio-visual checks happen in a private Hopin room.
+
+   Remember, all Q&A sessions this year will be a joint chat with the emcee and two speakers, and **start straight after every other talk**, in the Speaker Q&A session (the Monday and Tuesday Q&A sessions have different URLs).
+
+   Some speakers like to hang out in the event chat and answer questions during their talk, but that is entirely up to you. We'll be moderating questions before the Q&A regardless.
+
+   If you have any questions at all about the event, you definitely know how to reach me by now.
+
+   The Write the Docs Team
+
+05 - Post conf
+~~~~~~~~~~~~~~
+
+Feedback:
+   {{cfp_variables['feedback_form']}}
+Gift:
+   {{cfp_variables['speaker_gift_form']}}
+
+----
+
+Subject:
+   WTD {{city}} {{year}} -- feedback, hoodies and THANKS
+
+::
+
+   Hi {name},
+
+   It is a wrap! Thank you one last time for your hard work, insight and creativity.
+
+   We'll be publishing the videos at some point this week or next, keep an eye on Twitter, Slack or the mailing list for those.
+
+   We'd love to know how you found the whole process, from A to Z so we can improve next time. To that end we've got an anonymous (keep in mind that there aren't so many speaks) feedback form for you here:
+
+   ○ [Speaker feedback form]({{cfp_variables['feedback_form']}})
+
+   Finally, as is tradition at our in person events, we'd love to send you a free WTD speaker hoodie and sketchnote print of your talk, please fill in the form before {{cfp.gifts_by}}.
+
+   ○ [Speaker gift form]({{cfp_variables['speaker_gift_form']}})
+
+   The Write the Docs Team
+
+{% elif flagpostconf %}
+
+The conference is over.
+
+{% else %}
+
+Populate the CFP environment variables to see the email templates.::
+
+   export WTD_CFP_UPLOAD='TODO'
+   export WTD_CFP_SPEAKER_TICKET='TODO'
+   export WTD_CFP_CALENDLY='TODO'
+   export WTD_CFP_FEEDBACK_FORM='TODO'
+   export WTD_CFP_SPEAKER_GIFT_FORM='TODO'
+
+.. note:: Do this *inside* your `venv` if you're using one. For example in `venv/bin/activate`
+
+{% endif%}

--- a/docs/conf/atlantic/2023/cfp.rst
+++ b/docs/conf/atlantic/2023/cfp.rst
@@ -1,0 +1,190 @@
+:template: {{year}}/generic.html
+
+Call for Proposals
+==================
+
+Hello hello, fellow documentarians! It's that time of year again: We’re very excited to announce that we are now accepting talk proposals for our next {{ city }} conference, coming up on {{date.main}}. The conference is virtual, so you can speak or attend from anywhere. We will use regular {{ city }} conference times for the scheduling.
+
+Every year, Write the Docs invites people from all across our community to come up on stage to share their insights and experience. Whether you've worked on documentation for decades or you've just started this year, we want to hear from you!
+Read on to learn more about the goals of the conference and what we look for in talk proposals.
+
+{% if flagcfp %}
+In the meantime, mark your calendars:
+
+**The deadline for submitting proposals is Midnight {{tz}} on {{cfp.ends}}.**
+
+We'll let you know if your proposal has been accepted by the end of {{cfp.notification}}.
+{% else %}
+We will announce the CFP soon.
+{% endif %}
+
+.. contents::
+    :local:
+    :depth: 1
+    :backlinks: none
+
+{% if flagcfp %}
+
+Ready to submit your talk?
+You can do that here:
+
+.. raw:: html
+
+    <div class="announcement" style="background-color:white;">
+        <div class="uk-container">
+        <a style="border-bottom: none; font-size: .875rem;" class="uk-button uk-button-announcement uk-text-center" href="{{ cfp.url }}">Submit your proposal</a>
+        </div>
+    </div>
+
+{% endif %}
+
+Conference goals
+----------------
+
+Write the Docs conferences are our chance to get together to explore and celebrate the craft of documentation in a positive, inclusive environment.
+
+Between the talks on stage, the discussions in the unconference, the collaboration on the writing day and other conversations, 100% of the content for our conferences comes from our community! Whether your job title is writer, developer, product manager, support advocate, librarian, or one of a hundred others, your perspective on what makes good docs is what this conference is all about.
+
+Our goal is to give documentarians a chance to connect and learn from each other. You'll have the chance to compare notes on what's happening in the industry, dig into questions of convention and good practice, and generally nerd out about all the things we love about documentation.
+
+This year, as usual, we're trying to iterate on our tried and tested processes, both to improve our program and to give you, the speakers, a better idea of what to expect.
+
+Who we're looking for
+---------------------
+
+The short description here is "if you care about documentation and have something to say about it, we want you to speak"!
+
+That said, there are some more helpful and concrete pointers below.
+
+**Diverse group of speakers**
+
+We welcome talks from first-time speakers, from industry experts, and from everyone in between.
+Whatever your background and experience, we prefer hearing about new approaches rather than about tried-and-tested technology.
+We especially welcome talks from underrepresented groups within the tech community.
+We want to hear a variety of viewpoints, so we limit speakers to two talks in any four year period at each location.
+If you're a WTD conference organizer, please only submit talks to conferences you're not actively organizing.
+
+**Mix of roles and perspectives**
+
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+
+**Diverse audience**
+
+Likewise, we love the diversity of our community, and we encourage support-folks to attend talks about programming, developers to attend talks about writing, writers to attend talks about data, and so on and so forth.
+
+**Past speakers**
+
+Past speaker roles include but are not limited to
+
+* Writers
+* Developers
+* Designers
+* Testers
+* Support folks
+* Developer advocates
+* Community managers
+* Scientists
+* Librarians
+* Teachers
+
+What we’re looking for
+----------------------
+
+**Diverse topics**
+
+The focus of Write the Docs is software documentation, but we actively seek talks that address a wide range of related subjects, at various levels of expertise.
+Documentation perspectives from other fields are welcome, as are topics from adjacent fields!
+
+**Practicality and positivity**
+
+We prefer talks backed by experience and experimentation to talks about theory, and we definitely don't like talks that bad-mouth technologies or approaches.
+Don't tell us why you hate something – tell us how you overcame the problems it was causing.
+
+**Process over tooling**
+
+We tend to avoid talks about specific tools, which often turn into marketing pitches or tutorials.
+We would much rather hear about process, culture, data, people, or the metaphysical side effects of spending your life thinking about docs.
+
+**Audience awareness**
+
+When crafting talk proposals, remember that you're going to be talking to a mix of levels of expertise, skill sets, and professions.
+Your talk doesn't have to be relevant to everyone, but it should be relevant to most people and shouldn't make too many assumptions about what people already know.
+If you are making those assumptions about what your audience knows, it helps everyone if you state them up front explicitly.
+
+It can be  helpful to check out topics that might be related to your talk from previous years as well:
+
+* `Portland {{year-1}} <https://www.writethedocs.org/conf/portland/{{year-1}}/speakers/>`_
+* `Prague {{year-1}} <https://www.writethedocs.org/conf/prague/{{year-1}}/speakers/>`_
+* `Portland {{year-2}} <https://www.writethedocs.org/conf/portland/{{year-2}}/speakers/>`_
+* `Prague {{year-2}} <https://www.writethedocs.org/conf/prague/{{year-2}}/speakers/>`_
+
+Not sure about speaking?
+------------------------
+
+Don't worry too much about whether we will accept your talk proposal, just submit it anyway, and leave the selection up to us. Just because you're not sure whether your topic is a good fit, feel you don't have enough speaking experience for a conference, or you think someone else may be able to give a better talk on your topic does not mean you don't have awesome things to say.
+
+If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
+
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `http://slack.writethedocs.org/ <http://slack.writethedocs.org/>`_.)
+* **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
+
+Because the conference is virtual this year, there is no need for travel, and we're hoping this will make our CFP accessible to more documentarians. We will also provide resources and support for recording your talk.
+
+Selection process
+------------------
+
+We have a small panel of proposal reviewers, and make sure to have a similar diversity in the panel as we're aiming for in our speakers.
+We rate talks out of five, and then discuss the top rated proposals.
+
+We actively balance for diversity in as many ways as we can, which means that we do not review talks anonymously. Maybe one day the industry will be in a place where can do that, but we're certainly not there yet.
+
+Presentation format
+-------------------
+
+Presentations will be scheduled in 30-minute blocks. As the conference is virtual, all talks will be pre-recorded. We will offer resources and support for making your talk recording. After your talk, there will be a live Q&A session. You can opt out of the Q&A if you do not feel comfortable, but please let us know well in advance.
+
+Speaker benefits & logistics
+----------------------------
+
+If you are selected to speak at Write the Docs, we will waive your attendance fee. As the conference is virtual, there are no travel costs.
+If speaking incurs any costs that are difficult for you to cover, please `let us know <mailto:{{email}}>`_ and we'll do our best to help out.
+
+If you already have a ticket, we will of course refund it - just drop us an email at `{{email}} <mailto:{{email}}>`_.
+
+{% if flagcfp %}
+**You’ll hear from us with our proposal decisions by the end of {{cfp.notification}}.**
+
+All talks will be shown prerecorded, and we'll be asking for a **completed video from you by {{cfp.video_by}}**. We have a host of options to support you in making this happen, including the possibility of a live recording call with our videographer. During the conference we'll ask you to participate in a moderated Q&A video session after your talk recording is shown.
+
+{% endif %}
+
+Note that all Speakers must read, understand, and agree to our :doc:`/code-of-conduct`. All talks and slides will need to follow our Code of Conduct. If you are unsure about any aspect of this, please ask us for clarification.
+
+Example proposal
+----------------
+
+If you'd like some guidance on how to create a talk proposal, take a look at our :doc:`Example proposal <example-proposal>`.
+
+Questions?
+----------
+
+If you have any questions, please email us at `{{email}} <mailto:{{email}}>`_ and let us know.
+
+{% if flagcfp %}
+
+Submit your proposal
+--------------------------
+
+Submit your proposal at {{cfp.url}}. You'll need to sign up for a Pretalx account, unless you already have one from a previous conference.
+
+.. raw:: html
+
+    <div class="announcement" style="background-color:white;">
+        <div class="uk-container">
+        <a style="border-bottom: none; font-size: .875rem;" class="uk-button uk-button-announcement uk-text-center" href="{{ cfp.url }}">Submit your proposal</a>
+        </div>
+    </div>
+
+{% endif %}

--- a/docs/conf/atlantic/2023/contact.rst
+++ b/docs/conf/atlantic/2023/contact.rst
@@ -1,0 +1,10 @@
+
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/team.png
+
+Contact Us
+==========
+
+If you have any questions or concerns,
+the best way to reach us is via email.
+You can email us at {{ shortcode }}@writethedocs.org.

--- a/docs/conf/atlantic/2023/convince-your-manager.rst
+++ b/docs/conf/atlantic/2023/convince-your-manager.rst
@@ -1,0 +1,57 @@
+:template: {{year}}/generic.html
+
+Convince Your Manager
+=====================
+
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
+Feel free to adapt and share with your manager to show them the many benefits of attending!
+
+Sample email
+-------------
+
+Remember to change the things in `[brackets]`!
+
+----
+
+  FROM: [your name]
+
+  TO: [your employer or manager's name]
+
+  SUBJECT: Professional Development: Documentation Community Conference
+
+  I'd like to attend Write the Docs {{city}}, which takes place {{ date.main }}. This three-day online event explores the art and science of documentation, and covers a diverse range of topics related to documentation in the software industry.
+
+  Write the Docs conferences bring together everyone who writes the docs – Tech Writers, Developers, Developer Relations, Customer Support – making the events an ideal networking opportunity.
+  Each conference successfully combines a number of different event formats to deliver engaging, practical, and timely content.
+
+  There is a single track of talks, a parallel unconference event, and a community writing day. The `sessions from last year </conf/{{ shortcode }}/{{year-1}}/speakers/>`_ will give you a good idea of the kinds of topics covered, many of which are relevant to my work.
+
+  Costs:
+
+  * Conference ticket - {{tickets.corporate.price}}
+
+  Benefits:
+
+  * Discovering solutions to problems I'm facing at work
+  * Exposure to the latest ideas, techniques, and tools for software docs
+  * Opportunity to learn from the best doc teams in the industry
+  * Building professional connections with other documentarians
+
+  Thanks in advance,
+  [your name]
+
+----
+
+Resources
+---------
+
+When discussing how to pitch the conference, a few generally helpful tips emerged:
+
+* Highlight a few specific talks that relate to ongoing projects at work. (This one's dependent on pitching after the talk line up has been announced).
+* If your company is looking to hire another documentarian, the job fair and networking at the event are an excellent resource.
+* Don't forget that one of the benefits to your attendance is that it raises the visibility of your company in the community. If your team wants a reputation for caring about their docs, having people at Write the Docs is a great way to do that.
+
+In addition, it can be useful to share some info about previous conferences. You can find the websites for previous events on :doc:`/conf/index/`, and a quick list of last year's talks down below.
+But perhaps more useful might be some of the info in our :doc:`press-kit/`, which includes community testimonials, photos, and more.
+

--- a/docs/conf/atlantic/2023/convince-your-manager.rst
+++ b/docs/conf/atlantic/2023/convince-your-manager.rst
@@ -25,7 +25,7 @@ Remember to change the things in `[brackets]`!
   Write the Docs conferences bring together everyone who writes the docs – Tech Writers, Developers, Developer Relations, Customer Support – making the events an ideal networking opportunity.
   Each conference successfully combines a number of different event formats to deliver engaging, practical, and timely content.
 
-  There is a single track of talks, a parallel unconference event, and a community writing day. The `sessions from last year </conf/{{ shortcode }}/{{year-1}}/speakers/>`_ will give you a good idea of the kinds of topics covered, many of which are relevant to my work.
+  There is a single track of talks, a parallel unconference event, and a community writing day. The `sessions from last year </conf/prague/2022/speakers/>`_ will give you a good idea of the kinds of topics covered, many of which are relevant to my work.
 
   Costs:
 

--- a/docs/conf/atlantic/2023/example-proposal.rst
+++ b/docs/conf/atlantic/2023/example-proposal.rst
@@ -1,0 +1,60 @@
+:template: {{year}}/generic.html
+
+Example talk proposal title
+===========================
+
+Substitute a catchy title that promises practical lessons
+
+Abstract
+--------
+
+This is the content that Write the Docs would post on the conference schedule. To evaluate the quality of your proposal, the proposal committee also takes into account all of the other information that you provide.
+
+Include a brief story, typically two to four paragraphs, that describes your personal work experience with the topic. Make sure the abstract appeals to our audience of documentarians. We're suspicious of proposals that look like they belong at other conferences.
+
+Include a list of things that our audience can learn from your talk, such as:
+
+- Lessons that the audience can apply in their own work
+- Things that audiences should research further
+- Spoilers that provide details about the talk
+
+Help your audience think: "Oh yes, this talk could help me when I do X in my work!"
+
+Avoid walls of text. We recommend that you limit your proposal to a maximum of 300 words. If your proposal is accepted, this is what the audience will see in the program when they preview your talk.
+
+Who and Why
+-----------
+
+Use this opportunity to show the selection committee that you empathize with your audience. Help them think: "Oh yes, this talk could help me when I do X in my work!"
+
+Our audience creates documentation primarily for software. Given the variety of tools used for software documentation, we rarely accept talks that focus on a specific software tool or set of tools. Talks that discuss tools should also discuss the wider context, applications, and implications of implementing the tools.
+
+Our audience goes beyond the technical writing community. Here's a typical demographic distribution of people who attend our conferences:
+
+* Technical Writers (60%)
+* Developers (10%)
+* Support Staff (10%)
+* Managers (10%)
+* Community Contributors, Enthusiasts & Other Folks (10%)
+
+Only the proposal committee will see the information that you include here.
+ 
+Other Information
+-----------------
+
+Based on your background, use this section to describe your qualifications to the selection committee.
+
+We welcome talks from first-time speakers, from industry experts, and from everyone in between. Whatever your background and experience, we prefer hearing about new approaches rather than about tried-and-tested technology. We especially welcome talks from underrepresented groups within the tech community.
+
+We've accepted talks from people who work in a variety of roles, including:
+
+* Writers
+* Developers
+* Designers
+* Testers
+* Support
+* Developer advocates
+* Community managers
+* Scientists
+* Librarians
+* Teachers

--- a/docs/conf/atlantic/2023/index.rst
+++ b/docs/conf/atlantic/2023/index.rst
@@ -1,0 +1,26 @@
+:template: {{year}}/index.html
+:banner: _static/conf/images/headers/{{ shortcode }}-group.png
+
+:orphan:
+
+.. raw:: html
+
+  <div class="news-block">
+    <div class="uk-container">
+
+      <h2>Updates from the team</h2>
+      <section>
+      <div class="content">
+
+.. postlist:: 10
+   :date: %B %d, %Y
+   :format: {title} - {date}
+   :list-style: none
+   :tags: {{ shortcode }}-{{ year }}
+
+.. raw:: html
+
+      </div>
+      </section>
+    </div>
+  </div><!--- end news block -->

--- a/docs/conf/atlantic/2023/job-fair.rst
+++ b/docs/conf/atlantic/2023/job-fair.rst
@@ -1,0 +1,39 @@
+:template: {{year}}/generic.html
+
+Job Fair
+========
+
+Connecting people with potential employers has always been a core benefit of attending Write the Docs, so we're excited to introduce some more structure to that connection.
+
+Documentarians looking for jobs will be able to talk to employers to learn about the company culture, ask about specific job openings, and talk to current employees.
+
+If you're an employer looking to fill a role, you can find information about :doc:`reserving a job fair spot <sponsors/prospectus/>` in the sponsorship prospectus.
+
+
+Schedule
+--------
+
+Scheduling information is available on our :doc:`/conf/{{shortcode}}/{{year}}/schedule` page.
+
+
+Tips for Attendees
+------------------
+
+If you're attending the Virtual Job Fair, make sure you're signed in to Hopin.
+
+* Select Expo in the left-hand pane.
+* Select the company of your choice.
+* You now have the following choices:
+
+  * Chat with attendees from the company under the Chat tab.
+  * Select the button to "Share Audio and Video". You can then chat "Face to Face" with company representatives.
+
+Tips for Sponsors
+-----------------
+
+If you want to maximize your contacts with potential new employees, make sure to:
+
+* Make sure your booth staff is registered in the online platform before the conference starts. All sponsor ticket holders will receive details about this a few days before the conference. These staff will be set up as moderators for your booth. As needed, you can also request additional moderators from the designated conference Job Fair volunteer.
+* When you're a moderator, you can always share your audio and video. Other attendees who want to "Share Audio and Video" will appear under the "Moderator Panel" at the bottom of the screen. When you select one or more persons, they'll join you in the video chat.
+
+You can also select users for 1:1 chats.

--- a/docs/conf/atlantic/2023/lightning-talks.rst
+++ b/docs/conf/atlantic/2023/lightning-talks.rst
@@ -1,0 +1,86 @@
+:template: {{year}}/generic.html
+
+Lightning Talks
+===============
+
+A lightning talk is a very short talk, up to 5 minutes, where you share an idea, concept, or a bit of information you find interesting.
+They’re quick, easy, and a great way to speak in front of an audience for the first time.
+Lightning talks allow people to discuss topics that were not covered fully or partially at the conference.
+
+Logistics
+---------
+
+**We're still planning to have plenty of lightning talks in the new online format, and are working on the exact details.**
+
+We have two categories for people who submit talks:
+
+* First-time speakers
+* Experienced speakers
+
+We do this so we have a mix of first time and experienced speakers.
+We also want first-time speakers to know that we care about them having a chance to get on stage.
+
+{% if lightning_talks and lightning_talks.signup_url %}
+**You can sign up for lightning talks each day of the conference** `on our Google Form <{{ lightning_talks.signup_url }}>`_.
+{% endif %}
+
+Planning: What goes into a lightning talk?
+------------------------------------------
+
+A lightning talk should be about **five minutes long**, just long enough to give an overview and make people curious about your topic. You can talk about anything that’s related to the event’s general theme (in the case of Write the Docs, anything even remotely related to documentation).
+
+First, you need a **topic**. Your topic might be:
+
+- A concept, process, or tool that you learned recently or are still learning
+- An idea for a website or product that would solve a problem you have
+- A retrospective, or what went right/wrong during a project you did or are doing
+- Anything relevant that the audience might be interested in knowing more about
+
+Next, you need an **outline** for the content. Think about the **audience**, and the **goal** of your talk. Choose points to make that will be understandable by the audience and achieve your presentation goal. Remember how quickly five minutes goes by when choosing what to include!
+
+Potential **points of interest** might be:
+
+- What could you use this for or when could you use it? Have you already used it? How?
+- When wouldn't it not be as useful? What are some contraindications to using it?
+- Resources related to the subject, including books, documentation, and URLs.
+- Are there any projects or companies that are using what you're sharing?
+- Is this something you'd like to collaborate with others on? Feel free to ASK!
+- What are some of the challenges related to using, building, or configuring what you're showing?
+
+Preparation: Slides are optional
+--------------------------------
+
+You absolutely don’t need slides. However, if you’d like to make slides, use anything that you are comfortable with.
+Don’t worry if it doesn’t look polished, lightning talks don’t need to be!
+You might use Microsoft Word, Keynote, a PDF, or a website.
+Even a simple terminal or console window where you enter commands can work well for presenting your ideas.
+
+If you're running code examples, have them written, debugged, and ready to go.
+Watching someone write code as they go can be great in a longer deep-dive type of talk, but it's not very well-suited to a lightning talk.
+
+Live Demos: Proceed at your own risk
+------------------------------------
+
+You may have the urge to do a live demonstration of the thing you’re talking about.
+It seems like an easy way to help the audience see your vision, and it is… if it works!
+Following Murphy’s Law, however, we can deduce that your live demo will go horribly wrong.
+A failed demo can derail all but the most skilled presenters, but if you choose to do a demo and it goes wrong don’t worry!
+Have a backup story to tell that explains what the demo would have shown and revert to it if necessary.
+
+Presenting: Your own five Minutes on stage!
+-------------------------------------------
+
+Take a deep breath and go for it. You are among friends, and nobody will mind if you make mistakes.
+Almost everyone starts out their public speaking career in the tech industry by giving lightning talks, so you can assume your audience has been in your shoes before. Throw caution to the wind and embrace your five minutes! :)
+
+Finishing up
+------------
+
+Curious people may follow up with you if they’d like to collaborate or have feedback about your presentation.
+
+License
+-------
+
+Thanks to the lovely Portland Python Users Group for use of this content.
+
+Lightning Talks: A Guide for Beginners by Michelle Rowley of PDX Python is licensed under a `Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International License <http://creativecommons.org/licenses/by-nc-sa/4.0/>`__.

--- a/docs/conf/atlantic/2023/mailing-list.rst
+++ b/docs/conf/atlantic/2023/mailing-list.rst
@@ -1,0 +1,35 @@
+:template: {{year}}/generic.html
+
+Join our mailing list
+=====================
+
+.. raw :: html
+
+    <!-- Begin Mailchimp Signup Form -->
+    <div id="mc_embed_signup">
+    <form action="https://writethedocs.us6.list-manage.com/subscribe/post?u=94377ea46d8b176a11a325d03&amp;id=dcf0ed349b" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
+        <div id="mc_embed_signup_scroll">
+
+    <div class="mc-field-group">
+      <label for="mce-EMAIL">Email Address </label>
+      <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
+    </div>
+    <div class="mc-field-group input-group">
+        <ul><li><input type="checkbox" value="1" name="group[14633][1]" id="mce-group[14633]-14633-0" checked><label for="mce-group[14633]-14633-0">Monthly Community Newsletter</label></li>
+    <li><input type="checkbox" value="2" name="group[14633][2]" id="mce-group[14633]-14633-1" checked><label for="mce-group[14633]-14633-1">North American Conference Announcements</label></li>
+    <li><input type="checkbox" value="4" name="group[14633][4]" id="mce-group[14633]-14633-2"><label for="mce-group[14633]-14633-2">European Conference Announcements</label></li>
+    <li><input type="checkbox" value="8" name="group[14633][8]" id="mce-group[14633]-14633-3" ><label for="mce-group[14633]-14633-3">Australian Conference Announcements</label></li>
+    </ul>
+    </div>
+      <div id="mce-responses" class="clear">
+        <div class="response" id="mce-error-response" style="display:none"></div>
+        <div class="response" id="mce-success-response" style="display:none"></div>
+      </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+        <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_94377ea46d8b176a11a325d03_dcf0ed349b" tabindex="-1" value=""></div>
+        <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
+        </div>
+    </form>
+    </div>
+
+    <!--End mc_embed_signup-->
+   <hr>

--- a/docs/conf/atlantic/2023/news/index.rst
+++ b/docs/conf/atlantic/2023/news/index.rst
@@ -1,0 +1,13 @@
+:template: {{year}}/generic.html
+
+News
+====
+
+Updates from the team.
+More here as it happens!
+
+ .. postlist:: 100
+   :date: %A, %B %d, %Y
+   :format: {title} - {date}
+   :list-style: none
+   :tags: {{ shortcode }}-{{ year }}

--- a/docs/conf/atlantic/2023/opportunity-grants.rst
+++ b/docs/conf/atlantic/2023/opportunity-grants.rst
@@ -1,0 +1,73 @@
+:template: {{year}}/generic.html
+
+Opportunity grants
+==================
+
+The grant program for WTD {{ name }} {{ year }} supports people who would otherwise not be able to attend the conference by covering attendance costs. Applications are open to anyone who wants to attend Write the Docs.
+
+{% if grants and grants.url %}
+To apply, fill in the form below.
+{% else %}
+We expect to open the grant program around the same time as ticket sales.
+{% endif %}
+As the conference is virtual this year, the grant offers you a single free ticket to the conference.
+
+We would like to encourage anyone to apply, who would otherwise have difficulties attending the conference.
+You are welcome to apply, even if you have received a grant before from our conferences or any others,
+regardless of the reason making it difficult for you to cover the cost, and with any experience
+level or background.
+
+Depending on the number of applications, we may not be able to provide every applicant with a free ticket. We prioritize applications based on the overall impact that granting an application will have on the applicant, the Write the Docs community, and the applicant's wider community and country, compared to others.
+
+Grant applicants, like all other participants in the Write the Documents community, are required to conform to the Code of Conduct: https://www.writethedocs.org/code-of-conduct/.
+
+{% if grants and grants.ends %}
+**Grant applications are open until {{ grants.ends }}, Midnight {{ tz }}.**
+{% endif %}
+
+.. contents::
+    :local:
+    :depth: 1
+    :backlinks: none
+
+What is covered
+----------------
+
+All grants include a free conference ticket for the virtual conference.
+
+Are you part of a marginalized or underrepresented group in tech?
+------------------------------------------------------------------
+
+Our grant program is open to anyone who wants to attend Write the Docs.
+However, we may prioritise applications from people who are part of a marginalized
+or underrepresented group in tech. If you are not part of any of these groups,
+you are still welcome to apply.
+
+These groups include, but are not limited to:
+
+* women and other gender minorities of all expressions and identities;  for example trans, agender and non-binary people
+* people of color
+* sexuality minorities, including asexual people
+* people with disabilities, both visible and invisible
+* neurodivergent people* people with chronic illnesses or diseases
+* religious and ethnic minorities
+* age minorities (under ~21, over ~50)
+* people experiencing poverty* homeless and home/food insecure people
+* caregivers of children or other dependents
+* people who have experienced trauma and its aftermath (PTSD, anxiety, etc)
+* people living with or recovering from substance abuse
+
+You do not have to tell us which underrepresented group(s) you are a part of.
+
+{% if grants and grants.url %}
+
+Submit your application
+--------------------------
+
+.. raw:: html
+
+	<iframe src="{{ grants.url }}?embedded=true" width="760" height="850" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>
+
+You can also view `the application form <{{ grants.url }}>`_ in its own page.
+
+{% endif %}

--- a/docs/conf/atlantic/2023/outing.rst
+++ b/docs/conf/atlantic/2023/outing.rst
@@ -1,0 +1,24 @@
+:template: {{year}}/generic.html
+
+{% if shortcode == '{{ shortcode }}'%}
+:banner: _static/conf/images/headers/group.png
+
+Write the Docs Boat Ride
+========================
+
+As this year's conference is virtual, we encourage you to go on a boat ride or walk in your own beautiful home town.
+
+{% elif shortcode == 'portland'%}
+
+:banner: _static/conf/images/headers/hike.png
+
+Write the Docs Hike
+===================
+
+{% include "conf/portland/hike.rst" %}
+
+{% else %}
+
+We don't have an outing yet.
+
+{% endif %}

--- a/docs/conf/atlantic/2023/press-kit.rst
+++ b/docs/conf/atlantic/2023/press-kit.rst
@@ -1,0 +1,60 @@
+:template: {{year}}/generic.html
+
+Press Kit
+=========
+
+We love that you're supporting Write the Docs by writing about the conference, sharing news about it on social media, telling people you're planning to attend.
+We're trying to make it as easy as possible for you to do any of the above, so here are some sample tweets, useful information, and handy images you can use.
+
+Sample tweets
+-------------
+
+Use these unedited, or tweak them as needed!
+
+
+.. raw:: html
+
+  <ul>
+    <li>I&#39;m attending Write the Docs {{date.main }} to discuss all things documentation. <br><a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="I&#39;m attending Write the Docs {{date.main }} to discuss all things documentation." data-url="https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/" data-hashtags="writethedocs" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></li>
+    <li>Join writers, programmers, librarians, scientists, developer advocates. and support humans at #writethedocs in {{ date.main }} to discuss all things documentation. <br><a href="https://twitter.com/share?ref_src=twsrc%5Etfw" class="twitter-share-button" data-text="Join writers, programmers, librarians, scientists, developer advocates. and support humans at #writethedocs in {{ date.main }} to discuss all things documentation." data-url="https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/" data-hashtags="writethedocs" data-show-count="false">Tweet</a><script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script></li>
+  </ul>
+
+Good things people have said about us
+-------------------------------------
+
+.. raw:: html
+
+  <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">I&#39;m finding myself really sad that today isn&#39;t a <a href="https://twitter.com/hashtag/writethedocs?src=hash&amp;ref_src=twsrc%5Etfw">#writethedocs</a> day today too. I mean yes, today I can literally write the docs, but still.</p>&mdash; Diana Potter (@drpotter) <a href="https://twitter.com/drpotter/status/601133512205291520?ref_src=twsrc%5Etfw">May 20, 2015</a></blockquote>
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+  <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr"><a href="https://twitter.com/hashtag/writethedocs?src=hash&amp;ref_src=twsrc%5Etfw">#writethedocs</a> ended yesterday. It was such a great conference! <a href="https://t.co/uhyEIYrbTV">https://t.co/uhyEIYrbTV</a></p>&mdash; 🌟 Aleen vs. the Forces of Evil 🌟 (@Aleen) <a href="https://twitter.com/Aleen/status/601111911791534081?ref_src=twsrc%5Etfw">May 20, 2015</a></blockquote>
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+  <blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">On my way home from another great <a href="https://twitter.com/hashtag/writethedocs?src=hash&amp;ref_src=twsrc%5Etfw">#writethedocs</a>. Already working on ways to apply what I learned. If you care about docs, be here next time!</p>&mdash; Daniel D. Beck (@ddbeck) <a href="https://twitter.com/ddbeck/status/601042665744957440?ref_src=twsrc%5Etfw">May 20, 2015</a></blockquote>
+  <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+
+Useful numbers
+---------------
+
+We have some stats about attendees, membership, and website hits over on the following blog posts:
+
+{% include "conf/events/current-stats.rst" %}
+
+Images and logos
+-------------------
+
+We're working on getting our new logos and images up here, in the meantime you can use any of the Creative Commons licensed images from our `Flickr gallery <https://www.flickr.com/photos/writethedocs/>`_ or take a look at the `logo and other assets stylesheet <https://github.com/writethedocs/resources/blob/master/conf/2020/STYLE%20SHEET%202020-2020.pdf>`_.
+
+In particular, we encourage you to use these three photos in your tweets and blog posts, which we think are especially representative of Write the Docs Portland.
+
+.. raw:: html
+
+  <a data-flickr-embed="true"  href="https://www.flickr.com/photos/writethedocs/34495135662/in/album-72157683817839465/" title="All quiet"><img src="https://farm5.staticflickr.com/4162/34495135662_664eaf3870_k.jpg" width="1024" height="683" alt="All quiet"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+
+  <hr>
+
+  <a data-flickr-embed="true"  href="https://www.flickr.com/photos/writethedocs/33849416753/in/album-72157683817839465/" title="Settling in to work"><img src="https://farm5.staticflickr.com/4194/33849416753_acf46120e6_b.jpg" width="1024" height="683" alt="Settling in to work"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+
+  <hr>
+
+  <a data-flickr-embed="true"  href="https://www.flickr.com/photos/writethedocs/33856825394/in/album-72157683817839465/" title="Group shot!"><img src="https://farm5.staticflickr.com/4193/33856825394_27fe2d0b6b_b.jpg" width="1024" height="393" alt="Group shot!"></a><script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>

--- a/docs/conf/atlantic/2023/schedule.rst
+++ b/docs/conf/atlantic/2023/schedule.rst
@@ -1,0 +1,6 @@
+:template: {{year}}/generic.html
+
+Schedule
+========
+
+{% include "conf/schedule.rst" %}

--- a/docs/conf/atlantic/2023/speakers.rst
+++ b/docs/conf/atlantic/2023/speakers.rst
@@ -1,0 +1,17 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/speakers.jpg
+
+Conference Speakers
+===================
+
+**All talk videos will be published on our YouTube channel no later than 1 week after the conference.**
+
+{% if flagspeakersannounced %}
+
+.. datatemplate::
+   :source: /_data/{{shortcode}}-{{year}}-sessions.yaml
+   :template: {{year}}/speakers.rst
+
+{% else %}
+  Nothing to see yet. The speakers for the conference will be announced shortly after the call for papers ends.
+{% endif %}

--- a/docs/conf/atlantic/2023/speaking-tips.rst
+++ b/docs/conf/atlantic/2023/speaking-tips.rst
@@ -1,0 +1,7 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/writing-day.png
+
+Speaking Tips
+=================
+
+{% include "conf/virtual/speaking-tips.rst" %}

--- a/docs/conf/atlantic/2023/sponsors/index.rst
+++ b/docs/conf/atlantic/2023/sponsors/index.rst
@@ -1,0 +1,4 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/{{ shortcode }}-group.png
+
+{% include "include/sponsors.jinja" with context %}

--- a/docs/conf/atlantic/2023/sponsors/prospectus.rst
+++ b/docs/conf/atlantic/2023/sponsors/prospectus.rst
@@ -1,0 +1,270 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/{{ shortcode }}-group.png
+
+Online Sponsorship Prospectus
+#############################
+
+.. contents:: Sections
+   :local:
+   :depth: 1
+   :backlinks: none
+
+Introduction
+============
+
+Welcome to our brand new **Online Conference Sponsorship Prospectus**.
+This document has been adapted for our new virtual conference format,
+including new benefits and increased value across our community.
+
+We're excited to work with the organizations in our community to build the best possible event in {{ year }}.
+In particular, we would love your feedback on sponsorship levels and benefits.
+We expanded the offerings and introduced a lot of new things,
+but please let us know if there are other points of interaction with our community that would be valuable for you.
+
+Concept
+=======
+
+{% include "conf/sponsorship/concept.rst" %}
+
+Demographics
+============
+
+{% include "conf/sponsorship/demographics.rst" %}
+
+Why Sponsor
+===========
+
+{% include "conf/sponsorship/why.rst" %}
+
+Sponsorship Packages
+====================
+
+The following options are suggested sponsorship levels. We are happy to discuss adjustments and custom packages.
+
+Second Draft
+------------
+
+The **Second Draft** package is great for companies looking to hire or to promote a product.
+
+- Three (3) tickets_
+- Two (2) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
+- A short description (250 characters) and logo of your company on the conference website
+- A table at our **virtual job fair**
+- Name included in welcome announcement in email newsletters and social media
+
+The **Second Draft** package costs **{{sponsorship.second_draft.price}}**.
+
+Publisher
+---------
+
+The **Publisher** package is great for sending a team and getting to know the community.
+
+- Seven (7) tickets_
+- Four (4) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
+- A short description (250 characters) and logo of your company on the conference website
+- A table at our **virtual job fair**
+- Name included in welcome announcement in email newsletters and social media
+- A small logo on all Write the Docs website pages for 3 months
+
+The **Publisher** package costs **{{sponsorship.publisher.price}}**.
+
+Patron
+------
+
+**Limit 3**
+
+The **Patron** package highlights your company as a force in the industry and community:
+
+- Thirteen (13) tickets_
+- Seven (7) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
+- A medium description (750 characters and logo of your company on the conference website
+- A **virtual sponsorship booth**
+- A featured table at our **virtual job fair**
+- Small logo included in intermission slides and on talk videos
+- Name included in welcome announcement in email newsletters and social media
+- 5 minute sponsored lightning talk on main stage of the conference
+- One newsletter sponsorship (logo & 300 characters) in our newsletter ({{ newsletter_subs }}+ subscribers)
+- A logo on all Write the Docs website pages until the end of {{ year }}. (30,000 pageviews/mo)
+- A :doc:`small ad </sponsorship/website>` displayed on all non-conferences pages of the Write the Docs website (240x180px, 180 characters, 10,000 pageviews/mo) for 3 months.
+
+The **Patron** package costs **{{sponsorship.patron.price}}**.
+
+Keystone
+--------
+
+The **Keystone** package highlights you as our main community partner:
+
+- Twenty (20) tickets_
+- Ten (10) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
+- A large description (750 characters) and logo of your company on the conference website
+- A featured **virtual sponsorship booth**
+- A featured table at our **virtual job fair**
+- Large logo included in intermission slides and on talk videos
+- Name included in welcome announcement in email newsletters and social media
+- 5 minute sponsored lightning talk on main stage of the conference
+- Two newsletter sponsorships (logo & 300 characters) in our newsletter ({{ newsletter_subs }}+ subscribers)
+- A logo on all Write the Docs website pages until the end of {{ year }}. (30,000 pageviews/mo)
+- A :doc:`small ad </sponsorship/website>` on the Write the Docs website (240x180px, 180 characters, 10,000 pageviews/mo) for 3 months
+
+The **Keystone** package costs **{{sponsorship.keystone.price}}**.
+
+Other Sponsorship Opportunities
+===============================
+
+The following a la carte offerings are available either independently or
+combined with one of the previous packages to increase visibility at the event.
+
+Opportunity Grants
+------------------
+
+Provide additional money for our Opportunity Grant program,
+which provides funding for people to attend the conference.
+
+**{{sponsorship.second_draft.price}}**
+
+This sponsorship helps people attend the conference that couldn't otherwise attend.
+It's great to show your support to the community.
+
+Benefits
+~~~~~~~~
+
+* Your sponsor logo will be shown on the stage during all staff presentations as a grant sponsor (opening, closing).
+* We will mention your company as a grant sponsor on Twitter from the official Write the Docs account
+
+Writing Day
+-----------
+
+Sponsor the Writing Day on Sunday, where we get together to help improve the documentation of many projects.
+This is great for any company that is looking for contributors to their open source projects.
+
+**{{sponsorship.second_draft.price}}**
+
+- **Logistics**: The Writing Day is during the day Sunday.
+
+Inquiries
+=========
+
+Please direct all inquiries to our sponsorship team at:
+
+- sponsorship@writethedocs.org
+
+Payment
+=======
+
+Invoices must be paid **within 30 days of invoice receipt**, or no later than one (1) week before the virtual conference.
+
+.. _ticket: https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}/
+.. _tickets: https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}/
+
+
+Run of Show
+===========
+{% if not flagrunofshow %}
+
+The Run of Show will be published closer to the event.
+
+{% else %}
+
+This Run of Show provides more context about the event and answers some common questions you may have.
+Please let us know if there is any information missing that would be useful for you.
+
+Sponsorship schedule
+--------------------
+
+* **SUNDAY**: The conference online platform is open. You are welcome to hang out at your sponsorship booth and attend the Writing Day, but no formal sponsorship events are happening. You're also encouraged to lead a Writing Day project if your documentation is open source.
+
+* **MONDAY**: The conference platform is open all day from the morning, so we recommend arriving around the time it opens to get the most interaction with attendees. 
+
+* **TUESDAY**: The Job Fair will be on Tuesday morning in the Expo area of the online platform. It will take place in existing sponsorship booths. If you do not have a booth, a temporary booth will be set up for the job fair, and then removed during lunch.
+
+See the :doc:`full schedule </conf/{{ shortcode }}/{{ year }}/schedule>` for exact timing details.
+
+Sponsorship platform
+--------------------
+
+We will be using `Hopin <https://hopin.to/>`_ as our online conference platform. It has multiple unique spaces for attendees during the conference, and we hope it will allow for a good amount of interaction between attendees and sponsors. The conference platform won't become fully active until the Sunday of the conference.
+
+Sponsorship spaces
+------------------
+
+A quick overview of the important spaces in the "venue":
+
+* The *Main stage* is where the talks happen. This is also where Lightning talks will be given.
+* The *Sessions area* is where the Writing Day and Unconference will happen.
+* The *Expo area* is where the Job Fair will happen. You can chat in text or video directly with attendees.
+
+Sponsorship events
+------------------
+
+Job Fair
+~~~~~~~~
+
+On Tuesday morning we hold our Job Fair,
+which is a wonderful place to connect with our over {{ about.attendees }} attendees.
+Many of them are looking for jobs now or will be in the near future,
+so it's a great chance to talk more about your company culture and open positions.
+
+**Logistics**: You will be assigned a sponsor booth in the *Expo area* where you can engage with attendees and answer questions.  We recommend that you answer general questions in the main session and then break off into private calls or chats to talk in more depth with specific people.
+
+You can also offer attendees a link to your website or a way to register interest in your job postings.
+
+Writing day
+~~~~~~~~~~~
+
+On Sunday we hold our Writing Day.
+This is a place where the community gathers to get actual work done.
+This generally involved communities and organizations hosting a documentation sprint on some piece of documentation that is open source and needs improvements.
+
+If you want to participate in the Writing Day,
+it helps to do a bit of work up front.
+The best way to prepare is to have a set of issues that you've already picked as "easy for beginners".
+Starting with these issues will make it much easier for people to start,
+and feel productive.
+Make sure you also have good installation instructions and other helpful beginners content as well.
+
+**Logistics**: We will send a signup sheet to the general attendee list a week before the conference, where you can sign up. You can introduce your project to attendees on Sunday morning during the Writing Day Introduction.
+
+How do I get the most out of my sponsorship?
+--------------------------------------------
+
+Come prepared to engage with our community, and to learn just as much as you teach. Engage with our event as attendees as well as sponsors. Send technical staff who can chat with people on the interesting things your company is doing, and get value from the vast amount of insight in the room. We do have some decision makers in the room, but soft sells will work better than hard sales in the environment we strive for.
+
+Who is my primary contact?
+--------------------------
+
+Eric Holscher will be your primary contact, but our team is available at sponsorship@writethedocs.org. If you have a time sensitive inquiry, please email the entire team to ensure a timely response.
+
+During the conference itself, we will also have a *help desk* available on the Hopin platform.
+You can find staff members there to ask any additional questions you might have.
+
+How do I use my sponsorship tickets?
+------------------------------------
+
+You should have received a unique URL with a discount code for your sponsorship tickets. We are happy to send it over again, just ask!
+
+How do I use my job postings?
+-----------------------------
+
+You can post your jobs to our `job board <https://jobs.writethedocs.org/>`_.
+You will be given a discount code that will let you post them for free,
+please ask us for this if you don't have it!
+They will be published in our :doc:`Newsletter </newsletter>` every month,
+and displayed on our website as well.
+
+What do I need for the job fair?
+--------------------------------
+
+The job fair will be a low key event. Generally we recommend having links available to your job descriptions, and ways for attendees to engage with you online after the event.
+
+What does the platform look and feel like?
+------------------------------------------
+
+You can see a demo of the platform in this video.
+It's currently linked to the expo hall demo,
+but it has demos of all the other areas as well:
+
+.. raw:: html
+
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/JgGVOlbOPUU?start=465" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+{% endif %}

--- a/docs/conf/atlantic/2023/talk-recording-guidelines.rst
+++ b/docs/conf/atlantic/2023/talk-recording-guidelines.rst
@@ -1,0 +1,6 @@
+:template: {{year}}/generic.html
+
+Guidelines for recording talks
+==============================
+
+{% include "conf/virtual/talk-recording-guide.rst" %}

--- a/docs/conf/atlantic/2023/team.rst
+++ b/docs/conf/atlantic/2023/team.rst
@@ -1,0 +1,52 @@
+:template: {{year}}/generic.html
+
+
+Meet the Team
+=============
+
+Our conference is run by a dedicated team consisting mostly of volunteers.
+This page outlines the folks who are helping get things done, and what their roles are.
+
+Folks
+-----
+
+Mikey Ariel
+~~~~~~~~~~~
+
+{% include "bios/mikey.rst" %}
+
+Samuel Wright
+~~~~~~~~~~~~~
+
+{% include "bios/sam.rst" %}
+
+Eric Holscher
+~~~~~~~~~~~~~
+
+{% include "bios/eric.rst" %}
+
+Sasha Romijn
+~~~~~~~~~~~~
+
+{% include "bios/sasha.rst" %}
+
+Primary Roles
+-------------
+
+* **Conference chair** - Mikey Ariel
+* **Code of conduct response** - See `code of conduct </code-of-conduct/#reporting-and-contact-information>`_ page
+* **Speaker coordinator** - Samuel Wright
+* **Unconference coordinator** - Mikey Ariel
+* **Lightning Talk coordinator** - Emily Axel
+* **Infrastructure coordinator** - Sasha Romijn
+* **Swag coordinator** - Mikey Ariel
+* **Communication coordinator** - Mikey Ariel
+* **Job Fair coordinator** - Sasha Romijn
+* **Welcome Wagon coordinators** - Daniel Beck, Andrea Szollossi, Kat Stoica Ostenfeld
+* **Sponsorship coordinator** - Eric Holscher
+* **Writing Day coordinator** - Mikey Ariel
+* **Emcee** - Kate Osadchenko
+* **Q&A coordinator** - Jessica Ulyate
+* **Social media coordinator** - Mikey Ariel
+
+You can read descriptions of all the roles in our :doc:`/organizer-guide/confs/event-roles` doc.

--- a/docs/conf/atlantic/2023/tickets.rst
+++ b/docs/conf/atlantic/2023/tickets.rst
@@ -1,0 +1,127 @@
+:template: {{year}}/generic.html
+
+Tickets
+=======
+
+Ticket Information
+------------------
+
+{% if flagticketsonsale %}
+
+**Tickets are on sale now!**
+
+{% elif flagsoldout %}
+
+Ticket status
+~~~~~~~~~~~~~
+
+**Tickets are sold out!**
+
+{% else %}
+
+**Tickets will be available in {{ date.tickets_live }}.**
+
+{% endif %}
+
+Ticket details
+~~~~~~~~~~~~~~
+
+Write the Docs {{ name }} {{ year }} is a virtual conference. Each ticket includes:
+
+* Live streaming of all talks
+* Q&A with speakers after each talk (may not be available for all speakers)
+* Access to the conference chat with all other attendees, speakers and sponsors
+* Access to the writing day
+* The virtual job fair
+
+**All talk videos will be published on our YouTube channel no later than 1 week after the conference.**
+
+Refund Policy
+-------------
+
+Refunds will be offered with a 10% processing fee until 2 weeks before the conference.
+Refunds after this date are not possible.
+
+Ticket Types
+------------
+
+
+{% if shirts and flaghasshirts %}
+
+.. class:: ticket
+
+**Official Conference Shirts**
+------------------------------------
+
+You can now visit our Write the Docs {{ name }} {{ year }} Pop-Up Shop and order this year’s branded shirt. The campaign will run until **{{ shirts.ends }}**.
+
+* `Buy {{ name }} {{ year }} Shirt <{{ shirts.url }}>`_
+
+{% endif %}
+
+.. class:: ticket
+
+**Corporate Tickets** *{{tickets.corporate.price}}*
+--------------------------------------------
+
+Purchase this ticket if a company is paying for your attendance. Companies interested in sponsorship can also receive tickets to the conference with a sponsorship package.
+
+{% if flagticketsonsale %}
+
+* `Buy Corporate Ticket <https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}>`__
+
+{% endif %}
+
+.. class:: ticket
+
+**Independent Tickets** *{{tickets.independent.price}}*
+--------------------------------------------
+
+Purchase this ticket if you are paying for yourself, or if you work at a non-profit, a government, or a company with fewer than 10 employees.
+
+{% if flagticketsonsale %}
+
+* `Buy Independent Ticket <https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}>`__
+
+{% endif %}
+
+.. class:: ticket
+
+**Student or Unemployed Tickets** *{{tickets.student.price}}*
+--------------------------------------------
+
+Purchase this ticket if you are currently enrolled as a student, or don't currently have a source of income.
+
+{% if flagticketsonsale %}
+
+* `Buy Student or Unemployed Ticket <https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}>`__
+
+{% endif %}
+
+.. class:: ticket
+
+**Corporate Concierge Tickets** *{{tickets.concierge.price}}*
+------------------------------------------------------
+
+We offer a corporate concierge service if your company is unable to follow our regular ticket sales process through the website.
+We can offer payment by invoice, process purchase orders, bank transfers, fill in supplier registration forms, and offer other support.
+Your tickets will be issued after we have received payment.
+The minimum purchase is three tickets.
+
+{% if flagticketsonsale %}
+
+* Contact us at `{{email}} <mailto:{{email}}>`_ for this service.
+
+{% endif %}
+
+.. class:: ticket
+
+**None of the above**
+---------------------
+
+If you can't afford these prices and still wish to attend, you can apply for our grant program.
+{% if grants and grants.ends and grants.url %}
+You can apply until **{{ grants.ends }}, Midnight {{ tz }}** on `our website <https://www.writethedocs.org/conf/{{ shortcode }}/{{ year }}/opportunity-grants/>`_.
+{% else %}
+Grant applications will open soon.
+{% endif %}

--- a/docs/conf/atlantic/2023/unconference-cheatsheet.rst
+++ b/docs/conf/atlantic/2023/unconference-cheatsheet.rst
@@ -1,0 +1,7 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/writing-day.png
+
+Unconference Cheat Sheet
+========================
+
+{% include "conf/virtual/unconference-cheatsheet.rst" %}

--- a/docs/conf/atlantic/2023/unconference.rst
+++ b/docs/conf/atlantic/2023/unconference.rst
@@ -1,0 +1,81 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/writing-day.png
+
+Unconference
+============
+
+Unconference sessions create an opportunity for conference attendees to share ideas, solve problems, and participate in discussions in different ways than we can on the main stage of the conference.
+
+Anyone can suggest and lead a session on a topic -- sessions can be organized as a group discussion on a particular issue, a Q&A, show-and-tell, or anything in between.
+
+If you've never attended an unconference, expect to interact closely with others from the community.
+
+Unconference sessions run all day on Monday, and Tuesday afternoon after the Job Fair.
+
+How does an unconference session work?
+--------------------------------------
+
+There is no stage in an unconference, and sessions instead focus on small group interaction.
+
+Whether you have a topic in mind, or a problem you would like to pose to the rest of the community, there is no wrong way to lead an unconference session. Good sessions emphasize group participation, however, so if you choose a format that includes a lot of your own ideas or material, be prepared to dial it back and use what you have as a starting point, not as the focal point.
+
+Here are a few ideas for how to structure an unconf session, borrowed from `Scott Berkun's post on unconference sessions <http://scottberkun.com/2006/how-to-run-a-great-unconference-session/>`__:
+
+-  **Group discussion** - Pick a topic and facilitate a group discussion.
+-  **The semi-talk** - Use a short presentation to lead into a group discussion on a topic.
+-  **Show and tell** - Show off your latest project, a new tool, or anything else you are excited about.
+-  **Presentation** - Because sessions are meant to be small and inclusive, this is a difficult format to lead a session with. The conference is virtual, so you can share your screen, but expect more interaction from others joining the session, and break often for questions and discussion.
+
+Lead a session
+--------------
+
+To lead an unconf session, propose a topic and pick a time; unconf sessions are scheduled for the same time slots as talks on the main stage.
+
+{% if unconf and unconf.url %}
+
+Sessions take place in Hopin, but you propose a session by adding your topic to a timeslot and table number in the  `Unconference sign-up sheet <{{unconf.url}}>`__.
+
+{% else %}
+
+Sessions take place in Hopin, but you propose a session by adding your topic to a timeslot and table number in the  Unconference sign-up sheet, which will be linked here closer to the event.
+
+{% endif %}
+
+When it's time for your session to begin, join the session in Hopin that corresponds to the table number you signed up for. There's a 15 minute break between sessions, but the previous session might still be running, so let them know it's time to switch. Give attendees a few minutes to join, then start the conversation!
+
+When the next session leader joins your session, it's time to finish up the conversation and let the next session begin. Or your group can end with time to take a break before the next session.
+
+We will start promoting the unconference sessions early in the day on the days of the conference, so post your topic early if you want a particular time slot, or to make sure that there's room.
+
+Keep in mind the following tips (inspired by the “Open Space Technology” infographic):
+
+* Whoever comes is the right people. You can get great results with 5 people or 20 people (the maximum size of sessions in Hopin). Sometimes it can be to have a smaller, but more engaged group in your session; sometimes your proposed topic will be very popular, and you'll need to pay attention to make sure that everyone has a chance to participate as they want.
+
+* Whenever it starts within your allotted time slot is the right time. People might come and go during the session and that’s ok! If you are worried about lack of attendance, see the previous tip.
+
+* Whatever happens is the only thing that could have happened. Even though the session starts out with a topic, keep an open mind to the discussions that occur, and you might end up with a totally different outcome.
+
+* When it’s over, it’s over. The time slots help organize the sessions, but you can finish early if that's how things develop. If a group of you wants to continue the conversation after your time slot is over, you can organize your own session in Hopin, but be aware that it won't appear on the Hopin schedule, so it's up to the group that wants to keep talking to make sure everyone winds up in the right session.
+
+Attend a session
+----------------
+
+{% if unconf and unconf.url %}
+
+* Starting Monday morning, check the `Unconference sign-up sheet <{{ unconf.url }}>`__ to see whether there are any sessions you want to join. New sessions are added all the time, so check back periodically.
+
+{% endif %}
+
+* At the time your chosen sessions start, join the session in Hopin that correspsond to the table number of the session. Sessions are limited to 20 participants, but you can check out a session without joining it too.
+
+* It's fine to join a session, decide it's not right for you, bow out politely, and join another session.
+
+* It's fine to join late if you needed a longer break.
+
+* Feel free to just listen or add your voice to the discussion.
+
+During the conference
+---------------------
+
+Check out the :doc:`/conf/{{shortcode}}/{{year}}/unconference-cheatsheet` for a quick reference that you can use during the conference to make the most out of the unconference. 
+

--- a/docs/conf/atlantic/2023/venue.rst
+++ b/docs/conf/atlantic/2023/venue.rst
@@ -1,0 +1,8 @@
+:template: {{year}}/generic.html
+
+About the Venue
+===============
+
+Our venue this year will be online!
+We're currently working to figure out the exact platform we'll be using.
+This page will be updated once we figure it out.

--- a/docs/conf/atlantic/2023/welcome-wagon.rst
+++ b/docs/conf/atlantic/2023/welcome-wagon.rst
@@ -1,0 +1,6 @@
+:template: {{ year }}/generic.html
+
+Welcome Wagon Guide
+===================
+
+{% include "conf/virtual/welcome-wagon.rst" %}

--- a/docs/conf/atlantic/2023/writing-day-cheatsheet.rst
+++ b/docs/conf/atlantic/2023/writing-day-cheatsheet.rst
@@ -1,0 +1,7 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/writing-day.png
+
+Writing Day Cheat Sheet
+=======================
+
+{% include "conf/virtual/writing-day-cheatsheet.rst" %}

--- a/docs/conf/atlantic/2023/writing-day.rst
+++ b/docs/conf/atlantic/2023/writing-day.rst
@@ -1,0 +1,38 @@
+:template: {{year}}/generic.html
+:banner: _static/conf/images/headers/writing-day.png
+
+Writing Day
+===========
+
+{% include "conf/events/writing-day.rst" %}
+
+Schedule
+--------
+
+- Date & Time: **{{date.day_two.dotw}}, {{date.day_two.date}}, {{date.day_two.writing_day_time}} {{tz}}**.
+- Location: **{{about.venue}}**.
+
+Your Project Here
+-----------------
+
+The Good Docs Project
+^^^^^^^^^^^^^^^^^^^^^
+The `Good Docs Project <https://thegooddocsproject.dev/>`_ is an open source community of technical writers, doc tools experts, and software engineers who are committed to improving the quality of documentation in open source by creating the templates, tools, and resources to empower everyone to create great docs. Come visit our table at Writing Day to provide feedback and collaborate with some of the project leaders on some of our key 2022 initiatives. We'll provide a Google Doc with specific agenda with times for each session on Writing Day.
+
+- **Project overview and Q&A** - We'll start our Writing Day with a high-level introduction to the project followed by a Q&A session.
+- **Template roadmap workshop** - The flagship initiative of our project is to create templates that can be used by both technical writers and non-technical writers to create high quality documentation. In this workshop, you'll participate in a fun, hands-on brainstorming activity to help us decide what templates we should add to our roadmap next. We'll close out this segment by showing you our roadmap and talking about how you can get involved to make the roadmap a reality if you'd like to contribute to the project beyond Writing Day.
+- **Template review workshop** - We have a few templates that are ready for a deeper review from the wider community. Come join this segment of Writing Day to provide feedback on our API Reference template, How To template, Code of Conduct template, and more.
+- **Chronologue workshop** - We're building out a new documentation site for a mock tool called The Chronologue, a telescope that can view astronomical events in different dimensions of time and space. Our documentation site will showcase our templates in action and hopefully provide a good example of excellent documentation in action. Come to this workshop to look at a product mock-up of the Chronologue and talk more about how you could be involved.
+- **Style guide working session** - We recently created an editorial board to review our templates for consistency and to share innovations and lessons learned about creating templates with the rest of the template-writing community. Come join this session to help us set up our first stub style guide (based on one of our templates, of course!) and help us add some recent decisions we've made to the guide. We'd also like your feedback and insights on how to hold effective style decision meetings.
+- **Website feedback help** - Our project website needs help and we know it! Come join this session to provide feedback on our website and talk about how we can redesign the website to better meet the needs of our users and community members.
+
+
+Write the Docs Meetups
+----------------------
+
+Organizing local Write the Docs meetup communities is a rewarding way to participate. During Writing Day, we'll have a table where we can share tips and best practices, especially in this time where all of our meetups are virtual.
+
+During the conference
+---------------------
+
+Check out the :doc:`/conf/{{shortcode}}/{{year}}/writing-day-cheatsheet` for a quick reference that you can use during the conference to make the most out of Writing Day.

--- a/docs/include/conf/current.rst
+++ b/docs/include/conf/current.rst
@@ -1,14 +1,13 @@
 
+2023 Conferences
+----------------
+
+- :doc:`Write the Docs Atlantic 2023 </conf/atlantic/2023/index>`, September 10-12, **Virtual - CEST and EDT**
+
+
 2022 Conferences
 ----------------
 
 - :doc:`Write the Docs Portland 2022 </conf/portland/2022/index>`, May 22-24, **Virtual - PST**
 - :doc:`Write the Docs Prague 2022 </conf/prague/2022/index>`, September 11-13, **Virtual - CET**
 - :doc:`Write the Docs Australia 2022 </conf/australia/2022/index>`, December 8-9, **Virtual - AEDT**
-
-2021 Conferences
-----------------
-
-- :doc:`Write the Docs Portland 2021 </conf/portland/2021/index>`, April 25-27, **"Portland" - Virtual - PST**
-- :doc:`Write the Docs Prague 2021 </conf/prague/2021/index>`, October 3-5, **"Prague" - Virtual - CEST**
-- **Cancelled** - :doc:`Write the Docs Australia & India 2021 </conf/australia/2021/index>`, December 2-3, **"Australia" - Virtual - AEDT**

--- a/docs/include/conf/past.rst
+++ b/docs/include/conf/past.rst
@@ -1,3 +1,10 @@
+2021 Conferences
+----------------
+
+- :doc:`Write the Docs Portland 2021 </conf/portland/2021/index>`, April 25-27, **"Portland" - Virtual - PST**
+- :doc:`Write the Docs Prague 2021 </conf/prague/2021/index>`, October 3-5, **"Prague" - Virtual - CEST**
+- **Cancelled** - :doc:`Write the Docs Australia & India 2021 </conf/australia/2021/index>`, December 2-3, **"Australia" - Virtual - AEDT**
+
 2020 Conferences
 ----------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,8 @@ Here are our latest events, and we hope to see you online or in person soon!
    *
    conf/*
    news/*
+   conf/atlantic/*/*
+   conf/atlantic/*/*/*
    conf/portland/*/*
    conf/portland/*/*/*
    conf/prague/*/*


### PR DESCRIPTION
- [ ] Update colors to be correct?
- [ ] ~~Use a new header image on the pages - something with sea? Means no community view, but may be better than reusing Prague photos everywhere.~~
- [ ] ~~Update all the times we mention in the config YAML? Not sure if they are displayed in landing already.~~
- [ ] Make sure the atlantic email works
- [ ] Make sure we have an atlantic mailing list

This currently conflicts in `_templates/2023` with #1816 - once we merge one, we need to fix the other PR. There is no news post, as that's going to be in #1815.

I also moved the 2021 configs to the past.

<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1823.org.readthedocs.build/
<!-- readthedocs-preview writethedocs-www end -->