### PR TITLE
Add a Sponsor Expo that combines Job Fair & Product demos

### DIFF
--- a/docs/_data/portland-2023-schedule.yaml
+++ b/docs/_data/portland-2023-schedule.yaml
@@ -94,7 +94,7 @@ talks_day2:
     title: Doors open
     duration: '1:00'
   - duration: '0:00'
-    title: "<b>Sponsor Expo (job fair & product demos) Starts</b>"
+    title: "<b>Sponsor Expo Starts</b>"
   - duration: '0:00'
     title: "<b>Unconference Starts</b>"
   - duration: '0:30'
@@ -120,7 +120,7 @@ talks_day2:
   - duration: '0:10'
     title: '✋ 10 min Q&A'
   - duration: '0:00'
-    title: "<b>Job Fair Ends</b>"
+    title: "<b>Sponsor Expo Ends</b>"
   - duration: '1:20'
     title: '🍽️ Lunch Break (80 mins)'
   - duration: '0:30'

--- a/docs/_data/portland-2023-schedule.yaml
+++ b/docs/_data/portland-2023-schedule.yaml
@@ -94,7 +94,7 @@ talks_day2:
     title: Doors open
     duration: '1:00'
   - duration: '0:00'
-    title: "<b>Job Fair Starts</b>"
+    title: "<b>Sponsor Expo (job fair & product demos) Starts</b>"
   - duration: '0:00'
     title: "<b>Unconference Starts</b>"
   - duration: '0:30'

--- a/docs/_templates/2023/menu-desktop.html
+++ b/docs/_templates/2023/menu-desktop.html
@@ -20,7 +20,7 @@
                                           {% endif %}
                                           <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/lightning-talks') }}">Lightning Talks</a></li>
                                           <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/unconference') }}">Unconference</a></li>
-                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/job-fair') }}">Job Fair</a></li>
+                                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/job-fair') }}">Sponsor Expo</a></li>
                                           {% if flaghashike %}
                                           <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/outing') }}">Hike</a></li>
                                           {% endif %}

--- a/docs/_templates/2023/menu-mobile.html
+++ b/docs/_templates/2023/menu-mobile.html
@@ -12,7 +12,7 @@
                           <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/welcome-wagon') }}">Welcome Wagon</a></li>
                           <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/lightning-talks') }}">Lightning Talks</a></li>
                           <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/unconference') }}">Unconference</a></li>
-                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/job-fair') }}">Job Fair</a></li>
+                          <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/job-fair') }}">Sponsor Expo</a></li>
                           {% if flaghaswritingday %}
                           <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/writing-day') }}">Writing Day</a></li>
                           {% endif %}

--- a/docs/conf/portland/2023/job-fair.rst
+++ b/docs/conf/portland/2023/job-fair.rst
@@ -1,7 +1,7 @@
 :template: {{year}}/generic.html
 
-Sponsor Expo: Job Fair & Product demos
-======================================
+Sponsor Expo
+============
 
 This year we're inviting our top sponsors to engage with our attendees at our Sponsor Expo.
 This is a combination of two primary events:

--- a/docs/conf/portland/2023/job-fair.rst
+++ b/docs/conf/portland/2023/job-fair.rst
@@ -1,19 +1,28 @@
 :template: {{year}}/generic.html
 
-Job Fair
-========
+Sponsor Expo: Job Fair & Product demos
+======================================
 
-{% include "conf/events/job-fair.rst" %}
+This year we're inviting our top sponsors to engage with our attendees at our Sponsor Expo.
+This is a combination of two primary events:
+
+* Our job fair, where companies can talk with attendees who are interested in work
+* An area for product demos, for companies building products that our audience might use
+
+We're excited to invite you to mingle with our top sponsors in this area,
+and learn more about what opportunities they have.
 
 Schedule
 --------
 
 - Date & Time: **{{ date.day_four.date }}, {{ date.day_four.job_fair_time }} {{tz}}**.
-- Location: **{{about.unconfroom}}**.
+- Location: **{{about.job_fair_room}}**.
 
 Full schedule information is available on our :doc:`/conf/{{shortcode}}/{{year}}/schedule`  page.
 
-Useful tips
------------
+.. Hide this for now...
 
-{% include "conf/events/job-fair-tips.rst" %}
+    Useful tips
+    -----------
+
+    {% include "conf/events/job-fair-tips.rst" %}

--- a/docs/conf/portland/2023/job-fair.rst
+++ b/docs/conf/portland/2023/job-fair.rst
@@ -19,10 +19,3 @@ Schedule
 - Location: **{{about.job_fair_room}}**.
 
 Full schedule information is available on our :doc:`/conf/{{shortcode}}/{{year}}/schedule`  page.
-
-.. Hide this for now...
-
-    Useful tips
-    -----------
-
-    {% include "conf/events/job-fair-tips.rst" %}

--- a/docs/conf/portland/2023/job-fair.rst
+++ b/docs/conf/portland/2023/job-fair.rst
@@ -4,13 +4,12 @@ Sponsor Expo
 ============
 
 This year we're inviting our top sponsors to engage with our attendees at our Sponsor Expo.
-This is a combination of two primary events:
+This is a combination of two things:
 
-* Our job fair, where companies can talk with attendees who are interested in work
-* An area for product demos, for companies building products that our audience might use
+* A job fair, where companies can talk with attendees who are interested in work
+* Product demos, for companies building products that our audience might use
 
-We're excited to invite you to mingle with our top sponsors in this area,
-and learn more about what opportunities they have.
+We're looking forward to facilitating constructive networking, connecting people with jobs and employers, and hearing more from some of our sponsors. 
 
 Schedule
 --------

--- a/docs/conf/portland/2023/sponsor-expo.rst
+++ b/docs/conf/portland/2023/sponsor-expo.rst
@@ -1,0 +1,1 @@
+job-fair.rst

--- a/docs/conf/portland/2023/sponsors/prospectus.rst
+++ b/docs/conf/portland/2023/sponsors/prospectus.rst
@@ -66,7 +66,7 @@ The **Second Draft** package costs **{{sponsorship.second_draft.price}}**.
 Publisher
 ---------
 
-The **Publisher** package gets you a larger website presence and a visible on-site presence, either at the job fair or a sponsored workshop that you provide.
+The **Publisher** package gets you a larger website presence and a visible on-site presence at our Sponsor Expo.
 
 Benefits
 ~~~~~~~~
@@ -80,7 +80,7 @@ Benefits
 Hiring Package
 ~~~~~~~~~~~~~~
 
-- A table at our **job fair**
+- A table at our **sponsor expo**
 - Three (3) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
 
 Product Package
@@ -112,7 +112,7 @@ Benefits
 Hiring Package
 ~~~~~~~~~~~~~~
 
-- A table at our **job fair**
+- A table at our **sponsor expo**
 - Three (3) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
 
 Product Package
@@ -136,7 +136,7 @@ Benefits
 - Large logo included in intermission slides and on talk videos
 - A large logo and long description (750 characters) on the conference website
 - Name included in welcome announcement in email newsletters and social media
-- A table at our **job fair**
+- A table at our **sponsor expo**
 - Five (5) featured job postings on our Job Board, also promoted in our newsletter ({{ newsletter_subs }} subscribers)
 - A 1 hour **sponsored tutorial** at the conference
 - One product promotion highlight in our conference mailing list. Includes logo and 2 paragraphs of copy.
@@ -223,7 +223,7 @@ Sponsorship schedule
 
 * **MONDAY**: The conference venue is open all day, so we recommend arriving early to get the most interaction with attendees. The unconference is open all day, but generally attended more heavily in the afternoon. 
 
-* **TUESDAY**: The Sponsor Expo (job fair & product demos) will be on Tuesday morning in the sponsor area. We recommend arriving around 8:30am to set up your table if you're attending. The unconference will continue on Tuesday as well, and is well attended.
+* **TUESDAY**: The Sponsor Expo will be on Tuesday morning in the sponsor area. We recommend arriving around 8:30am to set up your table if you're attending. The unconference will continue on Tuesday as well, and is well attended.
 
 See the :doc:`full schedule </conf/{{ shortcode }}/{{ year }}/schedule>` for exact timing details.
 
@@ -233,14 +233,14 @@ Sponsorship spaces
 A quick overview of the spaces in the venue that are important:
 
 * The *main stage* is where talks happen.
-* The *stage hallway* is where registration, sponsor booths, and swag tables are set up. This is where the Sponsor Expo (job fair & product demos) will happen.
+* The *stage hallway* is where registration, sponsor booths, and swag tables are set up. This is where the Sponsor Expo will happen.
 * The *unconference room* is downstairs from the main stage. This is where unconference sessions will be happening.
 
 Sponsorship events
 ------------------
 
-Sponsor Expo (job fair & product demos)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Sponsor Expo
+~~~~~~~~~~~~
 
 On Tuesday morning we hold our Sponsor Expo,
 which is a wonderful place to connect with our attendees.

--- a/docs/conf/portland/2023/sponsors/prospectus.rst
+++ b/docs/conf/portland/2023/sponsors/prospectus.rst
@@ -251,7 +251,7 @@ so it's a great chance to talk more about your company culture and open position
 Similarly,
 they are always looking for great products to use in their day to day workflows.
 
-**Logistics**: You will be assigned a booth where you can engage with attendees and answer questions.  We recommend that you answer general questions in the main session and schedule follow up discussions with folks later in the day or after the conference if they have deeper interest. We recommend having handouts or a QR code for folks to learn more information.
+**Logistics**: You will be assigned a booth where you can engage with attendees and answer questions.  We recommend that you answer general questions in the main session and schedule follow up discussions with folks later in the day or after the conference if they have deeper interest. We recommend having handouts or a QR code where folks can learn more.
 
 Unconference
 ~~~~~~~~~~~~

--- a/docs/conf/portland/2023/sponsors/prospectus.rst
+++ b/docs/conf/portland/2023/sponsors/prospectus.rst
@@ -221,9 +221,9 @@ Sponsorship schedule
 
 * **SUNDAY**: The conference venue is open. You are welcome to attend the Writing Day, but no formal sponsorship events are happening. You're also encouraged to lead a Writing Day table if you have ways for our attendees to engage with your product or contribute to your documentation.
 
-* **MONDAY**: The conference venue is open all day, so we recommend arriving early to get the most interaction with attendees. The unconference is open all day, but generally attended more heavily in the afternoon.
+* **MONDAY**: The conference venue is open all day, so we recommend arriving early to get the most interaction with attendees. The unconference is open all day, but generally attended more heavily in the afternoon. 
 
-* **TUESDAY**: The Sponsor Expo (Job Fair & Product demos) will be on Tuesday morning in the sponsor area. We recommend arriving around 8:30am to set up your table if you're attending. The unconference will continue on Tuesday as well, and is well attended.
+* **TUESDAY**: The Sponsor Expo (job fair & product demos) will be on Tuesday morning in the sponsor area. We recommend arriving around 8:30am to set up your table if you're attending. The unconference will continue on Tuesday as well, and is well attended.
 
 See the :doc:`full schedule </conf/{{ shortcode }}/{{ year }}/schedule>` for exact timing details.
 
@@ -233,30 +233,25 @@ Sponsorship spaces
 A quick overview of the spaces in the venue that are important:
 
 * The *main stage* is where talks happen.
-* The *stage hallway* is where registration, sponsor booths, and swag tables are set up. This is where the Sponsor Expo (Job Fair & Product demos) will happen.
+* The *stage hallway* is where registration, sponsor booths, and swag tables are set up. This is where the Sponsor Expo (job fair & product demos) will happen.
 * The *unconference room* is downstairs from the main stage. This is where unconference sessions will be happening.
 
 Sponsorship events
 ------------------
 
-Sponsor booths
-~~~~~~~~~~~~~~
+Sponsor Expo (job fair & product demos)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Many sponsorships come with a booth at the conference. This will be an 8 foot table with 2 chairs, provided with power. You will be able to talk with attendees and show demos of your products in this space.
-
-**Logistics**: Booths are outside of the main conference venue, in the hallway. Setup timing will be coordinated with the sponsor coordinator.
-
-Job Fair
-~~~~~~~~
-
-On Tuesday morning we hold our Job Fair,
+On Tuesday morning we hold our Sponsor Expo,
 which is a wonderful place to connect with our attendees.
-This is included in Hiring sponsorship packages.
+This gives you a chance to discuss whatever you'd like to with our attendees.
 
-Many of them are looking for jobs now or will be in the near future,
+Many attendees are looking for jobs now or will be in the near future,
 so it's a great chance to talk more about your company culture and open positions.
+Similarly,
+they are always looking for great products to use in their day to day workflows.
 
-**Logistics**: You will be assigned a booth where you can engage with attendees and answer questions.  We recommend that you answer general questions in the main session and schedule follow up discussions with folks later in the day or after the conference if they have deeper interest. We recommend having handouts or a QR code that links to your open job postings.
+**Logistics**: You will be assigned a booth where you can engage with attendees and answer questions.  We recommend that you answer general questions in the main session and schedule follow up discussions with folks later in the day or after the conference if they have deeper interest. We recommend having handouts or a QR code for folks to learn more information.
 
 Unconference
 ~~~~~~~~~~~~
@@ -315,9 +310,10 @@ please ask us for this if you don't have it!
 They will be published in our :doc:`Newsletter </newsletter>` every month,
 and displayed on our website as well.
 
-What do I need for the job fair?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+What do I need for the Sponsor Expo?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The job fair will be a low key event. Generally we recommend having links available to your job descriptions, and ways for attendees to engage with you online after the event.
+The Sponsor Expo will be a low key event. Generally we recommend having links available to resources, and ways for attendees to engage with you online after the event.
+Also some fun swag is never a bad choice :)
 
 {% endif %}

--- a/docs/conf/portland/2023/sponsors/prospectus.rst
+++ b/docs/conf/portland/2023/sponsors/prospectus.rst
@@ -223,7 +223,7 @@ Sponsorship schedule
 
 * **MONDAY**: The conference venue is open all day, so we recommend arriving early to get the most interaction with attendees. The unconference is open all day, but generally attended more heavily in the afternoon.
 
-* **TUESDAY**: The Job Fair will be on Tuesday morning in the sponsor area. We recommend arriving around 8:30am to set up your table if you're attending. The unconference will continue on Tuesday as well, and is well attended.
+* **TUESDAY**: The Sponsor Expo (Job Fair & Product demos) will be on Tuesday morning in the sponsor area. We recommend arriving around 8:30am to set up your table if you're attending. The unconference will continue on Tuesday as well, and is well attended.
 
 See the :doc:`full schedule </conf/{{ shortcode }}/{{ year }}/schedule>` for exact timing details.
 
@@ -233,7 +233,7 @@ Sponsorship spaces
 A quick overview of the spaces in the venue that are important:
 
 * The *main stage* is where talks happen.
-* The *stage hallway* is where registration, sponsor booths, and swag tables are set up. This is where the Job Fair will happen.
+* The *stage hallway* is where registration, sponsor booths, and swag tables are set up. This is where the Sponsor Expo (Job Fair & Product demos) will happen.
 * The *unconference room* is downstairs from the main stage. This is where unconference sessions will be happening.
 
 Sponsorship events

--- a/docs/conf/portland/2023/welcome-wagon.rst
+++ b/docs/conf/portland/2023/welcome-wagon.rst
@@ -39,7 +39,7 @@ Where is everything?
 -  The Registration desk is on the first floor in the Library/Astoria Room on Sunday and on the second floor, outside of the main stage, on Monday and Tuesday.
 -  The conference main stage and lightning talks are in Revolution Hall on the second floor.
 -  The unconference takes place on the first floor in the Library/Astoria Room.
--  The Job Fair is on the first floor in the Library/Astoria Room.
+-  The Sponsor Expo is in the hallway outside of the main venue.
 -  Snacks and drinks are on the first floor in the Library/Astoria Room.
 -  The quiet room is on the second floor in the Sunset Room.
 
@@ -126,11 +126,11 @@ What are lightning talks, and should I give one?
 -  If you are interested in giving a lightning talk, be prepared! There is a great guide `here <https://www.writethedocs.org/conf/portland/2023/lightning-talks/?highlight=re>`__.
 
 
-How do I take part in the Job Fair?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+How do I take part in the Sponsor Expo?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
--  The Job Fair is on Tuesday morning in the Library/Astoria Room.
--  Companies with open jobs will have a staffed table.
+-  The Sponsor Expo is on Tuesday morning.
+-  Companies with will have a staffed table.
 -  Approach a table and introduce yourself! 
 
 
@@ -143,7 +143,7 @@ How do I make the most out of this conference?
 -  Speaking of breaks--conferences are exhilarating, but can also be exhausting. Give your brain a break! Grab a quiet spot in the Sunset Room or take a quick walk. Play a board game on your lunch break. Come back invigorated.
 -  Starting Monday morning, check the unconference schedule in the Library/Astoria Room to see if there are any sessions you are interested in attending. New sessions are added all the time, so check back periodically.
 -  Eat! You can use the energy. There will be snacks in the Library/Astoria Room.
--  Are you looking for a job or is there an opening at your company? Check out the job board and the job fair in the Library/Astoria Room.
+-  Are you looking for a job or is there an opening at your company? Check out the job board and the Sponsor Expo.
 
 
 Sample strategy for my first Write the Docs conference

--- a/docs/include/conf/schedule.rst
+++ b/docs/include/conf/schedule.rst
@@ -219,12 +219,13 @@ Talks are around 30 minutes, with moderated on-stage 10 minute Q&A.
 * **When**: **{{ date.day_four.talk_time }} {{ tz }}**
 {% endif %}
 * **Details**: :doc:`/conf/{{shortcode}}/{{year}}/speakers`
+
 {% if flaghasjobfair %}
 
-Job Fair
-~~~~~~~~
+Sponsor Expo
+~~~~~~~~~~~~
 
-The Job Fair is a great chance to talk with some of our sponsors who are hiring,
+The Sponsor Expo is a great chance to talk with some of our sponsors who are hiring,
 and get a sense of the job market.
 
 * **Where**: {{about.venue}}, {{about.job_fair_room }}


### PR DESCRIPTION
This is a new experiment this year,
and gives our product sponsors an area to setup.


<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1928.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->