### PR TITLE
newsletter: remove link

### DIFF
--- a/docs/blog/newsletter-december-2019.rst
+++ b/docs/blog/newsletter-december-2019.rst
@@ -25,7 +25,6 @@ There was another theory for the prevalence of negative comments. Most documenta
 
 Here is some recommended reading:
 
-* `Maybe Our Documentation "Best Practices" Aren't Really Best Practices <https://kayce.basqu.es/blog/best-practices>`__
 * `To Allow Blog Comments or Not? Here's What the Data Shows... <https://optinmonster.com/to-allow-blog-comments-or-not-heres-what-the-data-shows/>`__
 
 As well as some tool suggestions:


### PR DESCRIPTION
I've removed the link to Kayce Basques' blog post (https://kayce.basqu.es/blog/best-practices) as it's throwing a "Page not found/404" error.

It looks like his [website](https://kayce.basqu.es/) is being updated, so it may end up reappearing with a different URL (perhaps) at some point in the future and could therefore be added back in.

This is the message displayed on the homepage of his site:

<img width="615" alt="Screenshot 2022-10-24 at 11 52 30" src="https://user-images.githubusercontent.com/51410533/197499775-42df5870-66ff-4708-8a39-175cfd774316.png">



<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1831.org.readthedocs.build/en/1831/

<!-- readthedocs-preview writethedocs-www end -->