### PR TITLE
Fixing link to 2021 stats

### DIFF
--- a/docs/blog/write-the-docs-2022-stats.rst
+++ b/docs/blog/write-the-docs-2022-stats.rst
@@ -16,7 +16,7 @@ so we have removed it from the stats post.
 We have shared our high-level community stats since 2016,
 and will continue to do it each year going forward.
 
-You can read our previous posts from 2016_, 2017_, 2018_, 2019_, 2020_, _2021_.
+You can read our previous posts from 2016_, 2017_, 2018_, 2019_, 2020_, 2021_.
 
 .. _2021: https://www.writethedocs.org/blog/write-the-docs-2021-stats/
 .. _2020: https://www.writethedocs.org/blog/write-the-docs-2020-stats/


### PR DESCRIPTION
Removed extra underscore that was donking things up 🙂 

<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1873.org.readthedocs.build/en/1873/

<!-- readthedocs-preview writethedocs-www end -->