### PR TITLE
Fix atlantic news post

### DIFF
--- a/docs/conf/atlantic/2023/news/announcing-speakers.rst
+++ b/docs/conf/atlantic/2023/news/announcing-speakers.rst
@@ -6,7 +6,7 @@
 Announcing speakers and talks
 =============================
 
-Greetings, documentarians! Today we're excited to announce that we've finalized our speakers for the our first virtual {{City}} conference!
+Greetings, documentarians! Today we're excited to announce that we've finalized our speakers for the our first virtual {{city}} conference!
 
 Thank you so much to everyone who took the time to send us a proposal – we literally wouldn't have an event without you!
 


### PR DESCRIPTION
As `City` does not exist, this now says "speakers for our first virtual conference"


<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1972.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->