### PR TITLE
Contributing: Fix punctuation typo

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -47,7 +47,7 @@ Get more information on how to meet the community, learn new things, get involve
    about/about-the-org
 
 
-Our focus is on community, and putting on our conferences is where we spend much of our time and effort
+Our focus is on community, and putting on our conferences is where we spend much of our time and effort.
 Here are our latest events, and we hope to see you online or in person soon!
 
 .. include:: include/conf/current.rst


### PR DESCRIPTION
Fixing a punctuation typo in index.rst in the docs folder.

<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1839.org.readthedocs.build/en/1839/

<!-- readthedocs-preview writethedocs-www end -->