### PR TITLE
Fix missing line breaks in lists on the "Opportunity grants" pages

### DIFF
--- a/docs/conf/atlantic/2023/opportunity-grants.rst
+++ b/docs/conf/atlantic/2023/opportunity-grants.rst
@@ -49,10 +49,12 @@ These groups include, but are not limited to:
 * people of color
 * sexuality minorities, including asexual people
 * people with disabilities, both visible and invisible
-* neurodivergent people* people with chronic illnesses or diseases
+* neurodivergent people
+* people with chronic illnesses or diseases
 * religious and ethnic minorities
 * age minorities (under ~21, over ~50)
-* people experiencing poverty* homeless and home/food insecure people
+* people experiencing poverty
+* homeless and home/food insecure people
 * caregivers of children or other dependents
 * people who have experienced trauma and its aftermath (PTSD, anxiety, etc)
 * people living with or recovering from substance abuse

--- a/docs/conf/australia/2020/opportunity-grants.rst
+++ b/docs/conf/australia/2020/opportunity-grants.rst
@@ -39,10 +39,12 @@ This includes, but is not limited to:
 * people of color
 * sexuality minorities, including asexual people
 * people with disabilities, both visible and invisible
-* neurodivergent people* people with chronic illnesses or diseases
+* neurodivergent people
+* people with chronic illnesses or diseases
 * religious and ethnic minorities
 * age minorities (under ~21, over ~50)
-* people experiencing poverty* homeless and home/food insecure people
+* people experiencing poverty
+* homeless and home/food insecure people
 * caregivers of children or other dependents
 * people who have experienced trauma and its aftermath (PTSD, anxiety, etc)
 * people living with or recovering from substance abuse

--- a/docs/conf/australia/2021/opportunity-grants.rst
+++ b/docs/conf/australia/2021/opportunity-grants.rst
@@ -49,10 +49,12 @@ These groups include, but are not limited to:
 * people of color
 * sexuality minorities, including asexual people
 * people with disabilities, both visible and invisible
-* neurodivergent people* people with chronic illnesses or diseases
+* neurodivergent people
+* people with chronic illnesses or diseases
 * religious and ethnic minorities
 * age minorities (under ~21, over ~50)
-* people experiencing poverty* homeless and home/food insecure people
+* people experiencing poverty
+* homeless and home/food insecure people
 * caregivers of children or other dependents
 * people who have experienced trauma and its aftermath (PTSD, anxiety, etc)
 * people living with or recovering from substance abuse

--- a/docs/conf/australia/2022/opportunity-grants.rst
+++ b/docs/conf/australia/2022/opportunity-grants.rst
@@ -49,10 +49,12 @@ These groups include, but are not limited to:
 * people of color
 * sexuality minorities, including asexual people
 * people with disabilities, both visible and invisible
-* neurodivergent people* people with chronic illnesses or diseases
+* neurodivergent people
+* people with chronic illnesses or diseases
 * religious and ethnic minorities
 * age minorities (under ~21, over ~50)
-* people experiencing poverty* homeless and home/food insecure people
+* people experiencing poverty
+* homeless and home/food insecure people
 * caregivers of children or other dependents
 * people who have experienced trauma and its aftermath (PTSD, anxiety, etc)
 * people living with or recovering from substance abuse

--- a/docs/conf/australia/2023/opportunity-grants.rst
+++ b/docs/conf/australia/2023/opportunity-grants.rst
@@ -49,10 +49,12 @@ These groups include, but are not limited to:
 * people of color
 * sexuality minorities, including asexual people
 * people with disabilities, both visible and invisible
-* neurodivergent people* people with chronic illnesses or diseases
+* neurodivergent people
+* people with chronic illnesses or diseases
 * religious and ethnic minorities
 * age minorities (under ~21, over ~50)
-* people experiencing poverty* homeless and home/food insecure people
+* people experiencing poverty
+* homeless and home/food insecure people
 * caregivers of children or other dependents
 * people who have experienced trauma and its aftermath (PTSD, anxiety, etc)
 * people living with or recovering from substance abuse

--- a/docs/conf/portland/2020/opportunity-grants.rst
+++ b/docs/conf/portland/2020/opportunity-grants.rst
@@ -32,10 +32,12 @@ This includes, but is not limited to:
 * people of color
 * sexuality minorities, including asexual people
 * people with disabilities, both visible and invisible
-* neurodivergent people* people with chronic illnesses or diseases
+* neurodivergent people
+* people with chronic illnesses or diseases
 * religious and ethnic minorities
 * age minorities (under ~21, over ~50)
-* people experiencing poverty* homeless and home/food insecure people
+* people experiencing poverty
+* homeless and home/food insecure people
 * caregivers of children or other dependents
 * people who have experienced trauma and its aftermath (PTSD, anxiety, etc)
 * people living with or recovering from substance abuse

--- a/docs/conf/portland/2021/opportunity-grants.rst
+++ b/docs/conf/portland/2021/opportunity-grants.rst
@@ -49,10 +49,12 @@ These groups include, but are not limited to:
 * people of color
 * sexuality minorities, including asexual people
 * people with disabilities, both visible and invisible
-* neurodivergent people* people with chronic illnesses or diseases
+* neurodivergent people
+* people with chronic illnesses or diseases
 * religious and ethnic minorities
 * age minorities (under ~21, over ~50)
-* people experiencing poverty* homeless and home/food insecure people
+* people experiencing poverty
+* homeless and home/food insecure people
 * caregivers of children or other dependents
 * people who have experienced trauma and its aftermath (PTSD, anxiety, etc)
 * people living with or recovering from substance abuse

--- a/docs/conf/portland/2022/opportunity-grants.rst
+++ b/docs/conf/portland/2022/opportunity-grants.rst
@@ -49,10 +49,12 @@ These groups include, but are not limited to:
 * people of color
 * sexuality minorities, including asexual people
 * people with disabilities, both visible and invisible
-* neurodivergent people* people with chronic illnesses or diseases
+* neurodivergent people
+* people with chronic illnesses or diseases
 * religious and ethnic minorities
 * age minorities (under ~21, over ~50)
-* people experiencing poverty* homeless and home/food insecure people
+* people experiencing poverty
+* homeless and home/food insecure people
 * caregivers of children or other dependents
 * people who have experienced trauma and its aftermath (PTSD, anxiety, etc)
 * people living with or recovering from substance abuse

--- a/docs/conf/portland/2023/opportunity-grants.rst
+++ b/docs/conf/portland/2023/opportunity-grants.rst
@@ -59,10 +59,12 @@ These groups include, but are not limited to:
 * people of color
 * sexuality minorities, including asexual people
 * people with disabilities, both visible and invisible
-* neurodivergent people* people with chronic illnesses or diseases
+* neurodivergent people
+* people with chronic illnesses or diseases
 * religious and ethnic minorities
 * age minorities (under ~21, over ~50)
-* people experiencing poverty* homeless and home/food insecure people
+* people experiencing poverty
+* homeless and home/food insecure people
 * caregivers of children or other dependents
 * people who have experienced trauma and its aftermath (PTSD, anxiety, etc)
 * people living with or recovering from substance abuse

--- a/docs/conf/prague/2020/opportunity-grants.rst
+++ b/docs/conf/prague/2020/opportunity-grants.rst
@@ -39,10 +39,12 @@ This includes, but is not limited to:
 * people of color
 * sexuality minorities, including asexual people
 * people with disabilities, both visible and invisible
-* neurodivergent people* people with chronic illnesses or diseases
+* neurodivergent people
+* people with chronic illnesses or diseases
 * religious and ethnic minorities
 * age minorities (under ~21, over ~50)
-* people experiencing poverty* homeless and home/food insecure people
+* people experiencing poverty
+* homeless and home/food insecure people
 * caregivers of children or other dependents
 * people who have experienced trauma and its aftermath (PTSD, anxiety, etc)
 * people living with or recovering from substance abuse

--- a/docs/conf/prague/2021/opportunity-grants.rst
+++ b/docs/conf/prague/2021/opportunity-grants.rst
@@ -49,10 +49,12 @@ These groups include, but are not limited to:
 * people of color
 * sexuality minorities, including asexual people
 * people with disabilities, both visible and invisible
-* neurodivergent people* people with chronic illnesses or diseases
+* neurodivergent people
+* people with chronic illnesses or diseases
 * religious and ethnic minorities
 * age minorities (under ~21, over ~50)
-* people experiencing poverty* homeless and home/food insecure people
+* people experiencing poverty
+* homeless and home/food insecure people
 * caregivers of children or other dependents
 * people who have experienced trauma and its aftermath (PTSD, anxiety, etc)
 * people living with or recovering from substance abuse

--- a/docs/conf/prague/2022/opportunity-grants.rst
+++ b/docs/conf/prague/2022/opportunity-grants.rst
@@ -49,10 +49,12 @@ These groups include, but are not limited to:
 * people of color
 * sexuality minorities, including asexual people
 * people with disabilities, both visible and invisible
-* neurodivergent people* people with chronic illnesses or diseases
+* neurodivergent people
+* people with chronic illnesses or diseases
 * religious and ethnic minorities
 * age minorities (under ~21, over ~50)
-* people experiencing poverty* homeless and home/food insecure people
+* people experiencing poverty
+* homeless and home/food insecure people
 * caregivers of children or other dependents
 * people who have experienced trauma and its aftermath (PTSD, anxiety, etc)
 * people living with or recovering from substance abuse


### PR DESCRIPTION
https://www.writethedocs.org/conf/atlantic/2023/opportunity-grants/#are-you-part-of-a-marginalized-or-underrepresented-group-in-tech

I guess these `*` in the middle of list items are supposed to be separate items:

![](https://github.com/writethedocs/www/assets/8576823/5d80e621-5daa-445b-a7ee-5d8642ee318b)

I changed all copies of the "Opportunity grants" page (including past conferences, just in case) so that future copies won't have this typo.

<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1966.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->