### PR TITLE
Remove mailchimp validation JS that submits form via AJAX

### DIFF
--- a/docs/_templates/navigation.html
+++ b/docs/_templates/navigation.html
@@ -62,5 +62,4 @@
     </div>
 </form>
 </div>
-<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='TICKETLINK';ftypes[1]='url';fnames[2]='COMPANY';ftypes[2]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
 <!--End mc_embed_signup-->

--- a/docs/newsletter.rst
+++ b/docs/newsletter.rst
@@ -69,7 +69,6 @@ too, if you like):
         </div>
     </form>
     </div>
-    <script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='TICKETLINK';ftypes[1]='url';fnames[2]='COMPANY';ftypes[2]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
     <!--End mc_embed_signup-->
 
    <hr>


### PR DESCRIPTION
This was breaking for users,
and seems unnecessary.
We can just submit the form.


<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1845.org.readthedocs.build/en/1845/

<!-- readthedocs-preview writethedocs-www end -->