### PR TITLE
Remove ATL from Quorum East

### DIFF
--- a/docs/meetups/index.rst
+++ b/docs/meetups/index.rst
@@ -74,7 +74,6 @@ Current Meetups: Quorum North America East / Central
 
 Several meetups are members of the Quorum North America East group:
 
-* Atlanta
 * Austin
 * Detroit / Windsor
 * Florida


### PR DESCRIPTION
Group no longer has an organizer, removing from East Coast Quorum

<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1859.org.readthedocs.build/en/1859/

<!-- readthedocs-preview writethedocs-www end -->