### PR TITLE
Ignore PDFs when spellchecking

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
       - uses: codespell-project/actions-codespell@master
         name: Check spelling
         with:
-          skip: "*.svg,*.js,*.map,*.css,*.scss,docs/_data/201[5|6|7]*"
+          skip: "*.pdf,*.svg,*.js,*.map,*.css,*.scss,docs/_data/201[5|6|7]*"
           ignore_words_file: "codespell/ignore.txt"
           path: docs
 


### PR DESCRIPTION
Does what it says. 

<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1830.org.readthedocs.build/en/1830/

<!-- readthedocs-preview writethedocs-www end -->