### PR TITLE
Update and future-proof the Quorum page

### DIFF
--- a/docs/organizer-guide/meetups/quorum.md
+++ b/docs/organizer-guide/meetups/quorum.md
@@ -1,9 +1,18 @@
 Write the Docs Meetup Quorum
 ============================
 
-The Quorum program brings together various local [Write the Docs](https://www.writethedocs.org/) meetup chapters in compatible time zones to provide quarterly super meetups over Zoom throughout the year. These quarterly virtual meetups can serve one or more time zones. Virtual events increase community participation and offer more opportunities for sharing knowledge. Virtual Meetup Quorums have high value in geographies where there isn't a tech epicenter. 
+The Quorum program brings together various local [Write the Docs](https://www.writethedocs.org/) meetup chapters in compatible time zones to provide quarterly super meetups over Zoom throughout the year. These quarterly virtual meetups can serve one or more time zones. Virtual events increase community participation and offer more opportunities for sharing knowledge. Virtual Meetup Quorums have high value in geographies where there isn't a tech epicenter.
 
 As always, ask questions on the [Write the Docs Slack workspace](https://www.writethedocs.org/slack/) any time.
+
+## Current coordinators
+
+Alyssa Rock @barbaricyawps is the current coordinator the Quorum program.
+Feel free to contact Alyssa on the WTD Slack workspace if:
+
+- You are interested in giving a presentation at Quorum event. We're always looking for new speakers and we're open to a wide variety of presentations from anyone in the Write the Docs community.
+- You are an organizer of a local WTD chapter and would like to participate in the Quorum program.
+
 
 ## Meetup links
 
@@ -11,61 +20,48 @@ A separate parent Meetup exists for each quorum program.
 Local chapter organizers announce upcoming events and direct their members to join the parent Meetup to RSVP for events.
 
 - [U.S. East Coast and Central](https://www.meetup.com/virtual-write-the-docs-east-coast-quorum/)
-- [U.S. West Coast and Mountain](https://www.meetup.com/virtual-write-the-docs-west-coast-quorum/)
+- [U.S. West Coast, Mountain, and Australia](https://www.meetup.com/virtual-write-the-docs-west-coast-quorum/)
 - Community organizers: Your parent meetup can be here!
 
 ## Meetup schedules
 
 Meetups are held quarterly.
-On a rotating basis, a different meetup is responsible for the quarterly super meetup.
+On a rotating basis, a different local meetup is responsible for organizing and emceeing the quarterly super meetup.
 
-If it is safe to do so (for example, coronavirus or other health risks), individual chapters can still meet in person during the off months for social networking or for their own local educational presentation events.
-Individual chapters are also welcome to organize in-person events to view the super meetups.
+### East Coast U.S. calendar
 
-As a general rule, Quorum meetup events occur on a dependable cadence. For example, during the 3rd week of the month, with the 4th week acting as a backup if needed. 
-Monday through Thursday are acceptable days of the week for presentations.
-The off months for each quarter can act as a backup for meetings if needed.
-Conduct a planning meeting the month before each meetup to plan the logistics for the upcoming quarter.
-
-In 2021, U.S. East Coast and Central meetups the first month of the quarter and U.S. West Coast and Mountain occurred in the second month of the quarter.
-Determine appropriate Virtual Quorum Meetups times and events that work for your geography. 
-
-Plan and publish a calendar each year, like:
-
-### East Coast U.S. calendar for 2022
-
-  | Month  | Event                         |
-  | ------ | ----------------------------- |
-  | Jan    | Off (no meetings)             |
-  | Feb    | East Coast Quorum meetup      |
-  | Mar    | Off (no meetings)             |
-  | Apr    | East Coast Quorum meetup      |
-  | May    | WTD Portland conference       |
-  | June   | Off (no meetings)             |
-  | July   | Off (no meetings)             |
-  | Aug    | East Coast Quorum meetup      |
-  | Sept   | Off (no meetings)             |
-  | Oct    | Off (no meetings)             |
-  | Nov    | East Coast Quorum meetup      |
-  | Dec    | Off (no meetings)             |
+  | Q | Month | Event                         |
+  | - | ----- | ----------------------------- |
+  | 1 | Jan   | Off (no meetings)             |
+  | 1 | Feb   | Off (no meetings)             |
+  | 1 | Mar   | East Coast Quorum meetup      |
+  | 2 | Apr   | Off (no meetings)             |
+  | 2 | May   | WTD Portland conference       |
+  | 2 | June  | East Coast Quorum meetup      |
+  | 3 | July  | Off (no meetings)             |
+  | 3 | Aug   | East Coast Quorum meetup      |
+  | 3 | Sept  | WTD Atlantic conference       |
+  | 4 | Oct   | Off (no meetings)             |
+  | 4 | Nov   | East Coast Quorum meetup      |
+  | 4 | Dec   | Off (no meetings)             |
 
 
-### West Coast U.S. calendar for 2022
+### West Coast U.S. calendar
 
-  | Month  | Event                         |
-  | ------ | ----------------------------- |
-  | Jan    | West Coast Quorum meetup      |
-  | Feb    | Off (no meetings)             |
-  | Mar    | West Coast Quorum meetup      |
-  | Apr    | Off (no meetings)             |
-  | May    | WTD Portland conference       |
-  | June   | West Coast Quorum meetup      |
-  | July   | Off (no meetings)             |
-  | Aug    | Off (no meetings)             |
-  | Sept   | West Coast Quorum meetup      |
-  | Oct    | Off (no meetings)             |
-  | Nov    | Off (no meetings)             |
-  | Dec    | West Coast Quorum meetup      |
+  | Q | Month | Event                         |
+  | - | ----- | ----------------------------- |
+  | 1 | Jan   | West Coast Quorum meetup      |
+  | 1 | Feb   | Off (no meetings)             |
+  | 1 | Mar   | Off (no meetings)             |
+  | 2 | Apr   | West Coast Quorum meetup      |
+  | 2 | May   | WTD Portland conference       |
+  | 2 | June  | Off (no meetings)             |
+  | 3 | July  | West Coast Quorum meetup      |
+  | 3 | Aug   | Off (no meetings)             |
+  | 3 | Sept  | WTD Atlantic conference       |
+  | 4 | Oct   | West Coast Quorum meetup      |
+  | 4 | Nov   | Off (no meetings)             |
+  | 4 | Dec   | Off (no meetings)             |
 
 
 ## Meeting agenda and times
@@ -74,7 +70,7 @@ Meetings last an hour and follow this agenda and time structure. For example, fo
 
 - **7:00 to 7:10 - Icebreakers and announcements** - For the first 10 minutes, remote attendees can join and participate in icebreaker activities. Then, the emcee makes announcements and introduces the speaker.
 - **7:15 to 8:00 - Presentation and Q&A** - The speaker has about 30-45 minutes for their presentation that includes the Q&A portion. The Q&A can expand to fill the time if the presentation is short.
-- **7:45 to 8:30 - Breakout rooms by meetup** - Attendance at this portion of the meetup is optional. We'll use Zoom breakout rooms to have people meet with their individual meetup organizers to say hi to other people in their meetup. Organizers can use that time to talk about job openings, talk about future meetups, and socialize.
+- **8:00 to 8:30 - Breakout rooms by meetup** - Attendance at this portion of the meetup is optional. We'll use Zoom breakout rooms to have people meet with their individual meetup organizers to say hi to other people in their meetup. Organizers can use that time to talk about job openings, talk about future meetups, and socialize.
 
 % See [Meeting agenda (detailed)](meeting-agenda-detailed.md) more detailed meeting instructions. See also: [Emcee script](emcee-script.md).-->
 
@@ -89,8 +85,6 @@ Traffic is hopefully driven back to local meetups by:
 
 - Hosting breakout rooms at the end of the Quorum meetups in which local meetup leaders can connect in smaller groups with people who came to the Quorum meetup that are from a common area.
 - Post links to each of the sponsoring local meetup groups in the Quorum meetup event details.
-
-% See [Quorum meetup publicity (detailed)](meetup-publicity-detailed.md) for more information about publicity. -->
 
 
 ## Advantages of participating
@@ -117,28 +111,17 @@ Participating local meetup organizers agree to:
 - Attend as many regional super meetups for your region as possible.
 - (Optional): It helps to have 1-2 core team members who can assist in coordinating the Zoom calls and communicating with meetup organizers.
 
-% For more information and tips for organizing a successful meetup when it's your turn, see [Organizing a meetup](meetup-organizing.md). -->
-
-% When you are the Zoom coordinator for the event, see the [Zoom coordinator guide](zoom-coordinator-guide).-->
-
 
 ## How to participate in Quorum
 
-We can launch a new quorum in a time zone or area if we have at least 4 or more local meetups in a given geography that are interested in participating.
+We can launch a new quorum in a region if we have at least 4 or more local meetups in a given geography that are interested in participating.
 
 To join the discussion, join the [Write the Docs Slack](https://www.writethedocs.org/slack/) and add yourself to the `#meetup-organizers-quorum`.
 
 We also use the [wtd-quorum on groups.io](https://groups.io/g/wtd-quorum) mailing list.
 The goal is to cross-post from Slack to the mailing list for archiving purposes.
 
-## Will Quorum meetups continue after in-person events resume?
-
-Yes! The long-term plan is that time-zone compatible Quorum events become a permanent part of Write the Docs.
-
-Appreciation and thanks to Alyssa Rock @barbaricyawps for leading the charge in community organizing to champion the pilot tests for regional virtual super meetups.
-Hat tip to the communities who participated in the successful test and implementation of the virtual Quorum meetups. 
-
-U.S. East Coast and Central meetups:
+Participating U.S. East Coast and Central meetups:
 
 - [Austin, TX](https://www.meetup.com/WriteTheDocs-ATX-Meetup/)
 - [Detroit, MI/Windsor, CAN](https://www.meetup.com/write-the-docs-detroit-windsor/)
@@ -148,7 +131,7 @@ U.S. East Coast and Central meetups:
 - [Toronto, ON, CAN](https://www.meetup.com/Write-The-Docs-Toronto/)
 - [Washington, D.C.](https://www.meetup.com/Write-the-Docs-DC/)
 
-U.S. West Coast, Mountain, and Australian meetups:
+Participating U.S. West Coast, Mountain, and Australian meetups:
 
 - [Bay Area, CA](https://www.meetup.com/Write-the-Docs-Bay-Area/)
 - [Los Angeles, CA](https://www.meetup.com/Write-the-Docs-LA/)
@@ -156,4 +139,9 @@ U.S. West Coast, Mountain, and Australian meetups:
 - [Seattle, WA](https://www.meetup.com/Write-The-Docs-Seattle/)
 - [Australia](https://www.meetup.com/Write-the-Docs-Australia/)
 
+
+
+## Will Quorum meetups continue after in-person events resume?
+
+Yes! The long-term plan is that time-zone compatible Quorum events become a permanent part of Write the Docs.
 


### PR DESCRIPTION
This PR adds a few additional updates to the Quorum page:

- The name of current Quorum coordinator (me) was moved up front rather than at the bottom of the page to make it more discoverable.
- It adds Australia to the Quorum program.
- It updates the calendar and future-proofs the calendar so that it is not specific to a calendar year.
- It removes a few broken links that aren't necessary.

Thanks!

<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1895.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->