### PR TITLE
Ticket sales and grants for Atlantic 2023

### DIFF
--- a/docs/_data/atlantic-2023-config.yaml
+++ b/docs/_data/atlantic-2023-config.yaml
@@ -27,12 +27,12 @@ buttons:
     #  link: /welcome-wagon
     #- text: See the Schedule!
     #  link: /schedule
-    #- text: Buy a Ticket!
-    #  link: /tickets
+    - text: Buy a Ticket!
+      link: /tickets
     - text: Sponsor us
       link: /sponsors/prospectus
-    - text: Submit a Talk
-      link: /cfp
+    #- text: Submit a Talk
+    #  link: /cfp
 #    - text: See the talks!
 #      link: /speakers
     #- text: See the Schedule!
@@ -67,11 +67,11 @@ buttons:
 
 tickets:
   concierge:
-    price: €250
+    price: €300
   corporate:
-    price: €150
+    price: €200
   independent:
-    price: €100
+    price: €125
   student:
     price: €25
 
@@ -89,7 +89,7 @@ sponsorship:
 date:
   main: "**September 10-12, 2023, online**"
   short: Sep 10-12, 2023
-  tickets_live: "April 2023"
+  tickets_live: "May 2023"
   month: September
   # Conference is special for the index to show the combined conference days
   conference:
@@ -171,10 +171,10 @@ sponsors:
 
 
 # Things that change over time, listed in order of change
-flagcfp: True
+flagcfp: False
 flaglanding: False
 flaghassponsors: False
-flagticketsonsale: False
+flagticketsonsale: True
 flagsoldout: False
 flagspeakersannounced: False
 flagrunofshow: False

--- a/docs/_data/atlantic-2023-config.yaml
+++ b/docs/_data/atlantic-2023-config.yaml
@@ -150,10 +150,10 @@ cfp:
   slides_by: "September 01, 2023"      # 2 weeks before the conf
   preview: "https://writethedocs-www--1777.org.readthedocs.build/conf/atlantic/2022/schedule/"
 
-#grants:
-#  url: https://docs.google.com/forms/d/e/1FAIpQLSf-kI51jdU9e85AV-ipQR3524IsKsFffSHQFgO-DupAAaqCPQ/viewform?usp=sf_link
-#  ends: "August 15, 2022"
-#  notification: "August 25, 2022"
+grants:
+  url: https://docs.google.com/forms/d/e/1FAIpQLSdHdUPNq949FGLws5JAMmhVNv48yKUVfnTqllKMpZSXS2Wuuw/viewform
+  ends: "August 15, 2022"
+  notification: "August 25, 2022"
 
 #unconf:
 #  url: https://bit.ly/wtd-prg-2022-ro

--- a/docs/conf/atlantic/2023/news/tickets-grants.rst
+++ b/docs/conf/atlantic/2023/news/tickets-grants.rst
@@ -9,7 +9,7 @@ Announcing Ticket Sales and Grant Program
 Greetings, documentarians! Today we're happy to announce that tickets for our {{name}} conference are `on sale now <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/>`_ and our `Opportunity Grant program <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/opportunity-grants/>`_ is open.
 
 Following the success of our previous virtual conferences, we look forward to our first Atlantic conference.
-The Call for Papers has closed and we're currently reviewing all proposals. We're looking forward to announcing
+The Call for Papers has closed and we're currently reviewing all proposals. We're planning to announce
 our speakers in the next few weeks.
 
 

--- a/docs/conf/atlantic/2023/news/tickets-grants.rst
+++ b/docs/conf/atlantic/2023/news/tickets-grants.rst
@@ -6,7 +6,7 @@
 Announcing Ticket Sales and Grant Program
 =========================================
 
-Greetings, documentarians! Today we're happy to announce that tickets are `on sale now <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/>`_ and our `Opportunity Grant program <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/opportunity-grants/>`_ is open.
+Greetings, documentarians! Today we're happy to announce that tickets for {{name}} conference are `on sale now <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/>`_ and our `Opportunity Grant program <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/opportunity-grants/>`_ is open.
 
 Following the success of our previous virtual conferences, we look forward to our first Atlantic conference.
 The Call for Papers has closed and we're currently reviewing all proposals. We're looking forward to announcing

--- a/docs/conf/atlantic/2023/news/tickets-grants.rst
+++ b/docs/conf/atlantic/2023/news/tickets-grants.rst
@@ -6,7 +6,7 @@
 Announcing Ticket Sales and Grant Program
 =========================================
 
-Greetings, documentarians! Today we're happy to announce that tickets for {{name}} conference are `on sale now <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/>`_ and our `Opportunity Grant program <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/opportunity-grants/>`_ is open.
+Greetings, documentarians! Today we're happy to announce that tickets for our {{name}} conference are `on sale now <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/>`_ and our `Opportunity Grant program <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/opportunity-grants/>`_ is open.
 
 Following the success of our previous virtual conferences, we look forward to our first Atlantic conference.
 The Call for Papers has closed and we're currently reviewing all proposals. We're looking forward to announcing

--- a/docs/conf/atlantic/2023/news/tickets-grants.rst
+++ b/docs/conf/atlantic/2023/news/tickets-grants.rst
@@ -1,0 +1,62 @@
+:template: {{year}}/generic.html
+
+.. post:: May 1st, 2023
+   :tags: {{shortcode}}-{{year}}, website, tickets
+
+Announcing Ticket Sales and Grant Program
+=========================================
+
+Greetings, documentarians! Today we're happy to announce that tickets are `on sale now <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/>`_ and our `Opportunity Grant program <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/opportunity-grants/>`_ is open.
+
+Following the success of our previous virtual conferences, we look forward to our first Atlantic conference.
+The Call for Papers has closed and we're currently reviewing all proposals. We're looking forward to announcing
+our speakers soon.
+
+
+Get your ticket for the conference
+----------------------------------
+
+**The {{shortcode}} conference will be held online on {{ date.short }}.** The `full event website <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/>`_ is live, with most details, and we'll be filling in more as it gets closer.
+
+Tickets are on sale now, so go ahead and `register for your ticket now <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/>`_! Even though our capacity is more flexible due to the virtual event platform, we might still sell out to make sure we're providing a manageable event size for our attendees, as always.
+
+We're going to keep the spirit of our previous virtual conferences for Prague and Portland:
+
+* Excellent single track of pre-recorded presentations with live moderated Q&A
+* Writing Day sessions
+* Unconference sessions
+* A virtual hallway track
+
+We really want to make sure that folks can get value from being at the event at the same time, and we think it will be another great year of helping our community connect.
+
+
+Grant program
+-------------
+
+We updated our grant program application to take into account the virtual format of the event.
+We're excited to be able to offer free tickets to a larger number of people, since there are now minimal other costs to attend the event.
+
+You can apply by **{{ grants.ends }}** on `our website <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/opportunity-grants/>`_.
+
+
+Support our community by sponsoring
+-----------------------------------
+
+Every year we are fortunate to have the support of like-minded organizations and communities, who believe in the collaborative and welcoming community spirit and help us make our events great.
+
+We have published our `virtual sponsorship prospectus`_ for the conference,
+and are open for new sponsorship inquiries.
+
+.. _virtual sponsorship prospectus: https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/sponsors/prospectus/
+
+We will still run the `job fair <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/job-fair/>`_, helping documentarians and organizations connect with each other. Check out the sponsorship prospectus for more details and to reserve your spot today.
+
+Thanks so much to the following companies for supporting the {{shortcode}} conference this year:
+
+.. datatemplate::
+   :source: /_data/{{shortcode}}-{{year}}-config.yaml
+   :template: {{year}}/sponsors-simplelist.rst
+
+Looking forward to seeing you all in our virtual space!
+
+The Write the Docs Team

--- a/docs/conf/atlantic/2023/news/tickets-grants.rst
+++ b/docs/conf/atlantic/2023/news/tickets-grants.rst
@@ -16,7 +16,7 @@ our speakers soon.
 Get your ticket for the conference
 ----------------------------------
 
-**The {{shortcode}} conference will be held online on {{ date.short }}.** The `full event website <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/>`_ is live, with most details, and we'll be filling in more as it gets closer.
+**The {{name}} conference will be held online on {{ date.short }}.** The `full event website <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/>`_ is live, with most details, and we'll be filling in more as it gets closer.
 
 Tickets are on sale now, so go ahead and `register for your ticket now <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/>`_! Even though our capacity is more flexible due to the virtual event platform, we might still sell out to make sure we're providing a manageable event size for our attendees, as always.
 
@@ -33,10 +33,10 @@ We really want to make sure that folks can get value from being at the event at 
 Grant program
 -------------
 
-We updated our grant program application to take into account the virtual format of the event.
-We're excited to be able to offer free tickets to a larger number of people, since there are now minimal other costs to attend the event.
+If the cost of our tickets is prohibitive to you, you can apply to our Opportunity Grant program.
+As a virtual event, we're excited to be able to offer free tickets to a larger number of people, since there are now minimal other costs to attend the event.
 
-You can apply by **{{ grants.ends }}** on `our website <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/opportunity-grants/>`_.
+You can apply until **{{ grants.ends }}** on `our website <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/opportunity-grants/>`_.
 
 
 Support our community by sponsoring
@@ -50,12 +50,6 @@ and are open for new sponsorship inquiries.
 .. _virtual sponsorship prospectus: https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/sponsors/prospectus/
 
 We will still run the `job fair <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/job-fair/>`_, helping documentarians and organizations connect with each other. Check out the sponsorship prospectus for more details and to reserve your spot today.
-
-Thanks so much to the following companies for supporting the {{shortcode}} conference this year:
-
-.. datatemplate::
-   :source: /_data/{{shortcode}}-{{year}}-config.yaml
-   :template: {{year}}/sponsors-simplelist.rst
 
 Looking forward to seeing you all in our virtual space!
 

--- a/docs/conf/atlantic/2023/news/tickets-grants.rst
+++ b/docs/conf/atlantic/2023/news/tickets-grants.rst
@@ -1,6 +1,6 @@
 :template: {{year}}/generic.html
 
-.. post:: May 1st, 2023
+.. post:: May 23rd, 2023
    :tags: {{shortcode}}-{{year}}, website, tickets
 
 Announcing Ticket Sales and Grant Program
@@ -10,13 +10,16 @@ Greetings, documentarians! Today we're happy to announce that tickets for {{name
 
 Following the success of our previous virtual conferences, we look forward to our first Atlantic conference.
 The Call for Papers has closed and we're currently reviewing all proposals. We're looking forward to announcing
-our speakers soon.
+our speakers in the next few weeks.
 
 
 Get your ticket for the conference
 ----------------------------------
 
 **The {{name}} conference will be held online on {{ date.short }}.** The `full event website <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/>`_ is live, with most details, and we'll be filling in more as it gets closer.
+The schedule will run from the
+early afternoon to early evening in most European/African timezones,
+and from early morning to late afternoon in US East Coast/South America timezones.
 
 Tickets are on sale now, so go ahead and `register for your ticket now <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/>`_! Even though our capacity is more flexible due to the virtual event platform, we might still sell out to make sure we're providing a manageable event size for our attendees, as always.
 


### PR DESCRIPTION
- [x] Finalise blog post
- [x] Tito to live
- [x] Actually set up grant program
- [x] Update blog post date
- [x] ~~Figure out which mailing lists this go to and Eric to make that happen~~ This one Atlantic only, as talks are announced quite soon and we should do that wider.

Blog post: https://writethedocs-www--1964.org.readthedocs.build/conf/atlantic/2023/news/tickets-grants/
Note that links in the blog post link to the live website and may therefore still be outdated.

<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1964.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->