### PR TITLE
Blank line before heading

### DIFF
--- a/docs/include/conf/portland/speaking-tips.rst
+++ b/docs/include/conf/portland/speaking-tips.rst
@@ -20,6 +20,7 @@ Venue specs
 ------------------
 
 The projector is 1920 x 1200 resolution at 60Hz via HDMI, DisplayPort or VGA
+
 Presentation format
 -------------------
 


### PR DESCRIPTION
Bug: 

![image](https://user-images.githubusercontent.com/95874/233113084-90aecc7c-8468-4c53-8652-c86ede8951d1.png)


<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1935.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->