### PR TITLE
Fix URL syntax

### DIFF
--- a/docs/conf/portland/2023/writing-day.rst
+++ b/docs/conf/portland/2023/writing-day.rst
@@ -22,7 +22,7 @@ Check out the :doc:`/conf/{{shortcode}}/{{year}}/writing-day-cheatsheet` for a q
 Submit Your Project 
 -------------------
 
-We encourage attendees to `submit projects <https://forms.gle/NNBzBCwjdB2vF7ZeA>` 
+We encourage attendees to `submit projects <https://forms.gle/NNBzBCwjdB2vF7ZeA>`_ 
 for Writing Day in advance. You are more than welcome to bring a project,
 and announce it during the actual Writing Day.
 


### PR DESCRIPTION
Missing underscore.

Sorry, I'm on a Mac and can't build the project...

<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1920.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->