### PR TITLE
Remove Australia from front page list of confs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,6 @@ tech writers, developer advocates, customer support, marketers, and anyone else 
 people to have great experiences with software.
 
 * :doc:`Attend one of our conferences </conf/index>`
-   - :doc:`Australia 2022 </conf/australia/2022/index>`, **December 8-9**, Virtual - AEDT
    - :doc:`Portland 2023 </conf/portland/2023/index>`, **May 7-9**, Portland, Oregon, United States
    - :doc:`Atlantic 2023 </conf/atlantic/2023/index>`, **September 10-12**, Virtual - CEST and EDT
 


### PR DESCRIPTION
This is in the past now,
so don't highlight it up front.


<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1866.org.readthedocs.build/en/1866/

<!-- readthedocs-preview writethedocs-www end -->