### PR TITLE
Fix #1973 - Change speaker simple list to use speaker+talk slug

### DIFF
--- a/docs/_templates/2021/speakers.rst
+++ b/docs/_templates/2021/speakers.rst
@@ -1,7 +1,7 @@
 {% for talk in data %}
 
 {% for speaker in talk.speakers %}
-.. _speaker-{{ speaker.slug }}:
+.. _speaker-{{ speaker.slug }}-{{ talk.slug }}:
 {% endfor %}
 
 .. Comment to break up reference issues

--- a/docs/_templates/2022/speakers.rst
+++ b/docs/_templates/2022/speakers.rst
@@ -1,7 +1,7 @@
 {% for talk in data %}
 
 {% for speaker in talk.speakers %}
-.. _speaker-{{ speaker.slug }}:
+.. _speaker-{{ speaker.slug }}-{{ talk.slug }}:
 {% endfor %}
 
 .. Comment to break up reference issues

--- a/docs/_templates/2023/speakers-simple-list.rst
+++ b/docs/_templates/2023/speakers-simple-list.rst
@@ -2,6 +2,6 @@
 
 .. Comment to break up reference issues
 
-* {% for speaker in talk.speakers %} :ref:`{{ speaker.name }} <speaker-{{ speaker.slug }}>`{{ ", " if not loop.last }}{% endfor %}: {{ talk.title }}
+* {% for speaker in talk.speakers %} :ref:`{{ speaker.name }} <speaker-{{ speaker.slug }}-{{ talk.slug }}>`{{ ", " if not loop.last }}{% endfor %}: {{ talk.title }}
 
 {%- endfor -%}

--- a/docs/_templates/2023/speakers.rst
+++ b/docs/_templates/2023/speakers.rst
@@ -2,7 +2,7 @@
 
 {# Make speakers linkable from announcements and other places #}
 {% for speaker in talk.speakers %}
-.. _speaker-{{ speaker.slug }}:
+.. _speaker-{{ speaker.slug }}-{{ talk.slug }}:
 {% endfor %}
 
 .. Comment to break up reference issues

--- a/docs/_templates/include/schedule2021.rst
+++ b/docs/_templates/include/schedule2021.rst
@@ -11,7 +11,7 @@
                   {% if session.title %}
                       {{ session.title }}
                   {% elif session.data %}
-                     <a href="../speakers/#speaker-{{ session.data.speakers.0.slug }}">{{ session.speaker_names }} - {{ session.data.title }}</a>
+                     <a href="../speakers/#speaker-{{ session.data.speakers.0.slug }}-{{ session.data.slug }}">{{ session.speaker_names }} - {{ session.data.title }}</a>
                   {% else %}
                      ERROR: {{ session }}
                   {% endif %}


### PR DESCRIPTION
This may have broken in the past too. Can't fix the mailing we sent out unfortunately.