### PR TITLE
Improve accessibility

### DIFF
--- a/docs/_static/conf-legacy/2017/icomoon/demo.html
+++ b/docs/_static/conf-legacy/2017/icomoon/demo.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
     <meta charset="utf-8">
     <title>IcoMoon Demo</title>

--- a/docs/_templates/2018/base.html
+++ b/docs/_templates/2018/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/docs/_templates/2018/base.html
+++ b/docs/_templates/2018/base.html
@@ -145,16 +145,16 @@
 
                     <div class="footer-icon-list">
                         <a href="https://github.com/writethedocs">
-                            <img src="{{ pathto('_static/conf/images/icons/github-footer-green.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/github-footer-green.svg', 1) }}" alt="GitHub">
                         </a>
                         <a href="https://twitter.com/writethedocs">
-                            <img src="{{ pathto('_static/conf/images/icons/twitter-footer-green.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/twitter-footer-green.svg', 1) }}" alt="Twitter">
                         </a>
                         <a href="https://www.flickr.com/photos/writethedocs/">
-                            <img src="{{ pathto('_static/conf/images/icons/flickr-green.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/flickr-green.svg', 1) }}" alt="Flickr">
                         </a>
                         <a href="https://writethedocs.slack.com">
-                            <img src="{{ pathto('_static/conf/images/icons/slack-green.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/slack-green.svg', 1) }}" alt="Slack">
                         </a>
                     </div><!-- end footer icons list of  links -->
                 </div> <!-- end of footer social section -->

--- a/docs/_templates/2018/base.html
+++ b/docs/_templates/2018/base.html
@@ -170,16 +170,16 @@
             </div><!-- end of footer content  -->
             <div class="footer-pics">
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-01.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-01.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-02.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-02.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-04.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-04.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-03.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-03.jpg', 1) }}" alt="" >
                 </div>
             </div>
         </div>

--- a/docs/_templates/2018/base.html
+++ b/docs/_templates/2018/base.html
@@ -201,7 +201,7 @@
         </script>
 
         <!-- UIkit JS -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-beta.25/js/uikit.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-beta.25/js/uikit-icons.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.16.22/js/uikit.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.16.22/js/uikit-icons.min.js"></script>
     </body>
 </html>

--- a/docs/_templates/2018/base.html
+++ b/docs/_templates/2018/base.html
@@ -13,8 +13,6 @@
         <meta name="author" content="Write the Docs">
         <meta name="ROBOTS" content="ALL">
 
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
         <!-- Open Graph protocol -->
         <meta property="og:type" content="conference">
         <meta property="og:url" content="http://www.writethedocs.org">

--- a/docs/_templates/2018/index.html
+++ b/docs/_templates/2018/index.html
@@ -156,13 +156,13 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       <div class="picture-set">
         <div data-aos="pictrue-03" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-03.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-03.jpg', 1)  }}" alt="" >
         </div>
         <div data-aos="pictrue-02" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-02.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-02.jpg', 1)  }}" alt="" >
         </div>
         <div data-aos="pictrue-01" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-01.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-01.jpg', 1)  }}" alt="" >
         </div>
       </div>
     </div>

--- a/docs/_templates/2019/base.html
+++ b/docs/_templates/2019/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/docs/_templates/2019/base.html
+++ b/docs/_templates/2019/base.html
@@ -170,7 +170,7 @@
         </script>
 
         <!-- UIkit JS -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-beta.25/js/uikit.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-beta.25/js/uikit-icons.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.16.22/js/uikit.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.16.22/js/uikit-icons.min.js"></script>
     </body>
 </html>

--- a/docs/_templates/2019/base.html
+++ b/docs/_templates/2019/base.html
@@ -13,8 +13,6 @@
         <meta name="author" content="Write the Docs">
         <meta name="ROBOTS" content="ALL">
 
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
         <!-- Open Graph protocol -->
         <meta property="og:type" content="conference">
         <meta property="og:url" content="http://www.writethedocs.org">

--- a/docs/_templates/2019/base.html
+++ b/docs/_templates/2019/base.html
@@ -139,16 +139,16 @@
             </div><!-- end of footer content  -->
             <div class="footer-pics">
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-01.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-01.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-02.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-02.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-04.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-04.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-03.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-03.jpg', 1) }}" alt="" >
                 </div>
             </div>
         </div>

--- a/docs/_templates/2019/base.html
+++ b/docs/_templates/2019/base.html
@@ -114,16 +114,16 @@
 
                     <div class="footer-icon-list">
                         <a href="https://github.com/writethedocs">
-                            <img src="{{ pathto('_static/conf/images/icons/github-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/github-footer-white.svg', 1) }}" alt="GitHub">
                         </a>
                         <a href="https://twitter.com/writethedocs">
-                            <img src="{{ pathto('_static/conf/images/icons/twitter-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/twitter-footer-white.svg', 1) }}" alt="Twitter">
                         </a>
                         <a href="https://www.flickr.com/photos/writethedocs/">
-                            <img src="{{ pathto('_static/conf/images/icons/flickr-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/flickr-footer-white.svg', 1) }}" alt="Flickr">
                         </a>
                         <a href="https://www.writethedocs.org/slack/">
-                            <img src="{{ pathto('_static/conf/images/icons/slack-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/slack-footer-white.svg', 1) }}" alt="Slack">
                         </a>
                     </div><!-- end footer icons list of  links -->
                 </div> <!-- end of footer social section -->

--- a/docs/_templates/2019/index.html
+++ b/docs/_templates/2019/index.html
@@ -133,13 +133,13 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       <div class="picture-set">
         <div data-aos="pictrue-03" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-03.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-03.jpg', 1)  }}" alt="" >
         </div>
         <div data-aos="pictrue-02" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-02.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-02.jpg', 1)  }}" alt="" >
         </div>
         <div data-aos="pictrue-01" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-01.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-01.jpg', 1)  }}" alt="" >
         </div>
       </div>
     </div>
@@ -149,7 +149,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
     <div class="uk-container" uk-grid>
       <h2>Schedule Overview</h2>
       <div class="schedule-item uk-width-1-3@s">
-        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_one.icon + '-' + color +  '.svg', 1) }}">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_one.icon + '-' + color +  '.svg', 1) }}" alt="">
         <h3>{{ date.day_one.event }} </h3>
         <em>{{ date.day_one.date }} </em>
         <p>{{ date.day_one.summary }} </p>
@@ -157,7 +157,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       {% if date.day_two is defined %}
       <div class="schedule-item uk-width-1-3@s">
-        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_two.icon + '-' + color +  '.svg', 1) }}">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_two.icon + '-' + color +  '.svg', 1) }}" alt="">
         <h3>{{ date.day_two.event }} </h3>
         <em>{{ date.day_two.date }} </em>
         <p>{{ date.day_two.summary }} </p>
@@ -166,7 +166,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       {% if date.day_three is defined %}
       <div class="schedule-item uk-width-1-3@s">
-        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_three.icon + '-' + color +  '.svg', 1) }}">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_three.icon + '-' + color +  '.svg', 1) }}" alt="">
         <h3>{{ date.day_three.event }} </h3>
         <em>{{ date.day_three.date }} </em>
         <p>{{ date.day_three.summary }} </p>

--- a/docs/_templates/2020/base.html
+++ b/docs/_templates/2020/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/docs/_templates/2020/base.html
+++ b/docs/_templates/2020/base.html
@@ -170,7 +170,7 @@
         </script>
 
         <!-- UIkit JS -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-beta.25/js/uikit.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-beta.25/js/uikit-icons.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.16.22/js/uikit.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.16.22/js/uikit-icons.min.js"></script>
     </body>
 </html>

--- a/docs/_templates/2020/base.html
+++ b/docs/_templates/2020/base.html
@@ -13,8 +13,6 @@
         <meta name="author" content="Write the Docs">
         <meta name="ROBOTS" content="ALL">
 
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
         <!-- Open Graph protocol -->
         <meta property="og:type" content="conference">
         <meta property="og:url" content="http://www.writethedocs.org">

--- a/docs/_templates/2020/base.html
+++ b/docs/_templates/2020/base.html
@@ -139,16 +139,16 @@
             </div><!-- end of footer content  -->
             <div class="footer-pics">
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-01.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-01.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-02.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-02.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-04.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-04.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-03.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-03.jpg', 1) }}" alt="" >
                 </div>
             </div>
         </div>

--- a/docs/_templates/2020/base.html
+++ b/docs/_templates/2020/base.html
@@ -114,16 +114,16 @@
 
                     <div class="footer-icon-list">
                         <a href="https://github.com/writethedocs">
-                            <img src="{{ pathto('_static/conf/images/icons/github-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/github-footer-white.svg', 1) }}" alt="GitHub">
                         </a>
                         <a href="https://twitter.com/writethedocs">
-                            <img src="{{ pathto('_static/conf/images/icons/twitter-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/twitter-footer-white.svg', 1) }}" alt="Twitter">
                         </a>
                         <a href="https://www.flickr.com/photos/writethedocs/">
-                            <img src="{{ pathto('_static/conf/images/icons/flickr-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/flickr-footer-white.svg', 1) }}" alt="Flickr">
                         </a>
                         <a href="https://www.writethedocs.org/slack/">
-                            <img src="{{ pathto('_static/conf/images/icons/slack-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/slack-footer-white.svg', 1) }}" alt="Slack">
                         </a>
                     </div><!-- end footer icons list of  links -->
                 </div> <!-- end of footer social section -->

--- a/docs/_templates/2020/index.html
+++ b/docs/_templates/2020/index.html
@@ -134,13 +134,13 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       <div class="picture-set">
         <div data-aos="pictrue-03" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-03.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-03.jpg', 1)  }}" alt="" >
         </div>
         <div data-aos="pictrue-02" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-02.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-02.jpg', 1)  }}" alt="" >
         </div>
         <div data-aos="pictrue-01" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-01.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-01.jpg', 1)  }}" alt="" >
         </div>
       </div>
     </div>
@@ -150,7 +150,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
     <div class="uk-container" uk-grid>
       <h2>Schedule Overview</h2>
       <div class="schedule-item uk-width-1-3@s">
-        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_one.icon + '-' + color +  '.svg', 1) }}">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_one.icon + '-' + color +  '.svg', 1) }}" alt="">
         <h3>{{ date.day_one.event }} </h3>
         <em>{{ date.day_one.date }} </em>
         <p>{{ date.day_one.summary }} </p>
@@ -158,7 +158,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       {% if date.day_two is defined %}
       <div class="schedule-item uk-width-1-3@s">
-        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_two.icon + '-' + color +  '.svg', 1) }}">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_two.icon + '-' + color +  '.svg', 1) }}" alt="">
         <h3>{{ date.day_two.event }} </h3>
         <em>{{ date.day_two.date }} </em>
         <p>{{ date.day_two.summary }} </p>
@@ -167,7 +167,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       {% if date.day_three is defined %}
       <div class="schedule-item uk-width-1-3@s">
-        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_three.icon + '-' + color +  '.svg', 1) }}">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_three.icon + '-' + color +  '.svg', 1) }}" alt="">
         <h3>{{ date.day_three.event }} </h3>
         <em>{{ date.day_three.date }} </em>
         <p>{{ date.day_three.summary }} </p>

--- a/docs/_templates/2021/base.html
+++ b/docs/_templates/2021/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/docs/_templates/2021/base.html
+++ b/docs/_templates/2021/base.html
@@ -170,7 +170,7 @@
         </script>
 
         <!-- UIkit JS -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-beta.25/js/uikit.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-beta.25/js/uikit-icons.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.16.22/js/uikit.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.16.22/js/uikit-icons.min.js"></script>
     </body>
 </html>

--- a/docs/_templates/2021/base.html
+++ b/docs/_templates/2021/base.html
@@ -13,8 +13,6 @@
         <meta name="author" content="Write the Docs">
         <meta name="ROBOTS" content="ALL">
 
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
         <!-- Open Graph protocol -->
         <meta property="og:type" content="conference">
         <meta property="og:url" content="http://www.writethedocs.org">

--- a/docs/_templates/2021/base.html
+++ b/docs/_templates/2021/base.html
@@ -139,16 +139,16 @@
             </div><!-- end of footer content  -->
             <div class="footer-pics">
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-01.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-01.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-02.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-02.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-04.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-04.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-03.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-03.jpg', 1) }}" alt="" >
                 </div>
             </div>
         </div>

--- a/docs/_templates/2021/base.html
+++ b/docs/_templates/2021/base.html
@@ -114,16 +114,16 @@
 
                     <div class="footer-icon-list">
                         <a href="https://github.com/writethedocs">
-                            <img src="{{ pathto('_static/conf/images/icons/github-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/github-footer-white.svg', 1) }}" alt="GitHub">
                         </a>
                         <a href="https://twitter.com/writethedocs">
-                            <img src="{{ pathto('_static/conf/images/icons/twitter-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/twitter-footer-white.svg', 1) }}" alt="Twitter">
                         </a>
                         <a href="https://www.flickr.com/photos/writethedocs/">
-                            <img src="{{ pathto('_static/conf/images/icons/flickr-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/flickr-footer-white.svg', 1) }}" alt="Flickr">
                         </a>
                         <a href="https://www.writethedocs.org/slack/">
-                            <img src="{{ pathto('_static/conf/images/icons/slack-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/slack-footer-white.svg', 1) }}" alt="Slack">
                         </a>
                     </div><!-- end footer icons list of  links -->
                 </div> <!-- end of footer social section -->

--- a/docs/_templates/2021/index.html
+++ b/docs/_templates/2021/index.html
@@ -147,13 +147,13 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       <div class="picture-set">
         <div data-aos="pictrue-03" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-03.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-03.jpg', 1)  }}" alt="" >
         </div>
         <div data-aos="pictrue-02" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-02.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-02.jpg', 1)  }}" alt="" >
         </div>
         <div data-aos="pictrue-01" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-01.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-01.jpg', 1)  }}" alt="" >
         </div>
       </div>
     </div>
@@ -163,7 +163,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
     <div class="uk-container" uk-grid>
       <h2>Schedule Overview</h2>
       <div class="schedule-item uk-width-1-3@s">
-        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_one.icon + '-' + color +  '.svg', 1) }}">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_one.icon + '-' + color +  '.svg', 1) }}" alt="">
         <h3>{{ date.day_one.event }} </h3>
         <em>{{ date.day_one.date }} </em>
         <p>{{ date.day_one.summary }} </p>
@@ -171,7 +171,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       {% if date.day_two is defined %}
       <div class="schedule-item uk-width-1-3@s">
-        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_two.icon + '-' + color +  '.svg', 1) }}">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_two.icon + '-' + color +  '.svg', 1) }}" alt="">
         <h3>{{ date.day_two.event }} </h3>
         <em>{{ date.day_two.date }} </em>
         <p>{{ date.day_two.summary }} </p>
@@ -180,7 +180,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       {% if date.conference is defined %}
       <div class="schedule-item uk-width-1-3@s">
-        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.conference.icon + '-' + color +  '.svg', 1) }}">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.conference.icon + '-' + color +  '.svg', 1) }}" alt="" >
         <h3>{{ date.conference.event }} </h3>
         <em>{{ date.conference.date }} </em>
         <p>{{ date.conference.summary }} </p>

--- a/docs/_templates/2022/base.html
+++ b/docs/_templates/2022/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/docs/_templates/2022/base.html
+++ b/docs/_templates/2022/base.html
@@ -130,16 +130,16 @@
             </div><!-- end of footer content  -->
             <div class="footer-pics">
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-01.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-01.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-02.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-02.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-04.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-04.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-03.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-03.jpg', 1) }}" alt="" >
                 </div>
             </div>
         </div>

--- a/docs/_templates/2022/base.html
+++ b/docs/_templates/2022/base.html
@@ -161,7 +161,7 @@
         </script>
 
         <!-- UIkit JS -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-beta.25/js/uikit.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-beta.25/js/uikit-icons.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.16.22/js/uikit.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.16.22/js/uikit-icons.min.js"></script>
     </body>
 </html>

--- a/docs/_templates/2022/base.html
+++ b/docs/_templates/2022/base.html
@@ -6,7 +6,6 @@
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="author" content="Write the Docs">
         <meta name="ROBOTS" content="ALL">
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
         <link rel="apple-touch-icon" sizes="57x57" href="{{ pathto('_static/favicon/apple-icon-57x57.png', 1) }}">
         <link rel="apple-touch-icon" sizes="60x60" href="{{ pathto('_static/favicon/apple-icon-60x60.png', 1) }}">

--- a/docs/_templates/2022/base.html
+++ b/docs/_templates/2022/base.html
@@ -105,16 +105,16 @@
 
                     <div class="footer-icon-list">
                         <a href="https://github.com/writethedocs">
-                            <img src="{{ pathto('_static/conf/images/icons/github-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/github-footer-white.svg', 1) }}" alt="GitHub">
                         </a>
                         <a href="https://twitter.com/writethedocs">
-                            <img src="{{ pathto('_static/conf/images/icons/twitter-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/twitter-footer-white.svg', 1) }}" alt="Twitter">
                         </a>
                         <a href="https://www.flickr.com/photos/writethedocs/">
-                            <img src="{{ pathto('_static/conf/images/icons/flickr-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/flickr-footer-white.svg', 1) }}" alt="Flickr">
                         </a>
                         <a href="https://www.writethedocs.org/slack/">
-                            <img src="{{ pathto('_static/conf/images/icons/slack-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/slack-footer-white.svg', 1) }}" alt="Slack">
                         </a>
                     </div><!-- end footer icons list of  links -->
                 </div> <!-- end of footer social section -->

--- a/docs/_templates/2022/index.html
+++ b/docs/_templates/2022/index.html
@@ -135,13 +135,13 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       <div class="picture-set">
         <div data-aos="pictrue-03" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-03.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-03.jpg', 1)  }}" alt="" >
         </div>
         <div data-aos="pictrue-02" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-02.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-02.jpg', 1)  }}" alt="" >
         </div>
         <div data-aos="pictrue-01" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-01.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-01.jpg', 1)  }}" alt="" >
         </div>
       </div>
     </div>
@@ -151,7 +151,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
     <div class="uk-container" uk-grid>
       <h2>Schedule Overview</h2>
       <div class="schedule-item uk-width-1-3@s">
-        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_one.icon + '-' + color +  '.svg', 1) }}">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_one.icon + '-' + color +  '.svg', 1) }}" alt="">
         <h3>{{ date.day_one.event }} </h3>
         <em>{{ date.day_one.date }} </em>
         <p>{{ date.day_one.summary }} </p>
@@ -159,7 +159,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       {% if date.day_two is defined %}
       <div class="schedule-item uk-width-1-3@s">
-        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_two.icon + '-' + color +  '.svg', 1) }}">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_two.icon + '-' + color +  '.svg', 1) }}" alt="">
         <h3>{{ date.day_two.event }} </h3>
         <em>{{ date.day_two.date }} </em>
         <p>{{ date.day_two.summary }} </p>
@@ -168,7 +168,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       {% if date.conference is defined %}
       <div class="schedule-item uk-width-1-3@s">
-        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.conference.icon + '-' + color +  '.svg', 1) }}">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.conference.icon + '-' + color +  '.svg', 1) }}" alt="" >
         <h3>{{ date.conference.event }} </h3>
         <em>{{ date.conference.date }} </em>
         <p>{{ date.conference.summary }} </p>

--- a/docs/_templates/2023/base.html
+++ b/docs/_templates/2023/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/docs/_templates/2023/base.html
+++ b/docs/_templates/2023/base.html
@@ -13,8 +13,6 @@
         <meta name="author" content="Write the Docs">
         <meta name="ROBOTS" content="ALL">
 
-        <meta name="viewport" content="width=device-width, initial-scale=1.0">
-
         <link rel="manifest" href="{{ pathto('_static/favicon/manifest.json', 1) }}">
         <meta name="msapplication-TileColor" content="#ffffff">
         <meta name="msapplication-TileImage" content="/ms-icon-144x144.png">

--- a/docs/_templates/2023/base.html
+++ b/docs/_templates/2023/base.html
@@ -119,16 +119,16 @@
             </div><!-- end of footer content  -->
             <div class="footer-pics">
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-01.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-01.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-02.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-02.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-04.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-04.jpg', 1) }}" alt="" >
                 </div>
                 <div>
-                    <img src="{{ pathto('_static/conf/images/pics/ft-image-03.jpg', 1) }}">
+                    <img src="{{ pathto('_static/conf/images/pics/ft-image-03.jpg', 1) }}" alt="" >
                 </div>
             </div>
         </div>

--- a/docs/_templates/2023/base.html
+++ b/docs/_templates/2023/base.html
@@ -150,7 +150,7 @@
         </script>
 
         <!-- UIkit JS -->
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-beta.25/js/uikit.min.js"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.0.0-beta.25/js/uikit-icons.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.16.22/js/uikit.min.js"></script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/uikit/3.16.22/js/uikit-icons.min.js"></script>
     </body>
 </html>

--- a/docs/_templates/2023/base.html
+++ b/docs/_templates/2023/base.html
@@ -94,16 +94,16 @@
 
                     <div class="footer-icon-list">
                         <a href="https://github.com/writethedocs">
-                            <img src="{{ pathto('_static/conf/images/icons/github-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/github-footer-white.svg', 1) }}" alt="GitHub">
                         </a>
                         <a href="https://twitter.com/writethedocs">
-                            <img src="{{ pathto('_static/conf/images/icons/twitter-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/twitter-footer-white.svg', 1) }}" alt="Twitter">
                         </a>
                         <a href="https://www.flickr.com/photos/writethedocs/">
-                            <img src="{{ pathto('_static/conf/images/icons/flickr-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/flickr-footer-white.svg', 1) }}" alt="Flickr">
                         </a>
                         <a href="https://www.writethedocs.org/slack/">
-                            <img src="{{ pathto('_static/conf/images/icons/slack-footer-white.svg', 1) }}">
+                            <img src="{{ pathto('_static/conf/images/icons/slack-footer-white.svg', 1) }}" alt="Slack">
                         </a>
                     </div><!-- end footer icons list of  links -->
                 </div> <!-- end of footer social section -->

--- a/docs/_templates/2023/index.html
+++ b/docs/_templates/2023/index.html
@@ -143,13 +143,13 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       <div class="picture-set">
         <div data-aos="pictrue-03" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-03.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-03.jpg', 1)  }}" alt="" >
         </div>
         <div data-aos="pictrue-02" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-02.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-02.jpg', 1)  }}" alt="" >
         </div>
         <div data-aos="pictrue-01" data-aos-once="true">
-        <img src="{{ pathto('_static/conf/images/pics/pictrue-01.jpg', 1) }}">
+        <img src="{{ pathto('_static/conf/images/pics/pictrue-01.jpg', 1)  }}" alt="" >
         </div>
       </div>
     </div>
@@ -159,7 +159,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
     <div class="uk-container" uk-grid>
       <h2>Schedule Overview</h2>
       <div class="schedule-item uk-width-1-3@s">
-        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_one.icon + '-' + color +  '.svg', 1) }}">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_one.icon + '-' + color +  '.svg', 1) }}" alt="">
         <h3>{{ date.day_one.event }} </h3>
         <em>{{ date.day_one.date }} </em>
         <p>{{ date.day_one.summary }} </p>
@@ -167,7 +167,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       {% if date.day_two is defined %}
       <div class="schedule-item uk-width-1-3@s">
-        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_two.icon + '-' + color +  '.svg', 1) }}">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.day_two.icon + '-' + color +  '.svg', 1) }}" alt="">
         <h3>{{ date.day_two.event }} </h3>
         <em>{{ date.day_two.date }} </em>
         <p>{{ date.day_two.summary }} </p>
@@ -176,7 +176,7 @@ Home - Write the Docs {{ name }} {%- if cobrand is defined and cobrand %} + {{ c
 
       {% if date.conference is defined %}
       <div class="schedule-item uk-width-1-3@s">
-        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.conference.icon + '-' + color +  '.svg', 1) }}">
+        <img style="height: 150px;" src="{{ pathto('_static/conf/images/icons/' + date.conference.icon + '-' + color +  '.svg', 1) }}" alt="" >
         <h3>{{ date.conference.event }} </h3>
         <em>{{ date.conference.date }} </em>
         <p>{{ date.conference.summary }} </p>


### PR DESCRIPTION
I noticed some issues with website accessibility through some automated checks, so this should help with some of those. It doesn't address the following issues (as they seemed to require some design thinking):

* Link text not having high enough contrast with the background in conference pages
* Link text not having high enough contrast with surrounding text in any pages
* Text in the footer of conference pages (the `© 2023 Write the Docs` and two instances of `|`) not having high enough contrast with the background

Nor this as it comes from a theme:

* The alabaster theme setting a maximum viewport scale (`maximum-scale=0.9`)

Hopefully the reasons for the other changes are clear from the commit messages.

* Adding English as the language to pages
* Marking decorative images as decorative (`alt=""`)
* Adding alt text to images used as buttons
* Upgrading the UI Kit from beta to give a label to a button that didn't have it (not sure it's still idea as `aria-controls` doesn't seem to be present, but it's something)

<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1986.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->