### PR TITLE
Remove phone numbers from the COC

### DIFF
--- a/docs/include/conf/coc/au-coc.rst
+++ b/docs/include/conf/coc/au-coc.rst
@@ -1,11 +1,9 @@
 **Swapnil Ogale**
 
 * swapnilogale@gmail.com
-* +61 (0)422 593 837
 * Slack: swapnil_ogale
 
 **Sam Wright**
 
 * sam@writethedocs.org
-* +61 (0)0484 732 117
 * Slack: plaindocs

--- a/docs/include/conf/coc/eu-coc.rst
+++ b/docs/include/conf/coc/eu-coc.rst
@@ -1,17 +1,14 @@
 **Eric Holscher**
 
 * eric@writethedocs.org
-* +1-757-705-0532
 * slack: ericholscher
 
 **Mikey Ariel**
 
 * mikey@writethedocs.org
-* +420-603-261-361
 * slack: thatdocslady
 
 **Sasha Romijn**
 
 * sasha@writethedocs.org
-* +31-202-443-779
 * slack: sasha

--- a/docs/include/conf/coc/na-coc.rst
+++ b/docs/include/conf/coc/na-coc.rst
@@ -1,17 +1,14 @@
 **Eric Holscher**
 
 * eric@writethedocs.org
-* +1-757-705-0532
 * slack: ericholscher
 
 **Jennifer Rondeau**
 
 * jennifer.rondeau@gmail.com
-* +1-541-513-8624
-* slack: jrondeau
+=* slack: jrondeau
 
 **Sasha Romijn**
 
 * sasha@writethedocs.org
-* +31-202-443-779
 * slack: sasha

--- a/docs/include/conf/coc/na-coc.rst
+++ b/docs/include/conf/coc/na-coc.rst
@@ -6,7 +6,7 @@
 **Jennifer Rondeau**
 
 * jennifer.rondeau@gmail.com
-=* slack: jrondeau
+* slack: jrondeau
 
 **Sasha Romijn**
 

--- a/docs/include/conf/coc/vilnius-coc.rst
+++ b/docs/include/conf/coc/vilnius-coc.rst
@@ -1,11 +1,9 @@
 **Karina Klinkeviciute**
 
 * karina.klinkeviciute@gmail.com
-* +44 756 2300999
 * slack: 
 
 **Aidis Stukas**
 
 * aidiss@gmail.com 
-* +370 641 39571
 * slack: aidiss


### PR DESCRIPTION
These have never been used, and I'm getting weird texts that know who I am, and trying to reduce surface area.

If we want a number folks can text/call, we should probably setup Twilio or something single-use for the conf, or probably an email -> text system.

<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1834.org.readthedocs.build/en/1834/

<!-- readthedocs-preview writethedocs-www end -->