### PR TITLE
Bump python in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ If you run into trouble with broken links to video files, have a look at `_ext/f
 
 ### Prerequisites for generating the docs locally
 
-1. Install `python 3.6.x` using your package manager, if not installed already. You'll probably need `root` privileges to do this.
+1. Install `python 3.8.x` using your package manager, if not installed already. You'll probably need `root` privileges to do this.
 
 2. Generate a virtual environment for the WTD repo in the `venv` directory:
 
-    `virtualenv --python=/usr/bin/python3.6 venv`
+    `virtualenv --python=/usr/bin/python3.8 venv`
 
 ### Installing the project requirements
 
@@ -79,10 +79,6 @@ If you're not seeing new content in the local preview, run `make clean` to delet
 
 The Write the Docs website is hosted on [Read the Docs](https://readthedocs.org/projects/writethedocs-www).
 
-### Previewing changes on Netlify
-
-You can preview changes you've made on a pull request by clicking "Show all checks" at the bottom of the pull request page, and then clicking "Details" on the Netflify line, and navigating to the page you're making changes to.
-
 ### Updating the CSS
 
 Styling is maintained in `docs/_static/conf/css/` as SASS. Convert SASS to minified CSS by installing SASS
@@ -96,7 +92,6 @@ npm install -g sass
 ```
 sass --style=compressed docs/_static/conf/scss/main-2022.scss docs/_static/conf/css/main-2022.min.css
 ```
-
 
 ### Deactivating venv
 


### PR DESCRIPTION
* 3.6 is EOL and can be hard to install 
* 3.8 matches what we're using in GH Actions.

<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1887.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->