### PR TITLE
Lots of small changes to the website and sponsorship

### DIFF
--- a/docs/_templates/footer.html
+++ b/docs/_templates/footer.html
@@ -46,7 +46,7 @@
             &nbsp;<a rel="license" href="http://creativecommons.org/licenses/by-nc-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc-sa/4.0/80x15.png" /></a>
           </span>
           <span id="social-footer" class="pull-right">
-            <span><a href="mailto:support@writethedocs.org"><i class="iconf-email"></i>support@writethedocs.org</a></span> |
+            <span><a href="/contact/"><i class="iconf-email"></i>Contact Us</a></span> |
             <span><a href="/site-map"><i class="iconf-github-circled-alt2"></i>Site map</a></span> |
             <span><a href="https://github.com/writethedocs"><i class="iconf-github-circled-alt2"></i>GitHub</a></span> |
             <span><a href="https://twitter.com/writethedocs"><i class="iconf-twitter-circled"></i>Twitter</a></span> |
@@ -66,7 +66,7 @@
     <a class="sponsor" href="https://readthedocs.org" rel="noopener" target="_blank">
       <img src="https://read-the-docs-guidelines.readthedocs-hosted.com/_images/logo-wordmark-dark.png" alt="Read the Docs" class="sponsor-image">
       <div class="sponsor-name">Read the Docs</div>
-      <div class="sponsor-description">Donated Hosting</div>
+      <div class="sponsor-description">Website Hosting</div>
     </a>
     {% for sponsor in global_sponsors %}
     <a class="sponsor" href="{{ sponsor.link }}" rel="noopener" target="_blank">
@@ -77,8 +77,7 @@
     {% endfor %}
 
     <a class="sponsor" href="{{ pathto('sponsorship/index') }}" rel="noopener" target="_blank">
-      <div class="sponsor-name">Your logo here</div>
-      <div class="sponsor-description">Sponsor us</div>
+      <div class="sponsor-name">Sponsorship Info</div>
     </a>
   </div>
 </div>

--- a/docs/about/about-the-org.rst
+++ b/docs/about/about-the-org.rst
@@ -10,6 +10,7 @@ About Our Organization
    /origin-story
    /documentarians
    /code-of-conduct
+   /contact
 
 
 Guiding Principles and Governance

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -151,22 +151,22 @@ suppress_warnings = ['image.nonlocal_uri']
 
 # Our additions
 
-global_sponsors = yaml.safe_load("""
-- name: google
-  link: https://www.google.com
-  brand: Google
-  comment: Patron sponsor
-- name: archbee-new
-  link: https://archbee.io/?utm_medium=banner&utm_source=footer&utm_campaign=wtd
-  brand: Archbee
-  comment: Community sponsor
-""")
+# No global sponsors currently
+#
+# global_sponsors = yaml.safe_load("""
+# - name: archbee-new
+#   link: https://archbee.io/?utm_medium=banner&utm_source=footer&utm_campaign=wtd
+#   brand: Archbee
+#   comment: Community sponsor
+# """)
+
+global_sponsors = {}
 
 html_context = {
     'conf_py_root': os.path.dirname(os.path.abspath(__file__)),
-    'newsletter_subs': '6,500',
+    'newsletter_subs': '10,000',
     'slack_members': '15,000',
-    'website_visits': '30,000',
+    'website_visits': '20,000',
     'global_sponsors': global_sponsors,
     'cfp_variables': cfp_variables,
     'slack_join': "https://join.slack.com/t/writethedocs/shared_invite/zt-12k7dh46o-eNMS1sHejK2OiiBfnBf6hw",

--- a/docs/contact.rst
+++ b/docs/contact.rst
@@ -1,0 +1,20 @@
+Contact Us
+==========
+
+If you have any questions or concerns about Write the Docs,
+the best way to reach us is via email.
+You can email us at support@writethedocs.org.
+
+Please include any relevant information in your email about how we can help you.
+
+.. warning:: 
+    If you are looking to file a `Code of Conduct <https://www.writethedocs.org/code-of-conduct//#reporting-and-contact-information>`_ issue,
+    please refer there for contact information
+
+While you wait
+--------------
+
+There are a couple other places you might be able to find the information that you're looking for:
+
+* :doc:`/sponsorship/index`
+* :doc:`/conf/index`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,39 +15,40 @@ their users to be a member of our community. This can be programmers,
 tech writers, developer advocates, customer support, marketers, and anyone else who wants
 people to have great experiences with software.
 
-* :doc:`Attend one of our conferences </conf/index>`
+* Attend one of :doc:`our conferences </conf/index>`
    - :doc:`Portland 2023 </conf/portland/2023/index>`, **May 7-9**, Portland, Oregon, United States
    - :doc:`Atlantic 2023 </conf/atlantic/2023/index>`, **September 10-12**, Virtual - CEST and EDT
-
-Find or advertise a job
------------------------
-
-Work with other documentarians.
-
-* `Find a docs related job <https://jobs.writethedocs.org/>`__  on our Job Board
-* :doc:`Read the Guide to Hiring and Getting Hired </hiring-guide/index>`
 
 Connect with the community
 --------------------------
 
 Get more information on how to meet the community, get involved, stay in touch.
 
-* :doc:`Join our slack network </slack>` with thousands of other documentarians
-* :doc:`Join a local or online meetup </meetups/index>`
-* :doc:`Sponsor a conference, the newsletter or the site <sponsorship/index>`
-* `Fill out the current salary survey <https://salary-survey.writethedocs.org/>`__
+* Join our :doc:`slack network </slack>` with thousands of other documentarians
+* Join a :doc:`local or online meetup </meetups/index>` to dive deeper into the community
+* Learn more about our :doc:`sponsorship options <sponsorship/index>` for your company
 
-Learn
------
+Find or advertise a job
+-----------------------
 
-An ever increasing source of talk videos, articles, links, and resources:
+Work with other documentarians.
 
-* :doc:`Subscribe to one of our newsletters </newsletter>`
-* :doc:`Browse the newsletter and video archives by topic </topics>`
-* :doc:`Read the Documentation Guide <guide/index>`
-* :doc:`Read the latest salary survey report </surveys/salary-survey/2021>`
-* :doc:`See what the teams have been up to </blog/index>`
-* :doc:`Learn about Write the Docs itself <about/about-the-org>` 
+* Find or post a `docs related job <https://jobs.writethedocs.org/>`__ on our Job Board
+* Read our :doc:`Hiring Guide </hiring-guide/index>` to get started in the industry
+* Read our previous `salary survey <https://www.writethedocs.org/surveys/>`__ information to get a sense of the industry pay
+
+Learn from our resources
+------------------------
+
+We have an ever-increasing set of talk videos, articles, links, and resources:
+
+* Subscribe to one of :doc:`newsletter and conference </newsletter>` mailing lists
+* Browse our :doc:`topic index </topics>`
+* Read the latest in our :doc:`blog </blog/index>`
+* Learn about :doc:`Write the Docs <about/about-the-org>` itself
+
+We're glad you stopped by!
+We hope you'll join us either online or in-person for an event soon.
 
 .. toctree::
    :hidden:

--- a/docs/sponsorship/website.rst
+++ b/docs/sponsorship/website.rst
@@ -9,7 +9,7 @@ You can sponsor the Write the Docs community website in two ways:
 Website Stats
 -------------
 
-Our website currently gets {{ website_visits }} visits a month.
+Our website currently gets {{ website_visits }}+ visits a month.
 The best idea of who is visiting our site is the information we have from our conferences.
 Our audience is made up of:
 

--- a/docs/topics.rst
+++ b/docs/topics.rst
@@ -1,9 +1,11 @@
-Videos and articles
-===================
+Content Archive by Topic
+========================
 
-This page links to the topics that have been covered by `conference </conf/>`__ talks or in the `newsletter </newsletter/>`__. They're in no particular order, and some topics are repeated if they fit into more than one category. Enjoy!
+This page links to the topics that have been covered by `conference </conf/>`__ talks or in the `newsletter </newsletter/>`__.
+They're in no particular order, and some topics are repeated if they fit into more than one category.
+Enjoy!
 
-If you think something is wrongly categorised, please send us a pull request :)
+If you think something is wrongly categorized, please let us know.
 
 .. contents::
    :local:


### PR DESCRIPTION
I did a quick cleanup of the front page and website sponsorship,
which is where this started.
It mostly just cleans things up,
but it did change:

* Sidebar sponsorship is now just monthly
* Footer sponsorship is yearly
* I also added a contact us page, because that seems useful..


<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1891.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->