### PR TITLE
Update Topics page to include talks from 2019 – 2022 conferences

### DIFF
--- a/docs/_data/2019.portland.speakers.yaml
+++ b/docs/_data/2019.portland.speakers.yaml
@@ -793,4 +793,4 @@
     slug: riona-macnamara
     twitter: ''
     website: ''
-  title: "<i>Sponsored Talk</i>: Documentation for Good: Knowledge as a tool for equity and inclusion"
+  title: "Sponsored Talk: Documentation for Good: Knowledge as a tool for equity and inclusion"

--- a/docs/_data/prague-2020-sessions.yaml
+++ b/docs/_data/prague-2020-sessions.yaml
@@ -26,7 +26,7 @@
 
     <li>what the gut instinct of the user when landing on a document.</li>
 
-    <li>if the user is getting what they need from your documentation.<.li></ul>'
+    <li>if the user is getting what they need from your documentation.</li></ul>'
 - title: From Graffiti Writer to Technical Writer
   slug: from-graffiti-writer-to-technical-writer-kruno-golubi
   series: Write the Docs Prague

--- a/docs/topics.rst
+++ b/docs/topics.rst
@@ -87,14 +87,13 @@ Other media
 Including videos, diagrams, and screenshots.
 
 - |:newspaper:| `Is written content outdated - and is it time for video? </blog/newsletter-may-2022/#is-written-content-outdated-and-is-it-time-for-video>`__
-- |:movie_camera:| `Improve Customer Adoption with UI Help </videos/prague/2022/improve-customer-adoption-with-ui-help-prashant-mathapathi/>`__
 - |:newspaper:| `Command prompts in docs </blog/newsletter-october-2020/#command-prompts-in-docs>`__
 - |:newspaper:| `Tips for creating quality screenshots </blog/newsletter-may-2020/#tips-for-creating-quality-screenshots>`__
-- |:movie_camera:| `Bake a Little Documentation Love into Your Product </videos/prague/2020/bake-a-little-documentation-love-into-your-product-matt-reiner/>`__
 - |:movie_camera:| `Need Examples? Write Your Own! </videos/prague/2020/need-examples-write-your-own-joe-malin/>`__
 - |:newspaper:| `Behind the scenes with fonts, emojis, and Unicode </blog/newsletter-october-2019/#behind-the-scenes-with-fonts-emojis-and-unicode>`__
 - |:newspaper:| `Advice for creating technical illustrations </blog/newsletter-august-2019/#advice-for-creating-technical-illustrations>`__
 - |:newspaper:| `Tips and tricks for producing video </blog/newsletter-may-2019/#tips-and-tricks-for-producing-videos>`__
+- |:movie_camera:| `Draw the Docs </videos/portland/2019/draw-the-docs-alicja-raszkowska/>`__
 - |:movie_camera:| `So you want to make videos? </videos/prague/2018/so-you-want-to-make-videos-sarah-ley-hamilton/>`__
 - |:movie_camera:| `Graphic Content Warning: The Pros, Cons, and Alternatives to Screenshots </videos/portland/2018/graphic-content-warning-the-pros-cons-and-alternatives-to-screenshots-steve-stegelin/>`__
 - |:newspaper:| `Automated screenshot-taking </blog/newsletter-april-2018/#new-tool-to-try-out-automated-screenshots>`__
@@ -145,6 +144,19 @@ READMEs
 - |:movie_camera:| `Write the Readable README </videos/na/2016/write-the-readable-readme-daniel-beck/>`__
 - |:movie_camera:| `README Driven Development <https://www.youtube.com/watch?v=2ZhLaahzrOQ&list=PLZAeFn6dfHpnHBLE4qEUwg1LjhDZEvC2A&index=6>`__
 
+In-app documentation
+~~~~~~~~~~~~~~~~~~~~~~
+
+- |:movie_camera:| `Improve Customer Adoption with UI Help </videos/prague/2022/improve-customer-adoption-with-ui-help-prashant-mathapathi/>`__
+- |:movie_camera:| `Bake a Little Documentation Love into Your Product </videos/prague/2020/bake-a-little-documentation-love-into-your-product-matt-reiner/>`__
+- |:movie_camera:| `Tutorials, Tooltips, and Popups…oh MY! How to ease yourself and your users into in-app messaging. </videos/portland/2019/tutorials-tooltips-and-popupsoh-my-how-to-ease-yourself-and-your-users-into-in-app-messaging-meghan-mahar/>`__
+
+Release notes
+~~~~~~~~~~~~~~
+
+- |:newspaper:| `Do we tell users what’s new in the docs? </blog/newsletter-march-2020/#do-we-tell-users-what-s-new-in-the-docs>`__
+- |:movie_camera:| `Learning to love release notes </videos/prague/2018/learning-to-love-release-notes-anne-edwards/>`__
+
 Other specific doc types
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -154,13 +166,12 @@ Including how-tos, reference docs, tutorials, and books.
 - |:movie_camera:| `How to write a book for (and with) an open source community </videos/prague/2021/how-to-write-a-book-for-and-with-an-open-source-community-felicity-brand/>`__
 - |:movie_camera:| `So you need to give bad news to users… </videos/prague/2021/so-you-need-to-give-bad-news-to-users-ryan-macklin-he-they/>`__
 - |:newspaper:| `To answer, or not to answer: FAQs </blog/newsletter-may-2020/#to-answer-or-not-to-answer-faqs>`__
-- |:newspaper:| `Do we tell users what’s new in the docs? </blog/newsletter-march-2020/#do-we-tell-users-what-s-new-in-the-docs>`__
 - |:movie_camera:| `Emulating the Teacher’s Approving Nod in Teaching Material </videos/prague/2020/emulating-the-teacher-s-approving-nod-in-teaching-material-tanks-transfeld/>`__
 - |:movie_camera:| `How (and why) to make awesome video tutorials </videos/australia/2020/how-and-why-to-make-awesome-video-tutorials-sayraphim-lothian/>`__
 - |:movie_camera:| `Microcontent: Designing & Developing Reusable Content </videos/australia/2020/microcontent-designing-developing-reusable-content-scott-deloach/>`__
 - |:movie_camera:| `The Power of Empathy in Support Documentation: A 5-Step Guide </videos/prague/2019/the-power-of-empathy-in-support-documentation-a-5-step-guide-plamena-maleva/>`__
 - |:movie_camera:| `101 to 404s: How to write great error messages </videos/prague/2019/101-to-404s-how-to-write-great-error-messages-james-scott/>`__
-- |:movie_camera:| `Learning to love release notes </videos/prague/2018/learning-to-love-release-notes-anne-edwards/>`__
+- |:movie_camera:| `SDK Reference Manuals: A flow-based approach </videos/portland/2019/sdk-reference-manuals-a-flow-based-approach-chris-bush/>`__
 - |:movie_camera:| `"It's a Feature" - Documenting Known Issues and Product Shortcomings </videos/prague/2018/it-s-a-feature-documenting-known-issues-and-product-shortcomings-ivana-devcic/>`__
 - |:movie_camera:| `Writing the Next Great Tech Book </videos/portland/2018/writing-the-next-great-tech-book-brian-macdonald/>`__
 - |:newspaper:| `Code comments and other musings on developer docs </blog/newsletter-april-2019/#what-s-in-a-code-comment-and-other-musings-on-developer-docs>`__
@@ -300,6 +311,8 @@ Career growth
 - |:newspaper:| `Feeling like a fraud and how to deal with it </blog/newsletter-october-2019/#feeling-like-a-fraud-and-how-to-deal-with-it>`__
 - |:movie_camera:| `Fostering Talent: Mentorship, Peer Reviews and Going Beyond Your Job Description </videos/prague/2019/fostering-talent-mentorship-peer-reviews-and-going-beyond-your-job-description-arran-southall/>`__
 - |:newspaper:| `Making the leap to managing writers </blog/newsletter-july-2019/#making-the-leap-to-managing-writers>`__
+- |:movie_camera:| `Writer? Editor? Teacher? </videos/portland/2019/writer-editor-teacher-kathleen-juell/>`__
+- |:movie_camera:| `Harvest Past Experience to be a Great Tech Writer </videos/portland/2019/harvest-past-experience-to-be-a-great-tech-writer-mark-f-iverson/>`__
 - |:newspaper:| `Tips for lone writers starting from scratch </blog/newsletter-february-2019/#tips-for-lone-writers-starting-from-scratch>`__
 - |:newspaper:| `Personal development goals </blog/newsletter-february-2019/#personal-development-goals-for-documentarians>`__
 - |:newspaper:| `Career paths </blog/newsletter-december-2018/#technical-writing-career-paths>`__
@@ -359,6 +372,7 @@ Localization and globalization
 - |:movie_camera:| `How I use applied linguistics to be a better technical writer </videos/prague/2021/how-i-use-applied-linguistics-to-be-a-better-technical-writer-kat-stoica-ostenfeld/>`__
 - |:movie_camera:| `Influence your customer outreach with best practices for internationalization </videos/australia/2020/influence-your-customer-outreach-with-best-practices-for-internationalization-vikram-mulay/>`__
 - |:movie_camera:| `Found in Translation: Lessons from a Year of Open Source Localization </videos/prague/2019/found-in-translation-lessons-from-a-year-of-open-source-localization-zachary-sarah-corleissen/>`__
+- |:movie_camera:| `Localize the Docs! </videos/portland/2019/localize-the-docs-paul-wallace/>`__
 
 
 Design
@@ -430,6 +444,7 @@ Doc tools
 - |:newspaper:| `How your tools affect your writing </blog/newsletter-december-2019/#how-your-tools-affect-your-writing>`__
 - |:newspaper:| `Deciding on a new tool… </blog/newsletter-october-2019/#deciding-on-a-new-tool>`__
 - |:newspaper:| `… and migrating to a new tool </blog/newsletter-october-2019/#and-migrating-to-a-new-tool>`__
+- |:movie_camera:| `How I Learned to Stop Worrying and Love the Command Line </videos/portland/2019/how-i-learned-to-stop-worrying-and-love-the-command-line-mike-jang/>`__
 - |:movie_camera:| `Choosing a tool... and choosing your moment </videos/prague/2018/choosing-a-tool-and-choosing-your-moment-val-grimm/>`__
 - |:movie_camera:| `Writing extensions in Sphinx: supercharge your docs </videos/au/2017/writing-extensions-in-sphinx-supercharge-your-docs-nicola-nye/>`__
 - |:movie_camera:| `Finally! Trustworthy and Sensible API Documentation with GraphQL </videos/eu/2017/finally-trustworthy-and-sensible-api-documentation-with-graphql-garen-torikian/>`__
@@ -551,6 +566,9 @@ Building docs culture
 - |:movie_camera:| `Adventures in setting up a knowledge system for a research group </videos/prague/2021/adventures-in-setting-up-a-knowledge-system-for-a-research-group-victor-sluiter/>`__
 - |:movie_camera:| `How to be an Avante-Garde Guinea Pig: Building Better Content through Experimentation, Community-building, and Loud Squeaks </videos/prague/2020/how-to-be-an-avante-garde-guinea-pig-building-better-content-through-experimentation-community-building-and-loud-squeaks-jessica-valasek-estenssoro/>`__
 - |:movie_camera:| `Everyone’s a player (in a mid-90s MUD) </videos/australia/2020/everyone-s-a-player-in-a-mid-90s-mud-kenzie-woodbridge/>`__
+- |:movie_camera:| `Documenting for Open Source </videos/portland/2019/documenting-for-open-source-shannon-crabill/>`__
+- |:movie_camera:| `Defying the Status Quo: How a grassroots effort can transform an organization </videos/portland/2019/defying-the-status-quo-how-a-grassroots-effort-can-transform-an-organization-jodie-putrino/>`__
+- |:movie_camera:| `Sponsored Talk: Documentation for Good: Knowledge as a tool for equity and inclusion </videos/portland/2019/documentation-for-good-riona-macnamara/>`__
 - |:newspaper:| `Promoting plain language </blog/newsletter-november-2018/#promoting-plain-language>`__
 - |:newspaper:| `Common misconceptions about docs </blog/newsletter-august-2018/#common-misconceptions-about-documentation>`__
 - |:movie_camera:| `Who Writes the Docs? </videos/portland/2018/who-writes-the-docs-beth-aitman/>`__
@@ -570,6 +588,7 @@ Building community
 - |:movie_camera:| `Peer writing and beyond - An experimental approach to a sustainable open-source projects </videos/portland/2022/peer-writing-and-beyond-an-experimental-approach-to-a-sustainable-open-source-chris-ganta/>`__
 - |:movie_camera:| `All together now: Turning technologists into documentarians </videos/portland/2022/all-together-now-turning-technologists-into-documentarians-liani-lye-she-her/>`__
 - |:movie_camera:| `Helping Your Community Contribute to Developer Documentation </videos/prague/2020/helping-your-community-contribute-to-developer-documentation-diana-lakatos/>`__
+- |:movie_camera:| `Any friend of the docs is a friend of mine: Cultivating a community of documentation advocates </videos/portland/2019/any-friend-of-the-docs-is-a-friend-of-mine-cultivating-a-community-of-documentation-advocates-heather-stenson/>`__
 - |:movie_camera:| `A content manager's guide to crowdsourcing the docs </videos/eu/2017/a-content-manager-s-guide-to-crowdsourcing-the-docs-becky-todd/>`__
 - |:movie_camera:| `No Community Members Were Harmed in the Making of This Doc Sprint </videos/na/2017/no-community-members-were-harmed-in-the-making-of-this-doc-sprint-how-we-ran-a-48-hour-event-to-collect-community-wisdom-into-a-guidebook-for-newsroom-developers-ryan-pitts-lindsay-muscato/>`__
 - |:movie_camera:| `The Wisdom of Crowds: Crowdsourcing Minimalism in an Open Organization </videos/na/2017/the-wisdom-of-crowds-crowdsourcing-minimalism-in-an-open-organization-ingrid-towey/>`__
@@ -615,6 +634,7 @@ Including review, editing, and teaching.
 - |:movie_camera:| `The Pains of Composition: How to write your best documentation in a collaborative world </videos/australia/2020/the-pains-of-composition-how-to-write-your-best-documentation-in-a-collaborative-world-matt-reiner/>`__
 - |:newspaper:| `The challenge of giving difficult feedback </blog/newsletter-november-2019/#the-challenge-of-giving-difficult-feedback>`__
 - |:newspaper:| `Facilitating top-notch doc review </blog/newsletter-june-2019/#facilitating-top-notch-doc-review>`__
+- |:movie_camera:| `How to edit other people’s content without pissing them off </videos/portland/2019/how-to-edit-other-peoples-content-without-pissing-them-off-ingrid-towey/>`__
 - |:movie_camera:| `Good Code, Bad Code & Code Review <https://www.youtube.com/watch?v=Mx4iRq-inm8&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=8>`__
 - |:newspaper:| `Giving feedback </blog/newsletter-february-2018/#it-s-not-personal-it-s-feedback>`__
 - |:newspaper:| `Teaching peers writing </blog/newsletter-may-2017/#peer-to-peer-teaching>`__
@@ -676,6 +696,7 @@ Prioritisation
 ~~~~~~~~~~~~~~
 
 - |:newspaper:| `Dealing with competing priorities </blog/newsletter-april-2019/#dealing-with-competing-priorities>`__
+- |:movie_camera:| `Just Add Data: Make it easier to prioritize your documentation </videos/portland/2019/just-add-data-make-it-easier-to-prioritize-your-documentation-sarah-moir/>`__
 - |:movie_camera:| `Document What Matters: Lean Best Practice for Process Documentation </videos/prague/2018/document-what-matters-lean-best-practice-for-process-documentation-gillian-von-runte/>`__
 - |:movie_camera:| `Where do I start? The art and practice of documentation triage </videos/portland/2018/where-do-i-start-the-art-and-practice-of-documentation-triage-neal-kaplan/>`__
 
@@ -684,6 +705,7 @@ Agile and workflows
 
 - |:newspaper:| `Tracking work </blog/newsletter-july-2020/#tracking-work>`__
 - |:movie_camera:| `Documenting the (Ancient) History of Your Project </videos/prague/2020/documenting-the-ancient-history-of-your-project-natali-vlatko/>`__
+- |:movie_camera:| `Lessons Learned in a Year of Docs-Driven Development </videos/portland/2019/lessons-learned-in-a-year-of-docs-driven-development-jessica-parsons/>`__
 - |:newspaper:| `Task management for docs teams </blog/newsletter-october-2018/#task-management-tools-for-docs-teams>`__
 - |:newspaper:| `Agile workflows for docs </blog/newsletter-october-2018/#show-us-your-workflows>`__
 - |:newspaper:| `Working on Agile teams </blog/newsletter-may-2017/#the-challenges-of-documentation-in-an-agile-environment>`__
@@ -707,7 +729,9 @@ Strategy
 
 - |:movie_camera:| `Lessons Learned from Cloud Ops: Writing Docs for High-Stakes Situations </videos/portland/2022/lessons-learned-from-cloud-ops-writing-docs-for-high-stakes-situations-alastair-dallas/>`__
 - |:movie_camera:| `Content strategy in practice: a case study </videos/australia/2020/content-strategy-in-practice-a-case-study-sam-irons/>`__
+- |:movie_camera:| `Show Me the Money: How to Get Your Docs the Love and Support They Deserve </videos/portland/2019/show-me-the-money-how-to-get-your-docs-the-love-and-support-they-deserve-matt-reiner/>`__
 - |:movie_camera:| `Backseat content strategy <https://www.youtube.com/watch?v=omwamA30e_Y&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=4>`__
+- |:movie_camera:| `Product Documentation Strategy: What Is It and Why Do We Need It? </videos/portland/2019/product-documentation-strategy-what-is-it-and-why-do-we-need-it-kay-miles/>`__
 - |:movie_camera:| `Choosing a tool... and choosing your moment </videos/prague/2018/choosing-a-tool-and-choosing-your-moment-val-grimm/>`__
 - |:movie_camera:| `Audience, Market, Product: Tips for strategic API documentation planning </videos/portland/2018/audience-market-product-tips-for-strategic-api-documentation-planning-bob-watson/>`__
 - |:movie_camera:| `Bootstrapping Docs at a Startup </videos/na/2017/bootstrapping-docs-at-a-startup-jesse-seldess/>`__

--- a/docs/topics.rst
+++ b/docs/topics.rst
@@ -63,6 +63,8 @@ Editing
 Code samples
 ~~~~~~~~~~~~
 
+- |:movie_camera:| `Creating Quality Sample Code </videos/portland/2020/creating-quality-sample-code-jessica-garson/>`__
+- |:movie_camera:| `Need Examples? Write Your Own! </videos/prague/2020/need-examples-write-your-own-joe-malin/>`__
 - |:newspaper:| `Evolving developer docs, code samples </blog/newsletter-april-2018/#evolving-your-developer-docs-as-your-product-matures>`__
 - |:newspaper:| `Command prompts in code samples </blog/newsletter-october-2018/#to-prompt-or-not-to-prompt-that-is-the-question>`__
 - |:movie_camera:| `Making Your Code Examples Shine </videos/portland/2018/making-your-code-examples-shine-larry-ullman/>`__
@@ -89,7 +91,7 @@ Including videos, diagrams, and screenshots.
 - |:newspaper:| `Is written content outdated - and is it time for video? </blog/newsletter-may-2022/#is-written-content-outdated-and-is-it-time-for-video>`__
 - |:newspaper:| `Command prompts in docs </blog/newsletter-october-2020/#command-prompts-in-docs>`__
 - |:newspaper:| `Tips for creating quality screenshots </blog/newsletter-may-2020/#tips-for-creating-quality-screenshots>`__
-- |:movie_camera:| `Need Examples? Write Your Own! </videos/prague/2020/need-examples-write-your-own-joe-malin/>`__
+- |:movie_camera:| `Set your data free with model-based architecture diagramming </videos/portland/2020/set-your-data-free-with-model-based-architecture-diagramming-avi-flax/>`__
 - |:newspaper:| `Behind the scenes with fonts, emojis, and Unicode </blog/newsletter-october-2019/#behind-the-scenes-with-fonts-emojis-and-unicode>`__
 - |:newspaper:| `Advice for creating technical illustrations </blog/newsletter-august-2019/#advice-for-creating-technical-illustrations>`__
 - |:newspaper:| `Tips and tricks for producing video </blog/newsletter-may-2019/#tips-and-tricks-for-producing-videos>`__
@@ -127,6 +129,7 @@ Task-based writing
 API docs
 ~~~~~~~~
 
+- |:movie_camera:| `Shuffle ball change: Sashay your way to clearer API documentation </videos/portland/2021/shuffle-ball-change-sashay-your-way-to-clearer-api-documentation-rachael-stavchansky/>`__
 - |:movie_camera:| `Write the API docs before the API exists </videos/prague/2019/write-the-api-docs-before-the-api-exists-ben-ahmady/>`__
 - |:newspaper:| `Documenting APIs with "interesting" design choices </blog/newsletter-february-2019/#documenting-apis-with-interesting-design-choices>`__
 - |:newspaper:| `When does one API stop and another begin? </blog/newsletter-may-2018/#distinguishing-one-api-from-many>`__
@@ -165,10 +168,13 @@ Including how-tos, reference docs, tutorials, and books.
 - |:newspaper:| `Templates for concept documentation </blog/newsletter-may-2022/#templates-for-concept-documentation>`__
 - |:movie_camera:| `How to write a book for (and with) an open source community </videos/prague/2021/how-to-write-a-book-for-and-with-an-open-source-community-felicity-brand/>`__
 - |:movie_camera:| `So you need to give bad news to users… </videos/prague/2021/so-you-need-to-give-bad-news-to-users-ryan-macklin-he-they/>`__
+- |:movie_camera:| `Writing a perfect technical tutorial </videos/portland/2021/writing-a-perfect-technical-tutorial-jessica-garson/>`__
 - |:newspaper:| `To answer, or not to answer: FAQs </blog/newsletter-may-2020/#to-answer-or-not-to-answer-faqs>`__
 - |:movie_camera:| `Emulating the Teacher’s Approving Nod in Teaching Material </videos/prague/2020/emulating-the-teacher-s-approving-nod-in-teaching-material-tanks-transfeld/>`__
 - |:movie_camera:| `How (and why) to make awesome video tutorials </videos/australia/2020/how-and-why-to-make-awesome-video-tutorials-sayraphim-lothian/>`__
 - |:movie_camera:| `Microcontent: Designing & Developing Reusable Content </videos/australia/2020/microcontent-designing-developing-reusable-content-scott-deloach/>`__
+- |:movie_camera:| `Writing Backwards: Documenting the End-of-Life of a Product </videos/portland/2020/writing-backwards-documenting-the-end-of-life-of-a-product-anni-bond/>`__
+- |:movie_camera:| `Why SDK Docs Matter — And What I’m Doing About It! </videos/portland/2020/why-sdk-docs-matter-and-what-i-m-doing-about-it-shavindri-dissanayake-shavi/>`__
 - |:movie_camera:| `The Power of Empathy in Support Documentation: A 5-Step Guide </videos/prague/2019/the-power-of-empathy-in-support-documentation-a-5-step-guide-plamena-maleva/>`__
 - |:movie_camera:| `101 to 404s: How to write great error messages </videos/prague/2019/101-to-404s-how-to-write-great-error-messages-james-scott/>`__
 - |:movie_camera:| `SDK Reference Manuals: A flow-based approach </videos/portland/2019/sdk-reference-manuals-a-flow-based-approach-chris-bush/>`__
@@ -240,6 +246,7 @@ Maintenance
 
 - |:movie_camera:| `Maintaining Documentation: Make It Easy! </videos/prague/2022/maintaining-documentation-make-it-easy-emilia-juda-zbay/>`__
 - |:newspaper:| `Broken links and how to find them </blog/newsletter-june-2020/#broken-links-and-how-to-find-them>`__
+- |:movie_camera:| `Finding the line: Balancing business continuity and documentation debt </videos/portland/2020/finding-the-line-balancing-business-continuity-and-documentation-debt-luca-janssens/>`__
 - |:movie_camera:| `Future-Proofing Your Support Visuals </videos/prague/2020/future-proofing-your-support-visuals-jen-weaver/>`__
 - |:newspaper:| `When you find inaccuracies in your docs </blog/newsletter-february-2020/#when-you-find-inaccuracies-in-your-docs>`__
 - |:movie_camera:| `Making Yourself Redundant on Day One <https://www.youtube.com/watch?v=QYMUh55eXcY&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=9>`__
@@ -284,6 +291,7 @@ Getting hired
 Related roles
 ~~~~~~~~~~~~~
 
+- |:movie_camera:| `Is Tech Writer a Tester, and Vice Versa, Is Tester a Tech Writer? </videos/portland/2021/is-tech-writer-a-tester-and-vice-versa-is-tester-a-tech-writer-ines-stefanovic/>`__
 - |:newspaper:| `A tale of two careers </blog/newsletter-august-2020/#a-tale-of-two-careers>`__
 - |:movie_camera:| `What Writing Dictionaries Taught Me About Writing Documentation (And What I Had to Unlearn) </videos/portland/2018/what-writing-dictionaries-taught-me-about-writing-documentation-and-what-i-had-to-unlearn-erin-mckean/>`__
 - |:newspaper:| `Exploring other careers </blog/newsletter-february-2017/#exploring-your-technical-writing-career-options>`__
@@ -306,7 +314,6 @@ Career growth
 - |:newspaper:| `A magnificent array of management topics </blog/newsletter-july-2020/#a-magnificent-array-of-management-topics>`__
 - |:movie_camera:| `From Graffiti Writer to Technical Writer </videos/prague/2020/from-graffiti-writer-to-technical-writer-kruno-golubi/>`__
 - |:movie_camera:| `Overcoming the Plight of Lone Writers </videos/australia/2020/overcoming-the-plight-of-lone-writers-ankita-tripathi/>`__
-- |:movie_camera:| `Onboard yourself: How to get set-up for success in a new role </videos/australia/2020/onboard-yourself-how-to-get-set-up-for-success-in-a-new-role-michael-belton/>`__
 - |:newspaper:| `Leading and following: finding a mentor, being a mentor </blog/newsletter-october-2019/#leading-and-following-finding-a-mentor-being-a-mentor>`__
 - |:newspaper:| `Feeling like a fraud and how to deal with it </blog/newsletter-october-2019/#feeling-like-a-fraud-and-how-to-deal-with-it>`__
 - |:movie_camera:| `Fostering Talent: Mentorship, Peer Reviews and Going Beyond Your Job Description </videos/prague/2019/fostering-talent-mentorship-peer-reviews-and-going-beyond-your-job-description-arran-southall/>`__
@@ -328,14 +335,20 @@ Career growth
 Building a team
 ~~~~~~~~~~~~~~~
 
+Including onboarding new writers
+
 - |:movie_camera:| `How I convinced my boss to build our docs team </videos/prague/2022/how-i-convinced-my-boss-to-build-our-docs-team-karissa-van-baulen/>`__
 - |:movie_camera:| `From Me to Us: Building a docs team from the ground up </videos/portland/2022/from-me-to-us-building-a-docs-team-from-the-ground-up-lana-brindley-she-her/>`__
+- |:movie_camera:| `Level Up - Onboarding that enables writers to thrive </videos/portland/2021/level-up-onboarding-that-enables-writers-to-thrive-nicola-yap/>`__
+- |:movie_camera:| `Onboard yourself: How to get set-up for success in a new role </videos/australia/2020/onboard-yourself-how-to-get-set-up-for-success-in-a-new-role-michael-belton/>`__
+
 
 Learning...
 ~~~~~~~~~~~
 
 - |:movie_camera:| `The Art of Asking Questions </videos/prague/2022/the-art-of-asking-questions-jeff-smith/>`__
 - |:newspaper:| `What we’re learning in #learn-tech-writing </blog/newsletter-october-2020/#what-we-re-learning-in-learn-tech-writing>`__
+- |:movie_camera:| `Read the Rules: What technical writers can learn from board game design </videos/portland/2020/read-the-rules-what-technical-writers-can-learn-from-board-game-design-matthew-baldwin/>`__
 - |:newspaper:| `Learning regular expressions (regex) </blog/newsletter-october-2020/#learning-regular-expressions-regex>`__
 - |:newspaper:| `Book club: an intro to ‘Every Page is Page One’ </blog/newsletter-april-2020/#book-club-an-intro-to-every-page-is-page-one>`__
 - |:newspaper:| `Learning material recommendations - fundamentals of tech writing, contenet strategy, API docs, Git </blog/newsletter-march-2020/#learning-material-recommendations>`__
@@ -352,6 +365,8 @@ Accessibility and inclusivity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - |:movie_camera:| `ADHD and its impact on the Creative Process for Writers </videos/prague/2022/adhd-and-its-impact-on-the-creative-process-for-writers-tyler-smith/>`__
+- |:movie_camera:| `Writing Documentation with Neurodivergent Open Source Contributors In Mind </videos/portland/2021/writing-documentation-with-neurodivergent-open-source-contributors-in-mind-rin-oliver/>`__
+- |:movie_camera:| `Moving beyond empathy: a11y in documentation </videos/portland/2020/moving-beyond-empathy-a11y-in-documentation-alexandra-white/>`__
 - |:newspaper:| `Resources for diverse example names </blog/newsletter-july-2020/#resources-for-diverse-example-names>`__
 - |:movie_camera:| `Inclusive environments are better: science says so </videos/prague/2019/inclusive-environments-are-better-science-says-so-ilona-koren-deutsch/>`__
 - |:movie_camera:| `A11y-Friendly Documentation </videos/prague/2018/a11y-friendly-documentation-carolyn-stransky/>`__
@@ -371,6 +386,7 @@ Localization and globalization
 - |:movie_camera:| `Toward the broader globalization of Open Source: documenting your localisation Journey </videos/prague/2022/toward-the-broader-globalization-of-open-source-documenting-your-localisation-j-melissa-black/>`__
 - |:movie_camera:| `How I use applied linguistics to be a better technical writer </videos/prague/2021/how-i-use-applied-linguistics-to-be-a-better-technical-writer-kat-stoica-ostenfeld/>`__
 - |:movie_camera:| `Influence your customer outreach with best practices for internationalization </videos/australia/2020/influence-your-customer-outreach-with-best-practices-for-internationalization-vikram-mulay/>`__
+- |:movie_camera:| `Globalise the docs </videos/portland/2020/globalise-the-docs-lucy-carey/>`__
 - |:movie_camera:| `Found in Translation: Lessons from a Year of Open Source Localization </videos/prague/2019/found-in-translation-lessons-from-a-year-of-open-source-localization-zachary-sarah-corleissen/>`__
 - |:movie_camera:| `Localize the Docs! </videos/portland/2019/localize-the-docs-paul-wallace/>`__
 
@@ -392,6 +408,7 @@ UX writing
 ~~~~~~~~~~
 
 - |:newspaper:| `Edge cases and when (and where!) to document them </blog/newsletter-june-2022/#edge-cases-and-when-and-where-to-document-them>`__
+- |:movie_camera:| `Invisible influence — the documentation behind UX copy </videos/portland/2021/invisible-influence-the-documentation-behind-ux-copy-katherine-karaus/>`__
 - |:movie_camera:| `Little words, big ideas: How to write microcopy that works </videos/australia/2020/little-words-big-ideas-how-to-write-microcopy-that-works-yael-ben-david/>`__
 - |:movie_camera:| `UX Writing - Let Your Product Speak <https://www.youtube.com/watch?v=TGdm-1vVLDw&index=10&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt>`__
 - |:movie_camera:| `Creating experiences with information <https://www.youtube.com/watch?v=N_fUHIu9cl4&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=6>`__
@@ -440,7 +457,12 @@ Doc tools
 - |:movie_camera:| `Two years of Markdoc: what we’ve learned about balancing developer and author experience </videos/prague/2022/two-years-of-markdoc-what-we-ve-learned-about-balancing-developer-and-author-ex-ryan-paul/>`__
 - |:newspaper:| `Standards in documentation tooling </blog/newsletter-december-2021/#standards-in-documentation-tooling>`__
 - |:movie_camera:| `Hitchhiker’s Guide to Documentation Tools and Processes </videos/prague/2021/hitchhiker-s-guide-to-documentation-tools-and-processes-lukas-reu-ner/>`__
+- |:movie_camera:| `Putting the “tech” in technical writer </videos/portland/2021/putting-the-tech-in-technical-writer-swapnil-ogale/>`__
+- |:movie_camera:| `Documentation as an application: enabling interactive content that is tailored to the user </videos/portland/2020/documentation-as-an-application-enabling-interactive-content-that-is-tailored-to-the-user-ryan-paul/>`__
+- |:movie_camera:| `Model-view-docs: taming large-scale documentation projects using structured data </videos/portland/2020/model-view-docs-taming-large-scale-documentation-projects-using-structured-data-luc-perkins/>`__
 - |:movie_camera:| `The Rocky Road to DocOps </videos/prague/2020/the-rocky-road-to-docops-chris-noonan/>`__
+- |:movie_camera:| `Don’t Fear Migration! How to Successfully Move Docs to a New Tool </videos/portland/2020/don-t-fear-migration-how-to-successfully-move-docs-to-a-new-tool-brooke-wayne/>`__
+- |:movie_camera:| `Where Documentation, Cloud-hosted Interactive Tutorials and Continuous Integration Testing Intersect </videos/portland/2020/where-documentation-cloud-hosted-interactive-tutorials-and-continuous-integration-testing-intersect-dan-gunter/>`__
 - |:newspaper:| `How your tools affect your writing </blog/newsletter-december-2019/#how-your-tools-affect-your-writing>`__
 - |:newspaper:| `Deciding on a new tool… </blog/newsletter-october-2019/#deciding-on-a-new-tool>`__
 - |:newspaper:| `… and migrating to a new tool </blog/newsletter-october-2019/#and-migrating-to-a-new-tool>`__
@@ -504,17 +526,24 @@ Git
 - |:newspaper:| `Learning material recommendations - fundamentals of tech writing, contenet strategy, API docs, Git </blog/newsletter-march-2020/#learning-material-recommendations>`__
 - |:newspaper:| `Learning Git </blog/newsletter-april-2017/#starter-kit-for-command-line-git>`__
 
+Search
+~~~~~~~
+
+- |:movie_camera:| `The Search for Search </videos/portland/2020/the-search-for-search-paul-logan/>`__
+- |:movie_camera:| `Making documentation discoverable in search engines </videos/prague/2020/making-documentation-discoverable-in-search-engines-myriam-jessier/>`__
+
+
 Metrics and analytics
 ---------------------
 
 - |:newspaper:| `Discovering user needs </blog/newsletter-august-2019/#starting-out-with-analytics-and-then-upping-your-game>`__
 - |:movie_camera:| `Don’t trust the numbers! </videos/portland/2022/don-t-trust-the-numbers-kumar-dhanagopal/>`__
 - |:movie_camera:| `The Importance of Using Analytics and Feedback for your Documentation </videos/prague/2020/the-importance-of-using-analytics-and-feedback-for-your-documentation-karissa-van-baulen/>`__
-- |:movie_camera:| `Making documentation discoverable in search engines </videos/prague/2020/making-documentation-discoverable-in-search-engines-myriam-jessier/>`__
 
 User research
 ~~~~~~~~~~~~~
 
+- |:movie_camera:| `Walking Backwards: Tracing the New Customer Journey from Finish to Start to Help Shape Content </videos/portland/2020/walking-backwards-tracing-the-new-customer-journey-from-finish-to-start-to-help-shape-content-sally-stumbo/>`__
 - |:newspaper:| `Starting out with analytics - and then upping your game </blog/newsletter-august-2019/#starting-out-with-analytics-and-then-upping-your-game>`__
 - |:newspaper:| `Discovering user needs </blog/newsletter-december-2018/#discovering-user-needs>`__
 - |:movie_camera:| `Research like you’re wrong: Lessons from user research gone rogue </videos/portland/2018/research-like-you-re-wrong-lessons-from-user-research-gone-rogue-jen-lambourne/>`__
@@ -556,6 +585,7 @@ Metrics
 Culture and community
 ---------------------
 
+- |:movie_camera:| `A guide to getting started in open source </videos/portland/2021/a-guide-to-getting-started-in-open-source-abigail-mccarthy/>`__
 - |:movie_camera:| `5 things I learned from my first open source contribution </videos/australia/2020/5-things-i-learned-from-my-first-open-source-contribution-andrea-szollossi/>`__
 - |:movie_camera:| `A Year in the Life of The Better Docs Project </videos/prague/2018/a-year-in-the-life-of-the-better-docs-project-rowan-cota/>`__
 - |:movie_camera:| `Technical writing as public service: working on open source in government </videos/na/2016/technical-writing-as-public-service-working-on-open-source-in-government-britta-gustafson/>`__
@@ -564,6 +594,7 @@ Building docs culture
 ~~~~~~~~~~~~~~~~~~~~~
 
 - |:movie_camera:| `Adventures in setting up a knowledge system for a research group </videos/prague/2021/adventures-in-setting-up-a-knowledge-system-for-a-research-group-victor-sluiter/>`__
+- |:movie_camera:| `Almost None to Some: Driving DISQO’s Doc Culture as a Solo Documentarian </videos/portland/2021/almost-none-to-some-driving-disqo-s-doc-culture-as-a-solo-documentarian-falon-darville/>`__
 - |:movie_camera:| `How to be an Avante-Garde Guinea Pig: Building Better Content through Experimentation, Community-building, and Loud Squeaks </videos/prague/2020/how-to-be-an-avante-garde-guinea-pig-building-better-content-through-experimentation-community-building-and-loud-squeaks-jessica-valasek-estenssoro/>`__
 - |:movie_camera:| `Everyone’s a player (in a mid-90s MUD) </videos/australia/2020/everyone-s-a-player-in-a-mid-90s-mud-kenzie-woodbridge/>`__
 - |:movie_camera:| `Documenting for Open Source </videos/portland/2019/documenting-for-open-source-shannon-crabill/>`__
@@ -587,6 +618,7 @@ Building community
 
 - |:movie_camera:| `Peer writing and beyond - An experimental approach to a sustainable open-source projects </videos/portland/2022/peer-writing-and-beyond-an-experimental-approach-to-a-sustainable-open-source-chris-ganta/>`__
 - |:movie_camera:| `All together now: Turning technologists into documentarians </videos/portland/2022/all-together-now-turning-technologists-into-documentarians-liani-lye-she-her/>`__
+- |:movie_camera:| `Documentation Communities: Sound Strategy or Documentarian’s Gambit? </videos/portland/2021/documentation-communities-sound-strategy-or-documentarian-s-gambit-laura-novich/>`__
 - |:movie_camera:| `Helping Your Community Contribute to Developer Documentation </videos/prague/2020/helping-your-community-contribute-to-developer-documentation-diana-lakatos/>`__
 - |:movie_camera:| `Any friend of the docs is a friend of mine: Cultivating a community of documentation advocates </videos/portland/2019/any-friend-of-the-docs-is-a-friend-of-mine-cultivating-a-community-of-documentation-advocates-heather-stenson/>`__
 - |:movie_camera:| `A content manager's guide to crowdsourcing the docs </videos/eu/2017/a-content-manager-s-guide-to-crowdsourcing-the-docs-becky-todd/>`__
@@ -609,6 +641,7 @@ Style guides
 
 - |:newspaper:| `Choosing a style guide </blog/newsletter-november-2022/#choosing-a-style-guide>`__
 - |:movie_camera:| `The Art of Consistency: Creating an in-house style guide <https://www.youtube.com/watch?v=IDLSiX9O0Lg&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=11>`__
+- |:movie_camera:| `Building a style guide from the ground up: lessons learned from a lone writer </videos/portland/2021/building-a-style-guide-from-the-ground-up-lessons-learned-from-a-lone-writer-deanna-thompson/>`__
 - |:movie_camera:| `What They Don't Tell You About Creating New Style Guides </videos/portland/2018/what-they-don-t-tell-you-about-creating-new-style-guides-thursday-bram/>`__
 - |:newspaper:| `Enforcing UI style guides </blog/newsletter-june-2017/#the-enforcer-ui-style-guides-edition>`__
 - |:newspaper:| `Style guides we like </blog/newsletter-november-2016/#a-quick-guide-to-style-guides>`__
@@ -668,6 +701,7 @@ Including product managers, higher-ups, etc.
 
 - |:newspaper:| `Improving communication about what's in releases </blog/newsletter-september-2022/#improving-communication-about-what-s-in-releases>`__
 - |:movie_camera:| `Documentation as Marketing? From Conflict to Collaboration </videos/prague/2022/documentation-as-marketing-from-conflict-to-collaboration-mano-toth/>`__
+- |:movie_camera:| `Collaborating with teams on content strategy planning: pitfalls and best practices </videos/portland/2020/collaborating-with-teams-on-content-strategy-planning-pitfalls-and-best-practices-kateryna-osadchenko/>`__
 - |:newspaper:| `Getting more info from SMEs </blog/newsletter-may-2020/#getting-more-info-from-smes>`__
 - |:movie_camera:| `An introduction to developer experience, and the role of a documentarian </videos/australia/2020/an-introduction-to-developer-experience-and-the-role-of-a-documentarian-chris-ward/>`__
 - |:movie_camera:| `The subtle art of interrogation <https://www.youtube.com/watch?v=HVdzjFeaM7k&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=7>`__
@@ -705,6 +739,7 @@ Agile and workflows
 
 - |:newspaper:| `Tracking work </blog/newsletter-july-2020/#tracking-work>`__
 - |:movie_camera:| `Documenting the (Ancient) History of Your Project </videos/prague/2020/documenting-the-ancient-history-of-your-project-natali-vlatko/>`__
+- |:movie_camera:| `Building a content-focused, scientific document authoring workflow for Data Scientists and Engineers alike </videos/portland/2020/building-a-content-focused-scientific-document-authoring-workflow-for-data-scientists-and-engineers-alike-colin-dean/>`__
 - |:movie_camera:| `Lessons Learned in a Year of Docs-Driven Development </videos/portland/2019/lessons-learned-in-a-year-of-docs-driven-development-jessica-parsons/>`__
 - |:newspaper:| `Task management for docs teams </blog/newsletter-october-2018/#task-management-tools-for-docs-teams>`__
 - |:newspaper:| `Agile workflows for docs </blog/newsletter-october-2018/#show-us-your-workflows>`__
@@ -728,6 +763,8 @@ Strategy
 ~~~~~~~~
 
 - |:movie_camera:| `Lessons Learned from Cloud Ops: Writing Docs for High-Stakes Situations </videos/portland/2022/lessons-learned-from-cloud-ops-writing-docs-for-high-stakes-situations-alastair-dallas/>`__
+- |:movie_camera:| `Always complete, never finished </videos/portland/2021/always-complete-never-finished-daniele-procida/>`__
+- |:movie_camera:| `Beyond metrics: Using maturity models to develop a docs strategy </videos/portland/2021/beyond-metrics-using-maturity-models-to-develop-a-docs-strategy-sarah-r-rodlund/>`__
 - |:movie_camera:| `Content strategy in practice: a case study </videos/australia/2020/content-strategy-in-practice-a-case-study-sam-irons/>`__
 - |:movie_camera:| `Show Me the Money: How to Get Your Docs the Love and Support They Deserve </videos/portland/2019/show-me-the-money-how-to-get-your-docs-the-love-and-support-they-deserve-matt-reiner/>`__
 - |:movie_camera:| `Backseat content strategy <https://www.youtube.com/watch?v=omwamA30e_Y&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=4>`__
@@ -756,6 +793,7 @@ Theories/Philosophy
 Maths, science and history
 --------------------------
 
+- |:movie_camera:| `The Secret History of Libraries </videos/portland/2021/the-secret-history-of-libraries-paris-buttfield-addison/>`__
 - |:movie_camera:| `A Journey to Pattern Languages </videos/prague/2020/a-journey-to-pattern-languages-andrew-haynes/>`__
 - |:movie_camera:| `Facebook, Dynamite, Uber, Bombs, and You <https://www.youtube.com/watch?v=N13_FP2NkSk&t=0s&index=2&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt>`__
 - |:movie_camera:| `A brief history of text markup languages </videos/prague/2018/a-brief-history-of-text-markup-languages-tony-ibbs/>`__

--- a/docs/topics.rst
+++ b/docs/topics.rst
@@ -1,7 +1,7 @@
 Videos and articles
 ===================
 
-This page links to the topics that have been covered by `conference </conf/>`__ talks or in the `newsletter </newsletter/>`__. They’re in no particular order, and some topics are repeated if they fit into more than one category. Enjoy!
+This page links to the topics that have been covered by `conference </conf/>`__ talks or in the `newsletter </newsletter/>`__. They're in no particular order, and some topics are repeated if they fit into more than one category. Enjoy!
 
 If you think something is wrongly categorised, please send us a pull request :)
 
@@ -31,6 +31,7 @@ Naming and terminology
 - |:newspaper:| `Common words and how to identify them </blog/newsletter-june-2020/#common-words-and-how-to-identify-them>`__
 - |:movie_camera:| `Even Naming This Talk Is Hard </videos/na/2017/even-naming-this-talk-is-hard-ruthie-bendor/>`__
 - |:movie_camera:| `Whatchamacallit: Controlled Vocabularies for Technical Writers </videos/eu/2015/whatchamacallit-controlled-vocabularies-for-technical-writers-eboillat/>`__
+- 
 
 Specific writing questions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -51,6 +52,7 @@ One word vs another, using abbreviations, etc.
 - |:newspaper:| `Using abbreviations and acronyms </blog/newsletter-november-2016/#using-abbreviations-and-acronyms-in-documentation>`__
 - |:newspaper:| `Writing about unlabelled buttons </blog/newsletter-july-2017/#documenting-unlabeled-buttons>`__
 - |:newspaper:| `Jokes in documentation </blog/newsletter-july-2017/#keep-your-jokes-out-of-my-documentation>`__
+- |:newspaper:| `The contrarian view: reasons to use “utilize” </blog/newsletter-march-2022/#the-contrarian-view-reasons-to-use-utilize>`__
 
 Editing
 ~~~~~~~
@@ -175,6 +177,7 @@ Storytelling
 Writing doc sets
 ----------------
 
+- |:movie_camera:| `Don’t shoot yourself in the foot with content reuse </videos/portland/2022/don-t-shoot-yourself-in-the-foot-with-content-reuse-anna-gasparyan/>`__
 - |:movie_camera:| `Delivering Documents For All Three Use Cases </videos/au/2017/delivering-documents-for-all-three-use-cases-margaret-fero/>`__
 - |:movie_camera:| `What nobody tells you about documentation </videos/eu/2017/the-four-kinds-of-documentation-and-why-you-need-to-understand-what-they-are-daniele-procida/>`__
 
@@ -209,7 +212,6 @@ Maintenance
 - |:newspaper:| `When you find inaccuracies in your docs </blog/newsletter-february-2020/#when-you-find-inaccuracies-in-your-docs>`__
 - |:movie_camera:| `Making Yourself Redundant on Day One <https://www.youtube.com/watch?v=QYMUh55eXcY&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=9>`__
 - |:newspaper:| `Making docs maintainable </blog/newsletter-august-2017/#making-docs-maintainable>`__
-- |:movie_camera:| `CSAT - What's That? </videos/na/2016/csat-what-s-that-betsy-roseberg/>`__
 
 Jobs and careers
 ----------------
@@ -222,6 +224,7 @@ Jobs and careers
 Hiring
 ~~~~~~~
 
+- |:movie_camera:| `From Me to Us: Building a docs team from the ground up </videos/portland/2022/from-me-to-us-building-a-docs-team-from-the-ground-up-lana-brindley-she-her/>`__
 - |:newspaper:| `Using writing tests when hiring </blog/newsletter-august-2019/#using-writing-tests-when-hiring>`__
 - |:newspaper:| `Running objective interviews </blog/newsletter-june-2019/#running-objective-interviews>`__
 - |:newspaper:| `Developer to documentarian ratio </blog/newsletter-may-2019/#developer-to-documentarian-ratio>`__
@@ -263,6 +266,8 @@ Career growth
 
 - |:newspaper:| `Is coding necessary to write good docs? </blog/newsletter-september-2022/#is-coding-necessary-to-write-good-docs>`__
 - |:newspaper:| `What’s in a (role) name, after all? </blog/newsletter-may-2022/#what-s-in-a-role-name-after-all>`__
+- |:movie_camera:| `Beating the Virginia Blues: Thru-hiking strategies to help you survive your next big project </videos/portland/2022/beating-the-virginia-blues-thru-hiking-strategies-to-help-you-survive-your-next-kate-mueller/>`__
+- - |:newspaper:| `Taking steps into leadership </blog/newsletter-february-2022/#taking-steps-into-leadership>`__
 - |:newspaper:| `A magnificent array of management topics </blog/newsletter-july-2020/#a-magnificent-array-of-management-topics>`__
 - |:newspaper:| `Leading and following: finding a mentor, being a mentor </blog/newsletter-october-2019/#leading-and-following-finding-a-mentor-being-a-mentor>`__
 - |:newspaper:| `Feeling like a fraud and how to deal with it </blog/newsletter-october-2019/#feeling-like-a-fraud-and-how-to-deal-with-it>`__
@@ -275,9 +280,14 @@ Career growth
 - |:newspaper:| `Imposter syndrome </blog/newsletter-march-2018/#selling-yourself-short-impostor-syndrome-among-tech-writers>`__
 - |:movie_camera:| `An Alien Looking From the Outside In: Main Takeaways After One Year in Documentation </videos/eu/2017/an-alien-looking-from-the-outside-in-main-takeaways-after-one-year-in-documentation-meike-chabowski/>`__
 - |:newspaper:| `Job titles (real and imagined) </blog/newsletter-march-2017/#studies-in-comparative-job-titles>`__
-- |:newspaper:| `Exploring other careers </blog/newsletter-february-2017/#exploring-your-technical-writing-career-options>`__
 - |:movie_camera:| `We’re Not in Kansas Anymore: How to Find Courage while Following the Technical Doc Road </videos/na/2016/we-re-not-in-kansas-anymore-how-to-find-courage-while-following-the-technical-doc-road-christy-lutz/>`__
 - |:movie_camera:| `IMPOSTER NO MORE: How Tech Writers Can Shed Self-Doubt, Embrace Uncertainty, and Surf the Upcoming Swerve in Technical Documentation </videos/eu/2015/imposter-no-more-how-tech-writers-can-shed-self-doubt-embrace-uncertainty-and-surf-the-upcoming-swerve-in-technical-documentation-rmacnamara/>`__
+
+
+Becoming a tech writer
+~~~~~~~~~~~~~~~~~~~~~~
+
+- |:newspaper:| `Breaking into tech writing </blog/newsletter-april-2022/#breaking-into-tech-writing>`__
 
 Learning...
 ~~~~~~~~~~~
@@ -349,6 +359,7 @@ Doc site design
 - |:newspaper:| `Meaningful URLs </blog/newsletter-october-2017/#putting-our-urls-to-work-for-us-and-our-readers>`__
 - |:newspaper:| `API reference docs layout </blog/newsletter-december-2017/#thinking-hard-about-api-reference-docs-layout>`__
 - |:movie_camera:| `Code the Docs: Interactive Document Environments </videos/na/2016/code-the-docs-interactive-document-environments-tim-nugent-paris-buttfield-addison/>`__
+- |:newspaper:| `Can form follow function in techdoc? </blog/newsletter-april-2022/#can-form-follow-function-in-techdoc>`__
 
 User needs
 ~~~~~~~~~~
@@ -374,10 +385,12 @@ Doc tools
 - |:movie_camera:| `Writing multi-language documentation using Sphinx <https://www.youtube.com/watch?v=53iJTYLji0I&index=4&list=PLZAeFn6dfHpnHBLE4qEUwg1LjhDZEvC2A>`__
 - |:movie_camera:| `Designing MkDocs <https://www.youtube.com/watch?v=aOtnoBphzJ4&list=PLZAeFn6dfHpnHBLE4qEUwg1LjhDZEvC2A&index=10>`__
 - |:movie_camera:| `Going from Publican to Read the Docs <https://www.youtube.com/watch?v=UHsIhWI4hgE&index=12&list=PLZAeFn6dfHpnHBLE4qEUwg1LjhDZEvC2A>`__
+- |:newspaper:| `Standards in documentation tooling </blog/newsletter-december-2021/#standards-in-documentation-tooling>`__
 
 Docs-as-code
 ~~~~~~~~~~~~
 
+- |:movie_camera:| `One AWS team’s move to docs as code: what worked, what didn’t, what’s next </videos/portland/2022/one-aws-team-s-move-to-docs-as-code-what-worked-what-didn-t-what-s-next-marcia-riefer-johnston/>`__
 - |:newspaper:| `To git or not to git docs as code </blog/newsletter-august-2020/#to-git-or-not-to-git-docs-as-code>`__
 - |:newspaper:| `Pros and cons of the docs-as-code approach </blog/newsletter-april-2020/#pros-and-cons-of-the-docs-as-code-approach>`__
 - |:newspaper:| `Adventures in generating docs from code comments </blog/newsletter-august-2019/#adventures-in-generating-docs-from-code-comments>`__
@@ -405,12 +418,14 @@ Automation
 ~~~~~~~~~~
 
 - |:newspaper:| `Link-checking tools </blog/newsletter-may-2022/#link-checking-tools>`__
+- |:movie_camera:| `Unit Test the Docs: Why You Should Test Your Code Examples </videos/portland/2022/unit-test-the-docs-why-you-should-test-your-code-examples-ben-perlmutter/>`__
 - |:movie_camera:| `Run your documentation </videos/prague/2018/run-your-docs-predrag-mandic/>`__
 - |:newspaper:| `Automated screenshot-taking </blog/newsletter-april-2018/#new-tool-to-try-out-automated-screenshots>`__
 - |:movie_camera:| `Testing: it's not just for code anymore </videos/na/2017/testing-it-s-not-just-for-code-anymore-lyzi-diamond/>`__
 - |:movie_camera:| `Tech writing in a continuous deployment world </videos/na/2015/tech-writing-in-a-continuous-deployment-world-cburwinkle/>`__
 - |:movie_camera:| `Tested and Correct, How to Make Sure Your Documentation Keeps Working </videos/eu/2015/tested-and-correct-how-to-make-sure-your-documentation-keeps-working-adangoor/>`__
 - |:movie_camera:| `Generating docs from APIs </videos/eu/2015/generating-docs-from-apis-jhannaford/>`__
+- |:newspaper:| `Automation dreams - and realities </blog/newsletter-march-2022/#automation-dreams-and-realities>`__
 
 Git
 ~~~
@@ -423,6 +438,7 @@ Metrics and analytics
 ---------------------
 
 - |:newspaper:| `Discovering user needs </blog/newsletter-august-2019/#starting-out-with-analytics-and-then-upping-your-game>`__
+- |:movie_camera:| `Don’t trust the numbers! </videos/portland/2022/don-t-trust-the-numbers-kumar-dhanagopal/>`__
 
 User research
 ~~~~~~~~~~~~~
@@ -446,12 +462,15 @@ Gathering it and acting on it.
 - |:newspaper:| `Documentation feedback widgets - thumbs up or down? </blog/newsletter-december-2019/#documentation-feedback-widgets-thumbs-up-or-down>`__
 - |:newspaper:| `Collecting and acting on user feedback </blog/newsletter-may-2019/#collecting-and-acting-on-user-feedback>`__
 - |:newspaper:| `Gathering user feedback </blog/newsletter-november-2018/#getting-feedback-from-users>`__
+- |:movie_camera:| `CSAT - What's That? </videos/na/2016/csat-what-s-that-betsy-roseberg/>`__
+
 
 Measuring docs success
 ~~~~~~~~~~~~~~~~~~~~~~
 
 - |:newspaper:| `Objectives and key results (OKRs) for documentation </blog/newsletter-march-2019/#objectives-and-key-results-okrs-for-documentation>`__
 - |:newspaper:| `A/B testing docs </blog/newsletter-may-2018/#a-b-testing-for-stronger-docs>`__
+- |:movie_camera:| `Measuring Documentation Success in Open Source: Findings from Google’s Season of Docs Program </videos/portland/2022/measuring-documentation-success-in-open-source-findings-from-google-s-season-of-kassandra-dhillon/>`__
 
 Metrics
 ~~~~~~~
@@ -486,6 +505,8 @@ Building docs culture
 Building community
 ~~~~~~~~~~~~~~~~~~
 
+- |:movie_camera:| `Peer writing and beyond - An experimental approach to a sustainable open-source projects </videos/portland/2022/peer-writing-and-beyond-an-experimental-approach-to-a-sustainable-open-source-chris-ganta/>`__
+- |:movie_camera:| `All together now: Turning technologists into documentarians </videos/portland/2022/all-together-now-turning-technologists-into-documentarians-liani-lye-she-her/>`__
 - |:movie_camera:| `A content manager's guide to crowdsourcing the docs </videos/eu/2017/a-content-manager-s-guide-to-crowdsourcing-the-docs-becky-todd/>`__
 - |:movie_camera:| `No Community Members Were Harmed in the Making of This Doc Sprint </videos/na/2017/no-community-members-were-harmed-in-the-making-of-this-doc-sprint-how-we-ran-a-48-hour-event-to-collect-community-wisdom-into-a-guidebook-for-newsroom-developers-ryan-pitts-lindsay-muscato/>`__
 - |:movie_camera:| `The Wisdom of Crowds: Crowdsourcing Minimalism in an Open Organization </videos/na/2017/the-wisdom-of-crowds-crowdsourcing-minimalism-in-an-open-organization-ingrid-towey/>`__
@@ -526,6 +547,7 @@ Working with writers
 Including review, editing, and teaching.
 
 - |:newspaper:| `What’s in a good reviewer’s guide? </blog/newsletter-july-2022/#what-s-in-a-good-reviewer-s-guide>`__
+- |:movie_camera:| `Code Cowpokes and Word Wranglers: from Mutual Admiration to Solidarity </videos/portland/2022/code-cowpokes-and-word-wranglers-from-mutual-admiration-to-solidarity-erin-dees/>`__
 - |:newspaper:| `The challenge of giving difficult feedback </blog/newsletter-november-2019/#the-challenge-of-giving-difficult-feedback>`__
 - |:newspaper:| `Facilitating top-notch doc review </blog/newsletter-june-2019/#facilitating-top-notch-doc-review>`__
 - |:movie_camera:| `Good Code, Bad Code & Code Review <https://www.youtube.com/watch?v=Mx4iRq-inm8&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=8>`__
@@ -612,6 +634,7 @@ Continuous delivery
 Strategy
 ~~~~~~~~
 
+- |:movie_camera:| `Lessons Learned from Cloud Ops: Writing Docs for High-Stakes Situations </videos/portland/2022/lessons-learned-from-cloud-ops-writing-docs-for-high-stakes-situations-alastair-dallas/>`__
 - |:movie_camera:| `Backseat content strategy <https://www.youtube.com/watch?v=omwamA30e_Y&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=4>`__
 - |:movie_camera:| `Choosing a tool... and choosing your moment </videos/prague/2018/choosing-a-tool-and-choosing-your-moment-val-grimm/>`__
 - |:movie_camera:| `Audience, Market, Product: Tips for strategic API documentation planning </videos/portland/2018/audience-market-product-tips-for-strategic-api-documentation-planning-bob-watson/>`__

--- a/docs/topics.rst
+++ b/docs/topics.rst
@@ -155,6 +155,8 @@ Including how-tos, reference docs, tutorials, and books.
 - |:newspaper:| `To answer, or not to answer: FAQs </blog/newsletter-may-2020/#to-answer-or-not-to-answer-faqs>`__
 - |:newspaper:| `Do we tell users what’s new in the docs? </blog/newsletter-march-2020/#do-we-tell-users-what-s-new-in-the-docs>`__
 - |:movie_camera:| `Emulating the Teacher’s Approving Nod in Teaching Material </videos/prague/2020/emulating-the-teacher-s-approving-nod-in-teaching-material-tanks-transfeld/>`__
+- |:movie_camera:| `How (and why) to make awesome video tutorials </videos/australia/2020/how-and-why-to-make-awesome-video-tutorials-sayraphim-lothian/>`__
+- |:movie_camera:| `Microcontent: Designing & Developing Reusable Content </videos/australia/2020/microcontent-designing-developing-reusable-content-scott-deloach/>`__
 - |:movie_camera:| `Learning to love release notes </videos/prague/2018/learning-to-love-release-notes-anne-edwards/>`__
 - |:movie_camera:| `"It's a Feature" - Documenting Known Issues and Product Shortcomings </videos/prague/2018/it-s-a-feature-documenting-known-issues-and-product-shortcomings-ivana-devcic/>`__
 - |:movie_camera:| `Writing the Next Great Tech Book </videos/portland/2018/writing-the-next-great-tech-book-brian-macdonald/>`__
@@ -175,6 +177,7 @@ Storytelling
 ~~~~~~~~~~~~
 
 - |:movie_camera:| `When Wishing Still Helped … What Folklore Can Teach Us about Technical Writing </videos/prague/2020/when-wishing-still-helped-what-folklore-can-teach-us-about-technical-writing-ingrid-k-towey/>`__
+- |:movie_camera:| `Storytelling for Technical Products - What We Can Learn from Lego and Pixar </videos/australia/2020/storytelling-for-technical-products-what-we-can-learn-from-lego-and-pixar-akshay-iyer/>`__
 - |:movie_camera:| `Telling a Great Story on GitHub </videos/eu/2017/telling-a-great-story-on-github-lauri-apple/>`__
 - |:movie_camera:| `What Writing Fiction Teaches You About Writing Documentation </videos/na/2016/what-writing-fiction-teaches-you-about-writing-documentation-thursday-bram/>`__
 - |:movie_camera:| `Documenting your Story - Crafting a good presentation </videos/eu/2015/documenting-your-story-crafting-a-good-presentation-cward/>`__
@@ -206,6 +209,8 @@ Legacy docs
 ~~~~~~~~~~~
 
 - |:movie_camera:| `Organizing a Confluence hoard, or, does this page spark joy? </videos/prague/2020/organizing-a-confluence-hoard-or-does-this-page-spark-joy-abigail-sutherland/>`__
+- |:movie_camera:| `Legacy content from various perspectives </videos/australia/2020/legacy-content-from-various-perspectives-marcelina-haftka/>`__
+- |:movie_camera:| `When Agile Fails: Working on Large Documentation Projects </videos/australia/2020/when-agile-fails-working-on-large-documentation-projects-lana-brindley/>`__
 - |:movie_camera:| `How to tear down existing documentation and rewrite docs that actually work </videos/prague/2018/how-to-tear-down-existing-documentation-and-rewrite-docs-that-actually-work-alexandra-white/>`__
 - |:movie_camera:| `Tackling technical debt in the docs </videos/prague/2018/tackling-technical-debt-in-the-docs-louise-fahey/>`__
 - |:movie_camera:| `Where do I start? The art and practice of documentation triage </videos/portland/2018/where-do-i-start-the-art-and-practice-of-documentation-triage-neal-kaplan/>`__
@@ -283,6 +288,8 @@ Career growth
 - |:movie_camera:| `From travel content to technical content: my journey </videos/prague/2021/from-travel-content-to-technical-content-my-journey-kate-santo/>`__
 - |:newspaper:| `A magnificent array of management topics </blog/newsletter-july-2020/#a-magnificent-array-of-management-topics>`__
 - |:movie_camera:| `From Graffiti Writer to Technical Writer </videos/prague/2020/from-graffiti-writer-to-technical-writer-kruno-golubi/>`__
+- |:movie_camera:| `Overcoming the Plight of Lone Writers </videos/australia/2020/overcoming-the-plight-of-lone-writers-ankita-tripathi/>`__
+- |:movie_camera:| `Onboard yourself: How to get set-up for success in a new role </videos/australia/2020/onboard-yourself-how-to-get-set-up-for-success-in-a-new-role-michael-belton/>`__
 - |:newspaper:| `Leading and following: finding a mentor, being a mentor </blog/newsletter-october-2019/#leading-and-following-finding-a-mentor-being-a-mentor>`__
 - |:newspaper:| `Feeling like a fraud and how to deal with it </blog/newsletter-october-2019/#feeling-like-a-fraud-and-how-to-deal-with-it>`__
 - |:newspaper:| `Making the leap to managing writers </blog/newsletter-july-2019/#making-the-leap-to-managing-writers>`__
@@ -342,6 +349,7 @@ Localization and globalization
 - |:movie_camera:| `Creating documentation for the African audience </videos/prague/2022/creating-documentation-for-the-african-audience-benny-ifeanyi-iheagwara/>`__
 - |:movie_camera:| `Toward the broader globalization of Open Source: documenting your localisation Journey </videos/prague/2022/toward-the-broader-globalization-of-open-source-documenting-your-localisation-j-melissa-black/>`__
 - |:movie_camera:| `How I use applied linguistics to be a better technical writer </videos/prague/2021/how-i-use-applied-linguistics-to-be-a-better-technical-writer-kat-stoica-ostenfeld/>`__
+- |:movie_camera:| `Influence your customer outreach with best practices for internationalization </videos/australia/2020/influence-your-customer-outreach-with-best-practices-for-internationalization-vikram-mulay/>`__
 
 
 Design
@@ -360,6 +368,7 @@ UX writing
 ~~~~~~~~~~
 
 - |:newspaper:| `Edge cases and when (and where!) to document them </blog/newsletter-june-2022/#edge-cases-and-when-and-where-to-document-them>`__
+- |:movie_camera:| `Little words, big ideas: How to write microcopy that works </videos/australia/2020/little-words-big-ideas-how-to-write-microcopy-that-works-yael-ben-david/>`__
 - |:movie_camera:| `UX Writing - Let Your Product Speak <https://www.youtube.com/watch?v=TGdm-1vVLDw&index=10&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt>`__
 - |:movie_camera:| `Creating experiences with information <https://www.youtube.com/watch?v=N_fUHIu9cl4&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=6>`__
 - |:movie_camera:| `Conversational UI for Writers </videos/au/2017/conversational-uis-for-writers-chris-ward/>`__
@@ -379,6 +388,7 @@ UX writing
 Doc site design
 ~~~~~~~~~~~~~~~
 
+- |:movie_camera:| `A treasure map for the doc – Exploring the discoverability of documentation </videos/australia/2020/a-treasure-map-for-the-doc-exploring-the-discoverability-of-documentation-marika-vertzonis/>`__
 - |:movie_camera:| `Responsive Content - Presenting Your information On Any Device <https://www.youtube.com/watch?v=z7KBdPyRb18&index=5&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt>`__
 - |:newspaper:| `"Last updated" in docs </blog/newsletter-july-2017/#struggles-with-dates-and-versions>`__
 - |:newspaper:| `Documentation bylines </blog/newsletter-march-2017/#should-documentation-have-bylines>`__
@@ -517,6 +527,7 @@ Metrics
 Culture and community
 ---------------------
 
+- |:movie_camera:| `5 things I learned from my first open source contribution </videos/australia/2020/5-things-i-learned-from-my-first-open-source-contribution-andrea-szollossi/>`__
 - |:movie_camera:| `A Year in the Life of The Better Docs Project </videos/prague/2018/a-year-in-the-life-of-the-better-docs-project-rowan-cota/>`__
 - |:movie_camera:| `Technical writing as public service: working on open source in government </videos/na/2016/technical-writing-as-public-service-working-on-open-source-in-government-britta-gustafson/>`__
 
@@ -525,6 +536,7 @@ Building docs culture
 
 - |:movie_camera:| `Adventures in setting up a knowledge system for a research group </videos/prague/2021/adventures-in-setting-up-a-knowledge-system-for-a-research-group-victor-sluiter/>`__
 - |:movie_camera:| `How to be an Avante-Garde Guinea Pig: Building Better Content through Experimentation, Community-building, and Loud Squeaks </videos/prague/2020/how-to-be-an-avante-garde-guinea-pig-building-better-content-through-experimentation-community-building-and-loud-squeaks-jessica-valasek-estenssoro/>`__
+- |:movie_camera:| `Everyone’s a player (in a mid-90s MUD) </videos/australia/2020/everyone-s-a-player-in-a-mid-90s-mud-kenzie-woodbridge/>`__
 - |:newspaper:| `Promoting plain language </blog/newsletter-november-2018/#promoting-plain-language>`__
 - |:newspaper:| `Common misconceptions about docs </blog/newsletter-august-2018/#common-misconceptions-about-documentation>`__
 - |:movie_camera:| `Who Writes the Docs? </videos/portland/2018/who-writes-the-docs-beth-aitman/>`__
@@ -586,6 +598,7 @@ Including review, editing, and teaching.
 
 - |:newspaper:| `What’s in a good reviewer’s guide? </blog/newsletter-july-2022/#what-s-in-a-good-reviewer-s-guide>`__
 - |:movie_camera:| `Code Cowpokes and Word Wranglers: from Mutual Admiration to Solidarity </videos/portland/2022/code-cowpokes-and-word-wranglers-from-mutual-admiration-to-solidarity-erin-dees/>`__
+- |:movie_camera:| `The Pains of Composition: How to write your best documentation in a collaborative world </videos/australia/2020/the-pains-of-composition-how-to-write-your-best-documentation-in-a-collaborative-world-matt-reiner/>`__
 - |:newspaper:| `The challenge of giving difficult feedback </blog/newsletter-november-2019/#the-challenge-of-giving-difficult-feedback>`__
 - |:newspaper:| `Facilitating top-notch doc review </blog/newsletter-june-2019/#facilitating-top-notch-doc-review>`__
 - |:movie_camera:| `Good Code, Bad Code & Code Review <https://www.youtube.com/watch?v=Mx4iRq-inm8&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=8>`__
@@ -622,6 +635,7 @@ Including product managers, higher-ups, etc.
 - |:newspaper:| `Improving communication about what's in releases </blog/newsletter-september-2022/#improving-communication-about-what-s-in-releases>`__
 - |:movie_camera:| `Documentation as Marketing? From Conflict to Collaboration </videos/prague/2022/documentation-as-marketing-from-conflict-to-collaboration-mano-toth/>`__
 - |:newspaper:| `Getting more info from SMEs </blog/newsletter-may-2020/#getting-more-info-from-smes>`__
+- |:movie_camera:| `An introduction to developer experience, and the role of a documentarian </videos/australia/2020/an-introduction-to-developer-experience-and-the-role-of-a-documentarian-chris-ward/>`__
 - |:movie_camera:| `The subtle art of interrogation <https://www.youtube.com/watch?v=HVdzjFeaM7k&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=7>`__
 - |:newspaper:| `Helping project managers understand docs </blog/newsletter-june-2018/#helping-your-project-managers-understand-docs>`__
 - |:newspaper:| `Conflicts about what should be in the docs </blog/newsletter-july-2017/#who-s-running-this-content>`__
@@ -677,6 +691,7 @@ Strategy
 ~~~~~~~~
 
 - |:movie_camera:| `Lessons Learned from Cloud Ops: Writing Docs for High-Stakes Situations </videos/portland/2022/lessons-learned-from-cloud-ops-writing-docs-for-high-stakes-situations-alastair-dallas/>`__
+- |:movie_camera:| `Content strategy in practice: a case study </videos/australia/2020/content-strategy-in-practice-a-case-study-sam-irons/>`__
 - |:movie_camera:| `Backseat content strategy <https://www.youtube.com/watch?v=omwamA30e_Y&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=4>`__
 - |:movie_camera:| `Choosing a tool... and choosing your moment </videos/prague/2018/choosing-a-tool-and-choosing-your-moment-val-grimm/>`__
 - |:movie_camera:| `Audience, Market, Product: Tips for strategic API documentation planning </videos/portland/2018/audience-market-product-tips-for-strategic-api-documentation-planning-bob-watson/>`__

--- a/docs/topics.rst
+++ b/docs/topics.rst
@@ -208,6 +208,7 @@ Legacy docs
 Maintenance
 ~~~~~~~~~~~
 
+- |:movie_camera:| `Maintaining Documentation: Make It Easy! </videos/prague/2022/maintaining-documentation-make-it-easy-emilia-juda-zbay/>`__
 - |:newspaper:| `Broken links and how to find them </blog/newsletter-june-2020/#broken-links-and-how-to-find-them>`__
 - |:newspaper:| `When you find inaccuracies in your docs </blog/newsletter-february-2020/#when-you-find-inaccuracies-in-your-docs>`__
 - |:movie_camera:| `Making Yourself Redundant on Day One <https://www.youtube.com/watch?v=QYMUh55eXcY&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=9>`__
@@ -224,7 +225,6 @@ Jobs and careers
 Hiring
 ~~~~~~~
 
-- |:movie_camera:| `From Me to Us: Building a docs team from the ground up </videos/portland/2022/from-me-to-us-building-a-docs-team-from-the-ground-up-lana-brindley-she-her/>`__
 - |:newspaper:| `Using writing tests when hiring </blog/newsletter-august-2019/#using-writing-tests-when-hiring>`__
 - |:newspaper:| `Running objective interviews </blog/newsletter-june-2019/#running-objective-interviews>`__
 - |:newspaper:| `Developer to documentarian ratio </blog/newsletter-may-2019/#developer-to-documentarian-ratio>`__
@@ -284,14 +284,16 @@ Career growth
 - |:movie_camera:| `IMPOSTER NO MORE: How Tech Writers Can Shed Self-Doubt, Embrace Uncertainty, and Surf the Upcoming Swerve in Technical Documentation </videos/eu/2015/imposter-no-more-how-tech-writers-can-shed-self-doubt-embrace-uncertainty-and-surf-the-upcoming-swerve-in-technical-documentation-rmacnamara/>`__
 
 
-Becoming a tech writer
-~~~~~~~~~~~~~~~~~~~~~~
+Building a team
+~~~~~~~~~~~~~~~
 
-- |:newspaper:| `Breaking into tech writing </blog/newsletter-april-2022/#breaking-into-tech-writing>`__
+- |:movie_camera:| `How I convinced my boss to build our docs team </videos/prague/2022/how-i-convinced-my-boss-to-build-our-docs-team-karissa-van-baulen/>`__
+- |:movie_camera:| `From Me to Us: Building a docs team from the ground up </videos/portland/2022/from-me-to-us-building-a-docs-team-from-the-ground-up-lana-brindley-she-her/>`__
 
 Learning...
 ~~~~~~~~~~~
 
+- |:movie_camera:| `The Art of Asking Questions </videos/prague/2022/the-art-of-asking-questions-jeff-smith/>`__
 - |:newspaper:| `What we’re learning in #learn-tech-writing </blog/newsletter-october-2020/#what-we-re-learning-in-learn-tech-writing>`__
 - |:newspaper:| `Learning regular expressions (regex) </blog/newsletter-october-2020/#learning-regular-expressions-regex>`__
 - |:newspaper:| `Book club: an intro to ‘Every Page is Page One’ </blog/newsletter-april-2020/#book-club-an-intro-to-every-page-is-page-one>`__
@@ -308,6 +310,7 @@ Design and UX
 Accessibility and inclusivity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+- |:movie_camera:| `ADHD and its impact on the Creative Process for Writers </videos/prague/2022/adhd-and-its-impact-on-the-creative-process-for-writers-tyler-smith/>`__
 - |:newspaper:| `Resources for diverse example names </blog/newsletter-july-2020/#resources-for-diverse-example-names>`__
 - |:movie_camera:| `A11y-Friendly Documentation </videos/prague/2018/a11y-friendly-documentation-carolyn-stransky/>`__
 - |:newspaper:| `Accessibility for colour blindness </blog/newsletter-august-2017/#accessible-docs-colorblindness-edition>`__
@@ -318,6 +321,12 @@ Accessibility and inclusivity
 - |:newspaper:| `Responsible communication guide </blog/newsletter-october-2016/#coming-soon-the-responsible-communication-guide>`__
 - |:movie_camera:| `Accessible Math on the Web: A Server/Client Solution </videos/na/2016/accessible-math-on-the-web-a-server-client-solution-tim-arnold/>`__
 - |:movie_camera:| `Inclusive Tech Docs - TechComm Meets Accessibility </videos/eu/2015/inclusive-tech-docs-techcomm-meets-accessibility-rmatic/>`__
+
+Localization and globalization
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- |:movie_camera:| `Creating documentation for the African audience </videos/prague/2022/creating-documentation-for-the-african-audience-benny-ifeanyi-iheagwara/>`__
+- |:movie_camera:| `Toward the broader globalization of Open Source: documenting your localisation Journey </videos/prague/2022/toward-the-broader-globalization-of-open-source-documenting-your-localisation-j-melissa-black/>`__
 
 Design
 ~~~~~~~
@@ -353,6 +362,7 @@ UX writing
 Doc site design
 ~~~~~~~~~~~~~~~
 
+- |:movie_camera:| `Improve Customer Adoption with UI Help </videos/prague/2022/improve-customer-adoption-with-ui-help-prashant-mathapathi/>`__
 - |:movie_camera:| `Responsive Content - Presenting Your information On Any Device <https://www.youtube.com/watch?v=z7KBdPyRb18&index=5&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt>`__
 - |:newspaper:| `"Last updated" in docs </blog/newsletter-july-2017/#struggles-with-dates-and-versions>`__
 - |:newspaper:| `Documentation bylines </blog/newsletter-march-2017/#should-documentation-have-bylines>`__
@@ -373,6 +383,8 @@ User needs
 Doc tools
 ---------
 
+- |:movie_camera:| `Two years of Markdoc: what we’ve learned about balancing developer and author experience </videos/prague/2022/two-years-of-markdoc-what-we-ve-learned-about-balancing-developer-and-author-ex-ryan-paul/>`__
+- |:newspaper:| `Standards in documentation tooling </blog/newsletter-december-2021/#standards-in-documentation-tooling>`__
 - |:newspaper:| `How your tools affect your writing </blog/newsletter-december-2019/#how-your-tools-affect-your-writing>`__
 - |:newspaper:| `Deciding on a new tool… </blog/newsletter-october-2019/#deciding-on-a-new-tool>`__
 - |:newspaper:| `… and migrating to a new tool </blog/newsletter-october-2019/#and-migrating-to-a-new-tool>`__
@@ -385,7 +397,6 @@ Doc tools
 - |:movie_camera:| `Writing multi-language documentation using Sphinx <https://www.youtube.com/watch?v=53iJTYLji0I&index=4&list=PLZAeFn6dfHpnHBLE4qEUwg1LjhDZEvC2A>`__
 - |:movie_camera:| `Designing MkDocs <https://www.youtube.com/watch?v=aOtnoBphzJ4&list=PLZAeFn6dfHpnHBLE4qEUwg1LjhDZEvC2A&index=10>`__
 - |:movie_camera:| `Going from Publican to Read the Docs <https://www.youtube.com/watch?v=UHsIhWI4hgE&index=12&list=PLZAeFn6dfHpnHBLE4qEUwg1LjhDZEvC2A>`__
-- |:newspaper:| `Standards in documentation tooling </blog/newsletter-december-2021/#standards-in-documentation-tooling>`__
 
 Docs-as-code
 ~~~~~~~~~~~~
@@ -419,6 +430,7 @@ Automation
 
 - |:newspaper:| `Link-checking tools </blog/newsletter-may-2022/#link-checking-tools>`__
 - |:movie_camera:| `Unit Test the Docs: Why You Should Test Your Code Examples </videos/portland/2022/unit-test-the-docs-why-you-should-test-your-code-examples-ben-perlmutter/>`__
+- |:movie_camera:| `Beyond spell checking - what else can we check automatically? </videos/prague/2022/beyond-spell-checking-what-else-can-we-check-automatically-tibs/>`__
 - |:movie_camera:| `Run your documentation </videos/prague/2018/run-your-docs-predrag-mandic/>`__
 - |:newspaper:| `Automated screenshot-taking </blog/newsletter-april-2018/#new-tool-to-try-out-automated-screenshots>`__
 - |:movie_camera:| `Testing: it's not just for code anymore </videos/na/2017/testing-it-s-not-just-for-code-anymore-lyzi-diamond/>`__
@@ -468,9 +480,9 @@ Gathering it and acting on it.
 Measuring docs success
 ~~~~~~~~~~~~~~~~~~~~~~
 
+- |:movie_camera:| `Measuring Documentation Success in Open Source: Findings from Google’s Season of Docs Program </videos/portland/2022/measuring-documentation-success-in-open-source-findings-from-google-s-season-of-kassandra-dhillon/>`__
 - |:newspaper:| `Objectives and key results (OKRs) for documentation </blog/newsletter-march-2019/#objectives-and-key-results-okrs-for-documentation>`__
 - |:newspaper:| `A/B testing docs </blog/newsletter-may-2018/#a-b-testing-for-stronger-docs>`__
-- |:movie_camera:| `Measuring Documentation Success in Open Source: Findings from Google’s Season of Docs Program </videos/portland/2022/measuring-documentation-success-in-open-source-findings-from-google-s-season-of-kassandra-dhillon/>`__
 
 Metrics
 ~~~~~~~
@@ -539,6 +551,7 @@ Style guides
 Working across roles
 --------------------
 
+- |:movie_camera:| `Cultivating a Stakeholder Network for Our Docs: How Building Relationships Improves Our Content </videos/prague/2022/cultivating-a-stakeholder-network-for-our-docs-how-building-relationships-impro-taylor-cole/>`__
 - |:newspaper:| `The strengths of different backgrounds </blog/newsletter-november-2019/#the-strengths-of-different-backgrounds>`__
 
 Working with writers
@@ -582,6 +595,7 @@ Working with other roles
 Including product managers, higher-ups, etc.
 
 - |:newspaper:| `Improving communication about what's in releases </blog/newsletter-september-2022/#improving-communication-about-what-s-in-releases>`__
+- |:movie_camera:| `Documentation as Marketing? From Conflict to Collaboration </videos/prague/2022/documentation-as-marketing-from-conflict-to-collaboration-mano-toth/>`__
 - |:newspaper:| `Getting more info from SMEs </blog/newsletter-may-2020/#getting-more-info-from-smes>`__
 - |:movie_camera:| `The subtle art of interrogation <https://www.youtube.com/watch?v=HVdzjFeaM7k&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=7>`__
 - |:newspaper:| `Helping project managers understand docs </blog/newsletter-june-2018/#helping-your-project-managers-understand-docs>`__

--- a/docs/topics.rst
+++ b/docs/topics.rst
@@ -87,8 +87,11 @@ Other media
 Including videos, diagrams, and screenshots.
 
 - |:newspaper:| `Is written content outdated - and is it time for video? </blog/newsletter-may-2022/#is-written-content-outdated-and-is-it-time-for-video>`__
+- |:movie_camera:| `Improve Customer Adoption with UI Help </videos/prague/2022/improve-customer-adoption-with-ui-help-prashant-mathapathi/>`__
 - |:newspaper:| `Command prompts in docs </blog/newsletter-october-2020/#command-prompts-in-docs>`__
 - |:newspaper:| `Tips for creating quality screenshots </blog/newsletter-may-2020/#tips-for-creating-quality-screenshots>`__
+- |:movie_camera:| `Bake a Little Documentation Love into Your Product </videos/prague/2020/bake-a-little-documentation-love-into-your-product-matt-reiner/>`__
+- |:movie_camera:| `Need Examples? Write Your Own! </videos/prague/2020/need-examples-write-your-own-joe-malin/>`__
 - |:newspaper:| `Behind the scenes with fonts, emojis, and Unicode </blog/newsletter-october-2019/#behind-the-scenes-with-fonts-emojis-and-unicode>`__
 - |:newspaper:| `Advice for creating technical illustrations </blog/newsletter-august-2019/#advice-for-creating-technical-illustrations>`__
 - |:newspaper:| `Tips and tricks for producing video </blog/newsletter-may-2019/#tips-and-tricks-for-producing-videos>`__
@@ -147,8 +150,11 @@ Other specific doc types
 Including how-tos, reference docs, tutorials, and books.
 
 - |:newspaper:| `Templates for concept documentation </blog/newsletter-may-2022/#templates-for-concept-documentation>`__
+- |:movie_camera:| `How to write a book for (and with) an open source community </videos/prague/2021/how-to-write-a-book-for-and-with-an-open-source-community-felicity-brand/>`__
+- |:movie_camera:| `So you need to give bad news to users… </videos/prague/2021/so-you-need-to-give-bad-news-to-users-ryan-macklin-he-they/>`__
 - |:newspaper:| `To answer, or not to answer: FAQs </blog/newsletter-may-2020/#to-answer-or-not-to-answer-faqs>`__
 - |:newspaper:| `Do we tell users what’s new in the docs? </blog/newsletter-march-2020/#do-we-tell-users-what-s-new-in-the-docs>`__
+- |:movie_camera:| `Emulating the Teacher’s Approving Nod in Teaching Material </videos/prague/2020/emulating-the-teacher-s-approving-nod-in-teaching-material-tanks-transfeld/>`__
 - |:movie_camera:| `Learning to love release notes </videos/prague/2018/learning-to-love-release-notes-anne-edwards/>`__
 - |:movie_camera:| `"It's a Feature" - Documenting Known Issues and Product Shortcomings </videos/prague/2018/it-s-a-feature-documenting-known-issues-and-product-shortcomings-ivana-devcic/>`__
 - |:movie_camera:| `Writing the Next Great Tech Book </videos/portland/2018/writing-the-next-great-tech-book-brian-macdonald/>`__
@@ -168,6 +174,7 @@ Including how-tos, reference docs, tutorials, and books.
 Storytelling
 ~~~~~~~~~~~~
 
+- |:movie_camera:| `When Wishing Still Helped … What Folklore Can Teach Us about Technical Writing </videos/prague/2020/when-wishing-still-helped-what-folklore-can-teach-us-about-technical-writing-ingrid-k-towey/>`__
 - |:movie_camera:| `Telling a Great Story on GitHub </videos/eu/2017/telling-a-great-story-on-github-lauri-apple/>`__
 - |:movie_camera:| `What Writing Fiction Teaches You About Writing Documentation </videos/na/2016/what-writing-fiction-teaches-you-about-writing-documentation-thursday-bram/>`__
 - |:movie_camera:| `Documenting your Story - Crafting a good presentation </videos/eu/2015/documenting-your-story-crafting-a-good-presentation-cward/>`__
@@ -185,6 +192,7 @@ Information architecture
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 - |:newspaper:| `Where should support content live? </blog/newsletter-april-2022/#where-should-support-content-live>`__
+- |:movie_camera:| `More than words: Reviewing and updating your information architecture </videos/prague/2021/more-than-words-reviewing-and-updating-your-information-architecture-lana-brindley-she-her/>`__
 - |:newspaper:| `Organizing docs by role, or by topic? </blog/newsletter-october-2020/#organizing-docs-by-role-or-by-topic>`__
 - |:newspaper:| `A conversation about docs cleanup </blog/newsletter-june-2019/#order-from-chaos-or-a-conversation-about-docs-cleanup>`__
 - |:newspaper:| `Information architecture resources </blog/newsletter-october-2018/#resources-for-planning-out-your-information-architecture>`__
@@ -197,6 +205,7 @@ Information architecture
 Legacy docs
 ~~~~~~~~~~~
 
+- |:movie_camera:| `Organizing a Confluence hoard, or, does this page spark joy? </videos/prague/2020/organizing-a-confluence-hoard-or-does-this-page-spark-joy-abigail-sutherland/>`__
 - |:movie_camera:| `How to tear down existing documentation and rewrite docs that actually work </videos/prague/2018/how-to-tear-down-existing-documentation-and-rewrite-docs-that-actually-work-alexandra-white/>`__
 - |:movie_camera:| `Tackling technical debt in the docs </videos/prague/2018/tackling-technical-debt-in-the-docs-louise-fahey/>`__
 - |:movie_camera:| `Where do I start? The art and practice of documentation triage </videos/portland/2018/where-do-i-start-the-art-and-practice-of-documentation-triage-neal-kaplan/>`__
@@ -210,6 +219,7 @@ Maintenance
 
 - |:movie_camera:| `Maintaining Documentation: Make It Easy! </videos/prague/2022/maintaining-documentation-make-it-easy-emilia-juda-zbay/>`__
 - |:newspaper:| `Broken links and how to find them </blog/newsletter-june-2020/#broken-links-and-how-to-find-them>`__
+- |:movie_camera:| `Future-Proofing Your Support Visuals </videos/prague/2020/future-proofing-your-support-visuals-jen-weaver/>`__
 - |:newspaper:| `When you find inaccuracies in your docs </blog/newsletter-february-2020/#when-you-find-inaccuracies-in-your-docs>`__
 - |:movie_camera:| `Making Yourself Redundant on Day One <https://www.youtube.com/watch?v=QYMUh55eXcY&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt&index=9>`__
 - |:newspaper:| `Making docs maintainable </blog/newsletter-august-2017/#making-docs-maintainable>`__
@@ -219,6 +229,7 @@ Jobs and careers
 
 - |:newspaper:| `Knowledge transfer for documentarians </blog/newsletter-november-2022/#knowledge-transfer-for-documentarians>`__
 - |:newspaper:| `Joining as a manager </blog/newsletter-november-2022/#joining-as-a-manager>`__
+- |:movie_camera:| `Hustling for Fun and Profit as a Technical Writer: A Freelancing Starter Kit </videos/prague/2021/hustling-for-fun-and-profit-as-a-technical-writer-a-freelancing-starter-kit-karen-sawrey/>`__
 - |:newspaper:| `Salary survey </blog/newsletter-april-2020/#salary-survey-speculations>`__
 - |:newspaper:| `For those who might consider freelancing </blog/newsletter-july-2019/#for-those-who-might-consider-freelancing>`__
 
@@ -267,8 +278,11 @@ Career growth
 - |:newspaper:| `Is coding necessary to write good docs? </blog/newsletter-september-2022/#is-coding-necessary-to-write-good-docs>`__
 - |:newspaper:| `What’s in a (role) name, after all? </blog/newsletter-may-2022/#what-s-in-a-role-name-after-all>`__
 - |:movie_camera:| `Beating the Virginia Blues: Thru-hiking strategies to help you survive your next big project </videos/portland/2022/beating-the-virginia-blues-thru-hiking-strategies-to-help-you-survive-your-next-kate-mueller/>`__
-- - |:newspaper:| `Taking steps into leadership </blog/newsletter-february-2022/#taking-steps-into-leadership>`__
+- |:newspaper:| `Taking steps into leadership </blog/newsletter-february-2022/#taking-steps-into-leadership>`__
+- |:movie_camera:| `Docs leadership: How to become a stronger leader for your team </videos/prague/2021/docs-leadership-how-to-become-a-stronger-leader-for-your-team-jenn-leaver/>`__
+- |:movie_camera:| `From travel content to technical content: my journey </videos/prague/2021/from-travel-content-to-technical-content-my-journey-kate-santo/>`__
 - |:newspaper:| `A magnificent array of management topics </blog/newsletter-july-2020/#a-magnificent-array-of-management-topics>`__
+- |:movie_camera:| `From Graffiti Writer to Technical Writer </videos/prague/2020/from-graffiti-writer-to-technical-writer-kruno-golubi/>`__
 - |:newspaper:| `Leading and following: finding a mentor, being a mentor </blog/newsletter-october-2019/#leading-and-following-finding-a-mentor-being-a-mentor>`__
 - |:newspaper:| `Feeling like a fraud and how to deal with it </blog/newsletter-october-2019/#feeling-like-a-fraud-and-how-to-deal-with-it>`__
 - |:newspaper:| `Making the leap to managing writers </blog/newsletter-july-2019/#making-the-leap-to-managing-writers>`__
@@ -327,10 +341,13 @@ Localization and globalization
 
 - |:movie_camera:| `Creating documentation for the African audience </videos/prague/2022/creating-documentation-for-the-african-audience-benny-ifeanyi-iheagwara/>`__
 - |:movie_camera:| `Toward the broader globalization of Open Source: documenting your localisation Journey </videos/prague/2022/toward-the-broader-globalization-of-open-source-documenting-your-localisation-j-melissa-black/>`__
+- |:movie_camera:| `How I use applied linguistics to be a better technical writer </videos/prague/2021/how-i-use-applied-linguistics-to-be-a-better-technical-writer-kat-stoica-ostenfeld/>`__
+
 
 Design
 ~~~~~~~
 
+- |:movie_camera:| `When documenting is designing: How to assist API design as a technical writer </videos/prague/2021/when-documenting-is-designing-how-to-assist-api-design-as-a-technical-writer-fabrizio-ferri-benedetti/>`__
 - |:newspaper:| `Docs and design: When docs can’t fix all the things </blog/newsletter-november-2019/#docs-and-design-when-docs-can-t-fix-all-the-things>`__
 - |:movie_camera:| `How I decided to do this talk </videos/au/2017/how-i-decided-to-do-this-talk-gap-analysis-and-pull-apart-documentation-planning-laura-bailey>`__
 - |:movie_camera:| `Peanuts and Minimalism and Technical Writing </videos/au/2017/peanuts-and-minimalism-and-technical-writing-brice-fallon/>`__
@@ -362,7 +379,6 @@ UX writing
 Doc site design
 ~~~~~~~~~~~~~~~
 
-- |:movie_camera:| `Improve Customer Adoption with UI Help </videos/prague/2022/improve-customer-adoption-with-ui-help-prashant-mathapathi/>`__
 - |:movie_camera:| `Responsive Content - Presenting Your information On Any Device <https://www.youtube.com/watch?v=z7KBdPyRb18&index=5&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt>`__
 - |:newspaper:| `"Last updated" in docs </blog/newsletter-july-2017/#struggles-with-dates-and-versions>`__
 - |:newspaper:| `Documentation bylines </blog/newsletter-march-2017/#should-documentation-have-bylines>`__
@@ -374,6 +390,7 @@ Doc site design
 User needs
 ~~~~~~~~~~
 
+- |:movie_camera:| `The Baseline – Or Technical Writing for Non-Technical Readers </videos/prague/2020/the-baseline-or-technical-writing-for-non-technical-readers-paul-brown/>`__
 - |:movie_camera:| `Requirements that you didn't know were there </videos/eu/2017/requirements-that-you-didn-t-know-were-there-lesia-zasadna/>`__
 - |:movie_camera:| `As Good As It Gets: Why Better Trumps Best </videos/eu/2016/pretty-hurts-why-better-trumps-best-riona-macnamara/>`__
 - |:movie_camera:| `API documentation: Exploring the information needs of software developers </videos/eu/2016/api-documentation-exploring-the-information-needs-of-software-developers-michael-meng/>`__
@@ -385,6 +402,8 @@ Doc tools
 
 - |:movie_camera:| `Two years of Markdoc: what we’ve learned about balancing developer and author experience </videos/prague/2022/two-years-of-markdoc-what-we-ve-learned-about-balancing-developer-and-author-ex-ryan-paul/>`__
 - |:newspaper:| `Standards in documentation tooling </blog/newsletter-december-2021/#standards-in-documentation-tooling>`__
+- |:movie_camera:| `Hitchhiker’s Guide to Documentation Tools and Processes </videos/prague/2021/hitchhiker-s-guide-to-documentation-tools-and-processes-lukas-reu-ner/>`__
+- |:movie_camera:| `The Rocky Road to DocOps </videos/prague/2020/the-rocky-road-to-docops-chris-noonan/>`__
 - |:newspaper:| `How your tools affect your writing </blog/newsletter-december-2019/#how-your-tools-affect-your-writing>`__
 - |:newspaper:| `Deciding on a new tool… </blog/newsletter-october-2019/#deciding-on-a-new-tool>`__
 - |:newspaper:| `… and migrating to a new tool </blog/newsletter-october-2019/#and-migrating-to-a-new-tool>`__
@@ -451,6 +470,8 @@ Metrics and analytics
 
 - |:newspaper:| `Discovering user needs </blog/newsletter-august-2019/#starting-out-with-analytics-and-then-upping-your-game>`__
 - |:movie_camera:| `Don’t trust the numbers! </videos/portland/2022/don-t-trust-the-numbers-kumar-dhanagopal/>`__
+- |:movie_camera:| `The Importance of Using Analytics and Feedback for your Documentation </videos/prague/2020/the-importance-of-using-analytics-and-feedback-for-your-documentation-karissa-van-baulen/>`__
+- |:movie_camera:| `Making documentation discoverable in search engines </videos/prague/2020/making-documentation-discoverable-in-search-engines-myriam-jessier/>`__
 
 User research
 ~~~~~~~~~~~~~
@@ -470,6 +491,7 @@ User feedback
 Gathering it and acting on it.
 
 - |:newspaper:| `Collecting helpful user feedback </blog/newsletter-september-2022/#collecting-helpful-user-feedback>`__
+- |:movie_camera:| `Customer Feedback is the Fuel in our Engine </videos/prague/2021/customer-feedback-is-the-fuel-in-our-engine-kevin-hwang/>`__
 - |:newspaper:| `Gathering documentation feedback </blog/newsletter-july-2020/#gathering-documentation-feedback>`__
 - |:newspaper:| `Documentation feedback widgets - thumbs up or down? </blog/newsletter-december-2019/#documentation-feedback-widgets-thumbs-up-or-down>`__
 - |:newspaper:| `Collecting and acting on user feedback </blog/newsletter-may-2019/#collecting-and-acting-on-user-feedback>`__
@@ -501,6 +523,8 @@ Culture and community
 Building docs culture
 ~~~~~~~~~~~~~~~~~~~~~
 
+- |:movie_camera:| `Adventures in setting up a knowledge system for a research group </videos/prague/2021/adventures-in-setting-up-a-knowledge-system-for-a-research-group-victor-sluiter/>`__
+- |:movie_camera:| `How to be an Avante-Garde Guinea Pig: Building Better Content through Experimentation, Community-building, and Loud Squeaks </videos/prague/2020/how-to-be-an-avante-garde-guinea-pig-building-better-content-through-experimentation-community-building-and-loud-squeaks-jessica-valasek-estenssoro/>`__
 - |:newspaper:| `Promoting plain language </blog/newsletter-november-2018/#promoting-plain-language>`__
 - |:newspaper:| `Common misconceptions about docs </blog/newsletter-august-2018/#common-misconceptions-about-documentation>`__
 - |:movie_camera:| `Who Writes the Docs? </videos/portland/2018/who-writes-the-docs-beth-aitman/>`__
@@ -519,6 +543,7 @@ Building community
 
 - |:movie_camera:| `Peer writing and beyond - An experimental approach to a sustainable open-source projects </videos/portland/2022/peer-writing-and-beyond-an-experimental-approach-to-a-sustainable-open-source-chris-ganta/>`__
 - |:movie_camera:| `All together now: Turning technologists into documentarians </videos/portland/2022/all-together-now-turning-technologists-into-documentarians-liani-lye-she-her/>`__
+- |:movie_camera:| `Helping Your Community Contribute to Developer Documentation </videos/prague/2020/helping-your-community-contribute-to-developer-documentation-diana-lakatos/>`__
 - |:movie_camera:| `A content manager's guide to crowdsourcing the docs </videos/eu/2017/a-content-manager-s-guide-to-crowdsourcing-the-docs-becky-todd/>`__
 - |:movie_camera:| `No Community Members Were Harmed in the Making of This Doc Sprint </videos/na/2017/no-community-members-were-harmed-in-the-making-of-this-doc-sprint-how-we-ran-a-48-hour-event-to-collect-community-wisdom-into-a-guidebook-for-newsroom-developers-ryan-pitts-lindsay-muscato/>`__
 - |:movie_camera:| `The Wisdom of Crowds: Crowdsourcing Minimalism in an Open Organization </videos/na/2017/the-wisdom-of-crowds-crowdsourcing-minimalism-in-an-open-organization-ingrid-towey/>`__
@@ -610,7 +635,9 @@ Planning and how we work
 
 - |:newspaper:| `Estimating docs work </blog/newsletter-october-2022/#estimating-docs-work>`__
 - |:newspaper:| `Estimating work </blog/newsletter-june-2022/#estimating-work>`__
+- |:movie_camera:| `Alchemy in Adversity (How to become better and more resilient tech writers in a turbulent work environment) </videos/prague/2021/alchemy-in-adversity-how-to-become-better-and-more-resilient-tech-writers-in-a-turbulent-work-environment-anna-korinna-n-meth-szab/>`__
 - |:newspaper:| `Adapting to working from home </blog/newsletter-april-2020/#adapting-to-working-from-home>`__
+- |:movie_camera:| `Remote Job On-boarding: Top 10 Things We Can Do (Better) </videos/prague/2020/remote-job-on-boarding-top-10-things-we-can-do-better-karen-sawrey/>`__
 - |:newspaper:| `The costs of outdated docs </blog/newsletter-february-2020/#the-costs-of-outdated-docs>`__
 - |:newspaper:| `How to set priorities on a documentation team </blog/newsletter-february-2020/#how-to-set-priorities-on-a-documentation-team>`__
 - |:newspaper:| `Writing remotely </blog/newsletter-august-2019/#writing-remotely>`__
@@ -627,6 +654,7 @@ Agile and workflows
 ~~~~~~~~~~~~~~~~~~~
 
 - |:newspaper:| `Tracking work </blog/newsletter-july-2020/#tracking-work>`__
+- |:movie_camera:| `Documenting the (Ancient) History of Your Project </videos/prague/2020/documenting-the-ancient-history-of-your-project-natali-vlatko/>`__
 - |:newspaper:| `Task management for docs teams </blog/newsletter-october-2018/#task-management-tools-for-docs-teams>`__
 - |:newspaper:| `Agile workflows for docs </blog/newsletter-october-2018/#show-us-your-workflows>`__
 - |:newspaper:| `Working on Agile teams </blog/newsletter-may-2017/#the-challenges-of-documentation-in-an-agile-environment>`__
@@ -665,6 +693,7 @@ Defining success
 Theories/Philosophy
 -------------------
 
+- |:movie_camera:| `Cognitive Ergonomics in Technical Writing - Lessons from the Field </videos/prague/2021/cognitive-ergonomics-in-technical-writing-lessons-from-the-field-anita-diamond/>`__
 - |:movie_camera:| `7 Essential Tips for the Enlightened Tech Writer </videos/portland/2018/7-essential-tips-for-the-enlightened-tech-writer-ted-hudek/>`__
 - |:movie_camera:| `Peanuts and Minimalism and Technical Writing </videos/au/2017/peanuts-and-minimalism-and-technical-writing-brice-fallon/>`__
 - |:movie_camera:| `7 Values of Effective Tech Writing Teams </videos/na/2016/7-values-of-effective-tech-writing-teams-joao-fernandes/>`__
@@ -673,6 +702,7 @@ Theories/Philosophy
 Maths, science and history
 --------------------------
 
+- |:movie_camera:| `A Journey to Pattern Languages </videos/prague/2020/a-journey-to-pattern-languages-andrew-haynes/>`__
 - |:movie_camera:| `Facebook, Dynamite, Uber, Bombs, and You <https://www.youtube.com/watch?v=N13_FP2NkSk&t=0s&index=2&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt>`__
 - |:movie_camera:| `A brief history of text markup languages </videos/prague/2018/a-brief-history-of-text-markup-languages-tony-ibbs/>`__
 - |:movie_camera:| `Tech Writers Without Borders: Making the world a better place, one (numbered) step at a time </videos/eu/2017/tech-writers-without-borders-making-the-world-a-better-place-one-numbered-step-at-a-time-stuart-culshaw/>`__

--- a/docs/topics.rst
+++ b/docs/topics.rst
@@ -128,6 +128,7 @@ Task-based writing
 API docs
 ~~~~~~~~
 
+- |:movie_camera:| `Write the API docs before the API exists </videos/prague/2019/write-the-api-docs-before-the-api-exists-ben-ahmady/>`__
 - |:newspaper:| `Documenting APIs with "interesting" design choices </blog/newsletter-february-2019/#documenting-apis-with-interesting-design-choices>`__
 - |:newspaper:| `When does one API stop and another begin? </blog/newsletter-may-2018/#distinguishing-one-api-from-many>`__
 - |:newspaper:| `API reference docs layout </blog/newsletter-december-2017/#thinking-hard-about-api-reference-docs-layout>`__
@@ -157,6 +158,8 @@ Including how-tos, reference docs, tutorials, and books.
 - |:movie_camera:| `Emulating the Teacher’s Approving Nod in Teaching Material </videos/prague/2020/emulating-the-teacher-s-approving-nod-in-teaching-material-tanks-transfeld/>`__
 - |:movie_camera:| `How (and why) to make awesome video tutorials </videos/australia/2020/how-and-why-to-make-awesome-video-tutorials-sayraphim-lothian/>`__
 - |:movie_camera:| `Microcontent: Designing & Developing Reusable Content </videos/australia/2020/microcontent-designing-developing-reusable-content-scott-deloach/>`__
+- |:movie_camera:| `The Power of Empathy in Support Documentation: A 5-Step Guide </videos/prague/2019/the-power-of-empathy-in-support-documentation-a-5-step-guide-plamena-maleva/>`__
+- |:movie_camera:| `101 to 404s: How to write great error messages </videos/prague/2019/101-to-404s-how-to-write-great-error-messages-james-scott/>`__
 - |:movie_camera:| `Learning to love release notes </videos/prague/2018/learning-to-love-release-notes-anne-edwards/>`__
 - |:movie_camera:| `"It's a Feature" - Documenting Known Issues and Product Shortcomings </videos/prague/2018/it-s-a-feature-documenting-known-issues-and-product-shortcomings-ivana-devcic/>`__
 - |:movie_camera:| `Writing the Next Great Tech Book </videos/portland/2018/writing-the-next-great-tech-book-brian-macdonald/>`__
@@ -178,6 +181,7 @@ Storytelling
 
 - |:movie_camera:| `When Wishing Still Helped … What Folklore Can Teach Us about Technical Writing </videos/prague/2020/when-wishing-still-helped-what-folklore-can-teach-us-about-technical-writing-ingrid-k-towey/>`__
 - |:movie_camera:| `Storytelling for Technical Products - What We Can Learn from Lego and Pixar </videos/australia/2020/storytelling-for-technical-products-what-we-can-learn-from-lego-and-pixar-akshay-iyer/>`__
+- |:movie_camera:| `Wild Geeks: Poetry in the Digital Age </videos/prague/2019/wild-geeks-poetry-in-the-digital-age-ellie-farrier/>`__
 - |:movie_camera:| `Telling a Great Story on GitHub </videos/eu/2017/telling-a-great-story-on-github-lauri-apple/>`__
 - |:movie_camera:| `What Writing Fiction Teaches You About Writing Documentation </videos/na/2016/what-writing-fiction-teaches-you-about-writing-documentation-thursday-bram/>`__
 - |:movie_camera:| `Documenting your Story - Crafting a good presentation </videos/eu/2015/documenting-your-story-crafting-a-good-presentation-cward/>`__
@@ -188,6 +192,7 @@ Writing doc sets
 ----------------
 
 - |:movie_camera:| `Don’t shoot yourself in the foot with content reuse </videos/portland/2022/don-t-shoot-yourself-in-the-foot-with-content-reuse-anna-gasparyan/>`__
+- |:movie_camera:| `How to launch your startup with good docs </videos/prague/2019/how-to-launch-your-startup-with-good-docs-brian-lemke/>`__
 - |:movie_camera:| `Delivering Documents For All Three Use Cases </videos/au/2017/delivering-documents-for-all-three-use-cases-margaret-fero/>`__
 - |:movie_camera:| `What nobody tells you about documentation </videos/eu/2017/the-four-kinds-of-documentation-and-why-you-need-to-understand-what-they-are-daniele-procida/>`__
 
@@ -241,6 +246,7 @@ Jobs and careers
 Hiring
 ~~~~~~~
 
+- |:movie_camera:| `Fostering Technical Writing in Developing Nations </videos/prague/2019/fostering-technical-writing-in-developing-nations-prerana-pradhan/>`__
 - |:newspaper:| `Using writing tests when hiring </blog/newsletter-august-2019/#using-writing-tests-when-hiring>`__
 - |:newspaper:| `Running objective interviews </blog/newsletter-june-2019/#running-objective-interviews>`__
 - |:newspaper:| `Developer to documentarian ratio </blog/newsletter-may-2019/#developer-to-documentarian-ratio>`__
@@ -292,6 +298,7 @@ Career growth
 - |:movie_camera:| `Onboard yourself: How to get set-up for success in a new role </videos/australia/2020/onboard-yourself-how-to-get-set-up-for-success-in-a-new-role-michael-belton/>`__
 - |:newspaper:| `Leading and following: finding a mentor, being a mentor </blog/newsletter-october-2019/#leading-and-following-finding-a-mentor-being-a-mentor>`__
 - |:newspaper:| `Feeling like a fraud and how to deal with it </blog/newsletter-october-2019/#feeling-like-a-fraud-and-how-to-deal-with-it>`__
+- |:movie_camera:| `Fostering Talent: Mentorship, Peer Reviews and Going Beyond Your Job Description </videos/prague/2019/fostering-talent-mentorship-peer-reviews-and-going-beyond-your-job-description-arran-southall/>`__
 - |:newspaper:| `Making the leap to managing writers </blog/newsletter-july-2019/#making-the-leap-to-managing-writers>`__
 - |:newspaper:| `Tips for lone writers starting from scratch </blog/newsletter-february-2019/#tips-for-lone-writers-starting-from-scratch>`__
 - |:newspaper:| `Personal development goals </blog/newsletter-february-2019/#personal-development-goals-for-documentarians>`__
@@ -333,6 +340,7 @@ Accessibility and inclusivity
 
 - |:movie_camera:| `ADHD and its impact on the Creative Process for Writers </videos/prague/2022/adhd-and-its-impact-on-the-creative-process-for-writers-tyler-smith/>`__
 - |:newspaper:| `Resources for diverse example names </blog/newsletter-july-2020/#resources-for-diverse-example-names>`__
+- |:movie_camera:| `Inclusive environments are better: science says so </videos/prague/2019/inclusive-environments-are-better-science-says-so-ilona-koren-deutsch/>`__
 - |:movie_camera:| `A11y-Friendly Documentation </videos/prague/2018/a11y-friendly-documentation-carolyn-stransky/>`__
 - |:newspaper:| `Accessibility for colour blindness </blog/newsletter-august-2017/#accessible-docs-colorblindness-edition>`__
 - |:newspaper:| `Screen readers and svgs </blog/newsletter-may-2017/#screen-readers-and-accessibility>`__
@@ -350,12 +358,14 @@ Localization and globalization
 - |:movie_camera:| `Toward the broader globalization of Open Source: documenting your localisation Journey </videos/prague/2022/toward-the-broader-globalization-of-open-source-documenting-your-localisation-j-melissa-black/>`__
 - |:movie_camera:| `How I use applied linguistics to be a better technical writer </videos/prague/2021/how-i-use-applied-linguistics-to-be-a-better-technical-writer-kat-stoica-ostenfeld/>`__
 - |:movie_camera:| `Influence your customer outreach with best practices for internationalization </videos/australia/2020/influence-your-customer-outreach-with-best-practices-for-internationalization-vikram-mulay/>`__
+- |:movie_camera:| `Found in Translation: Lessons from a Year of Open Source Localization </videos/prague/2019/found-in-translation-lessons-from-a-year-of-open-source-localization-zachary-sarah-corleissen/>`__
 
 
 Design
 ~~~~~~~
 
 - |:movie_camera:| `When documenting is designing: How to assist API design as a technical writer </videos/prague/2021/when-documenting-is-designing-how-to-assist-api-design-as-a-technical-writer-fabrizio-ferri-benedetti/>`__
+- |:movie_camera:| `Surprise! You’re a designer now. </videos/prague/2019/surprise-you-re-a-designer-now-kelly-obrien/>`__
 - |:newspaper:| `Docs and design: When docs can’t fix all the things </blog/newsletter-november-2019/#docs-and-design-when-docs-can-t-fix-all-the-things>`__
 - |:movie_camera:| `How I decided to do this talk </videos/au/2017/how-i-decided-to-do-this-talk-gap-analysis-and-pull-apart-documentation-planning-laura-bailey>`__
 - |:movie_camera:| `Peanuts and Minimalism and Technical Writing </videos/au/2017/peanuts-and-minimalism-and-technical-writing-brice-fallon/>`__
@@ -389,6 +399,7 @@ Doc site design
 ~~~~~~~~~~~~~~~
 
 - |:movie_camera:| `A treasure map for the doc – Exploring the discoverability of documentation </videos/australia/2020/a-treasure-map-for-the-doc-exploring-the-discoverability-of-documentation-marika-vertzonis/>`__
+- |:movie_camera:| `Disagree with “I Agree”. Enforcing better data privacy through the language of documentation </videos/prague/2019/disagree-with-i-agree-enforcing-better-data-privacy-through-the-language-of-documentation-karen-sawrey/>`__
 - |:movie_camera:| `Responsive Content - Presenting Your information On Any Device <https://www.youtube.com/watch?v=z7KBdPyRb18&index=5&list=PLy70RNJ7dYrJ1wANiqa7ObwUnoJjouQjt>`__
 - |:newspaper:| `"Last updated" in docs </blog/newsletter-july-2017/#struggles-with-dates-and-versions>`__
 - |:newspaper:| `Documentation bylines </blog/newsletter-march-2017/#should-documentation-have-bylines>`__
@@ -401,6 +412,8 @@ User needs
 ~~~~~~~~~~
 
 - |:movie_camera:| `The Baseline – Or Technical Writing for Non-Technical Readers </videos/prague/2020/the-baseline-or-technical-writing-for-non-technical-readers-paul-brown/>`__
+- |:movie_camera:| `Seeing your docs through different eyes: Mapping doc users’ experiences </videos/prague/2019/seeing-your-docs-through-different-eyes-mapping-doc-users-experiences-aaron-collier/>`__
+- |:movie_camera:| `Documenting known unknowns </videos/prague/2019/documenting-known-unknowns-alison-macneil/>`__
 - |:movie_camera:| `Requirements that you didn't know were there </videos/eu/2017/requirements-that-you-didn-t-know-were-there-lesia-zasadna/>`__
 - |:movie_camera:| `As Good As It Gets: Why Better Trumps Best </videos/eu/2016/pretty-hurts-why-better-trumps-best-riona-macnamara/>`__
 - |:movie_camera:| `API documentation: Exploring the information needs of software developers </videos/eu/2016/api-documentation-exploring-the-information-needs-of-software-developers-michael-meng/>`__
@@ -433,6 +446,7 @@ Docs-as-code
 - |:movie_camera:| `One AWS team’s move to docs as code: what worked, what didn’t, what’s next </videos/portland/2022/one-aws-team-s-move-to-docs-as-code-what-worked-what-didn-t-what-s-next-marcia-riefer-johnston/>`__
 - |:newspaper:| `To git or not to git docs as code </blog/newsletter-august-2020/#to-git-or-not-to-git-docs-as-code>`__
 - |:newspaper:| `Pros and cons of the docs-as-code approach </blog/newsletter-april-2020/#pros-and-cons-of-the-docs-as-code-approach>`__
+- |:movie_camera:| `The UK government meets docs as code </videos/prague/2019/the-uk-government-meets-docs-as-code-jen-lambourne/>`__
 - |:newspaper:| `Adventures in generating docs from code comments </blog/newsletter-august-2019/#adventures-in-generating-docs-from-code-comments>`__
 - |:newspaper:| `What to do about text wrapping </blog/newsletter-july-2019/#what-to-do-about-text-wrapping>`__
 - |:newspaper:| `DITA vs docs-as-code </blog/newsletter-june-2019/#dita-vs-docs-as-code>`__
@@ -654,6 +668,7 @@ Planning and how we work
 - |:movie_camera:| `Remote Job On-boarding: Top 10 Things We Can Do (Better) </videos/prague/2020/remote-job-on-boarding-top-10-things-we-can-do-better-karen-sawrey/>`__
 - |:newspaper:| `The costs of outdated docs </blog/newsletter-february-2020/#the-costs-of-outdated-docs>`__
 - |:newspaper:| `How to set priorities on a documentation team </blog/newsletter-february-2020/#how-to-set-priorities-on-a-documentation-team>`__
+- |:movie_camera:| `The Super Effective Writing Process of Grammy-winning Artists </videos/prague/2019/the-super-effective-writing-process-of-grammy-winning-artists-kayla-lee/>`__
 - |:newspaper:| `Writing remotely </blog/newsletter-august-2019/#writing-remotely>`__
 - |:newspaper:| `Roadmaps and documenting 'future features' </blog/newsletter-march-2019/#roadmaps-and-documenting-future-features>`__
 


### PR DESCRIPTION
Update the topics page to include conference talks from 2019, 2020, 2021, and 2022 (AU, US, and EU). 

- Adds a few new categories including search, in-app documentation, globalization and localization, and building a team.
- I think I also added a few odd newsletter topics here and there.
- Fixes a couple typos on conference talk pages that I encountered putting this together. 

<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1853.org.readthedocs.build/en/1853/

<!-- readthedocs-preview writethedocs-www end -->