### PR TITLE
Add content to Writing Day for Australia 2022

### DIFF
--- a/docs/_data/australia-2022-config.yaml
+++ b/docs/_data/australia-2022-config.yaml
@@ -185,6 +185,6 @@ flagcancelled: False
 flaghashike: False
 flaghasfood: False
 flaghasboat: False
-flaghaswritingday: False
+flaghaswritingday: True
 flaghasjobfair: False
 flaghasbadgeflair: False

--- a/docs/_data/australia-2022-config.yaml
+++ b/docs/_data/australia-2022-config.yaml
@@ -185,6 +185,6 @@ flagcancelled: False
 flaghashike: False
 flaghasfood: False
 flaghasboat: False
-flaghaswritingday: True
+flaghaswritingday: False
 flaghasjobfair: False
 flaghasbadgeflair: False

--- a/docs/_ext/core.py
+++ b/docs/_ext/core.py
@@ -78,7 +78,7 @@ def load_conference_context_from_yaml(shortcode, year, year_str, page):
 
     # Do some additional contextual validation that can't be done by a YAML schema validator.
     # This aims to produce clear warnings rather than unexplained empty schedule output.
-    if data['flaghaswritingday'] and 'writing_day' not in schedule and shortcode != 'au':
+    if data['flaghaswritingday'] and 'writing_day' not in schedule and shortcode != 'australia':
         raise Exception('ERROR Missing key "writing_day" while reading schedule from %s' %
                         schedule_yaml_file)
     for day in range(1, data['date']['total_talk_days'] + 1):

--- a/docs/_ext/core.py
+++ b/docs/_ext/core.py
@@ -78,7 +78,7 @@ def load_conference_context_from_yaml(shortcode, year, year_str, page):
 
     # Do some additional contextual validation that can't be done by a YAML schema validator.
     # This aims to produce clear warnings rather than unexplained empty schedule output.
-    if data['flaghaswritingday'] and 'writing_day' not in schedule:
+    if data['flaghaswritingday'] and 'writing_day' not in schedule and shortcode != 'au':
         raise Exception('ERROR Missing key "writing_day" while reading schedule from %s' %
                         schedule_yaml_file)
     for day in range(1, data['date']['total_talk_days'] + 1):

--- a/docs/conf/australia/2022/writing-day.rst
+++ b/docs/conf/australia/2022/writing-day.rst
@@ -14,7 +14,7 @@ The Write the Docs Australia 2022 conference will feature workshops and events r
 
 Schedule - Day one
 ------------------
-The Writing Day events will take place both conference days mornings, for a few hours before the conference talks are scheduled. All times are listed in AEDT (Australian Eastern Daylight Time):
+The Writing Day events will take place both conference day mornings, for a few hours before the conference talks are scheduled. All times are listed in AEDT (Australian Eastern Daylight Time):
 
 **9:45 - 10:35** - Kickoff
 
@@ -27,7 +27,7 @@ The Writing Day events will take place both conference days mornings, for a few 
 
 Schedule - Day two
 ------------------
-The Writing Day events will take place both conference days mornings, for a few hours before the conference talks are scheduled. All times are listed in AEDT (Australian Eastern Daylight Time):
+The Writing Day events will take place both conference day mornings, for a few hours before the conference talks are scheduled. All times are listed in AEDT (Australian Eastern Daylight Time):
 
 **9:30 - 11:30** - Template review workshop
 

--- a/docs/conf/australia/2022/writing-day.rst
+++ b/docs/conf/australia/2022/writing-day.rst
@@ -4,18 +4,17 @@
 Writing Day
 ===========
 
-The 2022 Australia Write the Docs conference will feature a light Writing Day
-event as part of the regular conference activities. 
+The Write the Docs Australia 2022 conference will feature a light Writing Day event as part of the regular conference activities. 
 
 What is Writing Day?
 --------------------
 The Writing Day event gives open-source project owners a chance to get some help on their project's documentation needs or their documentation-related projects. The project's maintainers usually prepare simple, modular activities that people can participate in to get introduced to the project and make a meaningful contribution.
 
-The 2022 Australia Write the Docs conference will feature workshops and events run by `The Good Docs Project <https://tinyurl.com/good-docs-australia-2022>`_. The Good Docs Project is an open source community of 35+ technical writers, doc tools experts, UX designers, and software engineers who are committed to improving the quality of documentation in open source. They aim to educate and empower people to create high-quality documentation by providing them with resources, best practices, and tools to enhance their documentation in open source and beyond.
+The Write the Docs Australia 2022 conference will feature workshops and events run by `The Good Docs Project <https://tinyurl.com/good-docs-australia-2022>`_. The Good Docs Project is an open source community of 35+ technical writers, doc tools experts, UX designers, and software engineers who are committed to improving the quality of documentation in open source. They aim to educate and empower people to create high-quality documentation by providing them with resources, best practices, and tools to enhance their documentation in open source and beyond.
 
 Schedule - Day one
 ------------------
-The Writing Day event will be featured in the mornings of both conference days for a few hours before the regular conference begins. All times are listed in AEDT (Australian Eastern Daylight Time):
+The Writing Day events will take place both conference days mornings, for a few hours before the conference talks are scheduled. All times are listed in AEDT (Australian Eastern Daylight Time):
 
 **9:45 - 10:35** - Kickoff
 
@@ -23,21 +22,20 @@ The Writing Day event will be featured in the mornings of both conference days f
 
 **10:45 - 12:00** - Template roadmap workshop
 
-- The flagship initiative of our project is to create templates that can be used by both technical writers and non-technical writers to create high quality documentation. In this workshop, you'll participate in a fun, hands-on brainstorming activity to help us decide which templates we should add to our roadmap next. We'll close out this segment by showing you our roadmap and talking about how you can get involved to make the roadmap a reality if you'd like to contribute to the project beyond Writing Day.
+- The flagship initiative of our project is to create templates that can be used by both technical writers and non-technical writers to create high quality documentation. In this workshop, you'll participate in a fun, hands-on brainstorming activity to help us decide which templates we should add to our roadmap next. We'll close out this segment by showing you our roadmap and talking about how you can get involved to make the roadmap a reality if you'd like to contribute to the project beyond the Writing Day.
 
 
 Schedule - Day two
 ------------------
-The Writing Day event will be featured in the mornings of both conference days for a few hours before the regular conference begins. All times are listed in AEDT (Australian Eastern Daylight Time):
+The Writing Day events will take place both conference days mornings, for a few hours before the conference talks are scheduled. All times are listed in AEDT (Australian Eastern Daylight Time):
 
 **9:30 - 11:30** - Template review workshop
 
-- We have a few templates that are ready for a deeper review from the wider community. Come join this segment of Writing Day to provide feedback on our templates for How To, Release Notes, Contributing Guide, and README.
+- We have a few templates that are ready for a deeper review from the wider community. Come join this segment of the Writing Day to provide feedback on our templates for How To, Release Notes, Contributing Guide, and README.
 
 
-
-How to participate on writing day
----------------------------------
+How to participate in our Writing Day activities
+-------------------------------------------------
 
 **Step 1: Join our table and say hi!**
 

--- a/docs/conf/australia/2022/writing-day.rst
+++ b/docs/conf/australia/2022/writing-day.rst
@@ -4,24 +4,51 @@
 Writing Day
 ===========
 
-{% include "conf/events/writing-day.rst" %}
+The 2022 Australia Write the Docs conference will feature a light Writing Day
+event as part of the regular conference activities. 
 
-Schedule
---------
+What is Writing Day?
+--------------------
+The Writing Day event gives open-source project owners a chance to get some help on their project's documentation needs or their documentation-related projects. The project's maintainers usually prepare simple, modular activities that people can participate in to get introduced to the project and make a meaningful contribution.
 
-- Date & Time: **{{date.day_two.dotw}}, {{date.day_two.date}}, 9:30-17:00 {{tz}}**.
-- Location: **{{about.venue}}**.
+The 2022 Australia Write the Docs conference will feature workshops and events run by `The Good Docs Project <https://tinyurl.com/good-docs-australia-2022>`_. The Good Docs Project is an open source community of 35+ technical writers, doc tools experts, UX designers, and software engineers who are committed to improving the quality of documentation in open source. They aim to educate and empower people to create high-quality documentation by providing them with resources, best practices, and tools to enhance their documentation in open source and beyond.
 
-Your Project Here
------------------
+Schedule - Day one
+------------------
+The Writing Day event will be featured in the mornings of both conference days for a few hours before the regular conference begins. All times are listed in AEDT (Australian Eastern Daylight Time):
 
-Write the Docs Meetups
-----------------------
+**9:45 - 10:35** - Kickoff
 
-Organizing local Write the Docs meetup communities is a rewarding way to participate. During Writing Day, we'll have a table where we can share tips and best practices, especially in this time where all of our meetups are virtual.
+- Come get a general introduction to the Good Docs Project and an overview of the projects that we would like your help with today.
 
-During the conference
----------------------
+**10:45 - 12:00** - Template roadmap workshop
 
-Check out the :doc:`/conf/{{shortcode}}/{{year}}/writing-day-cheatsheet` for a quick reference that you can use during the conference to make the most out of Writing Day. 
+- The flagship initiative of our project is to create templates that can be used by both technical writers and non-technical writers to create high quality documentation. In this workshop, you'll participate in a fun, hands-on brainstorming activity to help us decide which templates we should add to our roadmap next. We'll close out this segment by showing you our roadmap and talking about how you can get involved to make the roadmap a reality if you'd like to contribute to the project beyond Writing Day.
+
+
+Schedule - Day two
+------------------
+The Writing Day event will be featured in the mornings of both conference days for a few hours before the regular conference begins. All times are listed in AEDT (Australian Eastern Daylight Time):
+
+**9:30 - 11:30** - Template review workshop
+
+- We have a few templates that are ready for a deeper review from the wider community. Come join this segment of Writing Day to provide feedback on our templates for How To, Release Notes, Contributing Guide, and README.
+
+
+
+How to participate on writing day
+---------------------------------
+
+**Step 1: Join our table and say hi!**
+
+Introduce yourself and tell us why you're interested in helping our project today! You are welcome to talk to us only using the room's chat function, but we would prefer to have you join the stage and share your audio/video if you are comfortable doing so. It's a little easier for us to interact with people on video, but chat is also fine!
+
+**Step 2: Join a workshop and participate**
+
+We'll offer different workshops throughout the day. Depending on which workshop you join during the day, you might have different links to materials like Miro boards or GitHub pull requests depending which workshop activity we're working on.
+
+**Step 3: Get some swag**
+
+If you participate in at least one workshop, you'll receive a link to a form where you can share your mailing address to get some swag. All participants will get some Good Docs Project stickers!
+
 


### PR DESCRIPTION
This PR adds the content for Writing Day for the Australia 2022 content.

NOTE: I don't know how to get it to show up in the conference menu under "Program" the way it appears for other WTD conferences. I might need @plaindocs to offer advice on that.

<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1837.org.readthedocs.build/en/1837/

<!-- readthedocs-preview writethedocs-www end -->