### PR TITLE
Capitalize “Slack”

### DIFF
--- a/docs/_data/2017.na.speakers.yaml
+++ b/docs/_data/2017.na.speakers.yaml
@@ -876,7 +876,7 @@
 
         this opportunity to brainstorm and discuss what''s working and what''
 
-        s not. </p><p>We created a WTD slack channel: #release-notes @ writethedocs.slack.com
+        s not. </p><p>We created a WTD Slack channel: #release-notes @ writethedocs.slack.com
 
         to continue our discussion about release notes.</p>
 

--- a/docs/_static_html/conf/eu/2016/news/thanks-for-coming/index.html
+++ b/docs/_static_html/conf/eu/2016/news/thanks-for-coming/index.html
@@ -181,7 +181,7 @@ We’ll send another update once they’re available!</p>
 <div class="section" id="write-the-docs-slack">
 <h2>Write the Docs Slack<a class="headerlink" href="#write-the-docs-slack" title="Permalink to this headline">¶</a></h2>
 <p>The Write the Docs Slack has really taken off this year! Our general Slack channel has been extra busy in the days and weeks leading up to the conference, and we hope that y’all continue the conversations throughout the year.</p>
-<p><a class="reference external" href="http://slack.writethedocs.org/">Join</a> our slack channel, or <a class="reference external" href="https://writethedocs.slack.com/messages">sign back in</a> if you’re already a member!</p>
+<p><a class="reference external" href="http://slack.writethedocs.org/">Join</a> our Slack channel, or <a class="reference external" href="https://writethedocs.slack.com/messages">sign back in</a> if you’re already a member!</p>
 </div>
 <div class="section" id="meetups">
 <h2>Meetups<a class="headerlink" href="#meetups" title="Permalink to this headline">¶</a></h2>

--- a/docs/_static_html/conf/na/2017/speakers/index.html
+++ b/docs/_static_html/conf/na/2017/speakers/index.html
@@ -1158,7 +1158,7 @@ and harness contributors to do the same? </p>
 services and their continual and more frequent releases, we need to find a balance
 between comprehensive, helpful, and accessible release notes. We want to take
 this opportunity to brainstorm and discuss what's working and what'
-s not. </p><p>We created a WTD slack channel: #release-notes @ writethedocs.slack.com
+s not. </p><p>We created a WTD Slack channel: #release-notes @ writethedocs.slack.com
 to continue our discussion about release notes.</p>
 
           </div>

--- a/docs/blog/2020-community-update.rst
+++ b/docs/blog/2020-community-update.rst
@@ -114,7 +114,7 @@ Thanks
 ------
 
 Thanks again for subscribing to our newsletter and being a member of our community.
-We hope to see you soon at one of our online events, on our slack,
+We hope to see you soon at one of our online events, on our Slack,
 or continue to see you here via this newsletter.
 
 You can always reply to this email if you have any questions or comments.

--- a/docs/blog/2021-community-update.rst
+++ b/docs/blog/2021-community-update.rst
@@ -123,7 +123,7 @@ Thanks
 ------
 
 Thanks again for subscribing to our newsletter and for being a member of our community.
-We hope to see you soon at one of our online events, on our slack,
+We hope to see you soon at one of our online events, on our Slack,
 or continue to see you here via this newsletter.
 
 You can always reply to this email if you have any questions or comments.

--- a/docs/blog/2021-salary-survey.rst
+++ b/docs/blog/2021-salary-survey.rst
@@ -30,7 +30,7 @@ Thanks
 ------
 
 Thanks again for for being a member of our community.
-We hope to see you soon at one of our online events, on our slack, or continue to see you here via this newsletter.
+We hope to see you soon at one of our online events, on our Slack, or continue to see you here via this newsletter.
 
 You can always email us at support@writethedocs.org if you have any questions or comments.
 Stay tuned for another newsletter update next month!

--- a/docs/blog/2022-community-update.rst
+++ b/docs/blog/2022-community-update.rst
@@ -124,7 +124,7 @@ Thanks
 ------
 
 Thanks again for subscribing to our newsletter and for being a member of our community.
-We hope to see you soon at one of our online events, on our slack,
+We hope to see you soon at one of our online events, on our Slack,
 or continue to see you here via this newsletter.
 
 You can always reply to this email if you have any questions or comments.

--- a/docs/blog/newsletter-april-2021.rst
+++ b/docs/blog/newsletter-april-2021.rst
@@ -64,7 +64,7 @@ Finally, editing challenges are sometimes not about words but relationships. Som
 What we're reading/listening to/watching
 ----------------------------------------
 
-The #bipoc group's been discussing the following materials on diversity, inclusion, and equity. Want to join the conversation? Join us in the #bipoc slack channel!
+The #bipoc group's been discussing the following materials on diversity, inclusion, and equity. Want to join the conversation? Join us in the #bipoc Slack channel!
 
 For a short read, check out: `Words Matter: Finally, Tech Looks at Removing Exclusionary Language <https://thenewstack.io/words-matter-finally-tech-looks-at-removing-exclusionary-language>`__ by Jennifer Riggins, June 2020. It discusses the tech industry’s look at the language it uses, because words do matter.
 

--- a/docs/blog/newsletter-july-2020.rst
+++ b/docs/blog/newsletter-july-2020.rst
@@ -72,7 +72,7 @@ Tracking documentation work can be challenging, especially if you're handling do
 * Jira: You can include a documentation component within your project. This allows people in your organization can log issues against the docs, and you can use Jira's features to track your issues by filtering on that documentation component.
 * Meetings: The old-fashioned way! You can hold regular meetings with your stakeholders to give them status updates on how your work that concerns them is progressing. It's also an opportunity to get details on what's coming up on their roadmap, and to hear about key priority changes so they don't surprise you at the last minute.
 
-If you have found a great way to track your docs work, or you'd like to ask for more tips, jump into the slack!
+If you have found a great way to track your docs work, or you'd like to ask for more tips, jump into the Slack!
 
 -----------------------------------
 Resources for diverse example names

--- a/docs/blog/newsletter-june-2021.rst
+++ b/docs/blog/newsletter-june-2021.rst
@@ -70,7 +70,7 @@ If you're interested to get a sense of the overall state of software documentati
 What we're reading & listening to
 ---------------------------------
 
-The #bipoc group's been discussing the following materials on diversity, inclusion, and equity. Want to join the conversation? Join us in the `#bipoc slack channel <https://app.slack.com/client/T0299N2DL/C016STMEWJD>`__!
+The #bipoc group's been discussing the following materials on diversity, inclusion, and equity. Want to join the conversation? Join us in the `#bipoc Slack channel <https://app.slack.com/client/T0299N2DL/C016STMEWJD>`__!
 
 For a short read: This `twitter thread <https://twitter.com/HeyChelseaTroy/status/1396503832255942656?s=19>`__ from @HeyChelseaTroy breaks down why approaching inclusion like other business initiatives often fails.
 

--- a/docs/blog/newsletter-may-2021.rst
+++ b/docs/blog/newsletter-may-2021.rst
@@ -93,7 +93,7 @@ So here are the new pages! Thank you to everybody who contributed discussion and
 What we’re reading and watching
 -------------------------------
 
-The #bipoc group’s been discussing the following materials on diversity, inclusion, and equity. Want to join the conversation? Please join us in the #bipoc slack channel!
+The #bipoc group’s been discussing the following materials on diversity, inclusion, and equity. Want to join the conversation? Please join us in the #bipoc Slack channel!
 
 For a short read, check out `this article in Good Housekeeping <https://www.goodhousekeeping.com/life/a35630674/how-to-support-asian-american-community-hate-crimes-violence/>`__ about why some Asians are having a hard time speaking out about the ongoing Anti-Asian hate crimes and how you can show support.
 

--- a/docs/blog/write-the-docs-2017-stats.rst
+++ b/docs/blog/write-the-docs-2017-stats.rst
@@ -42,7 +42,7 @@ Newsletter
 
 * 3,406 subscribers (up from 2,485 in 2016)
 
-Our :doc:`newsletter </newsletter>` contains curated distillations from the slack conversations that you have every day.
+Our :doc:`newsletter </newsletter>` contains curated distillations from the Slack conversations that you have every day.
 
 Meetups
 =======

--- a/docs/code-of-conduct-response.rst
+++ b/docs/code-of-conduct-response.rst
@@ -89,7 +89,7 @@ The most common resolutions the response team can decide on are:
 
 Resolutions are not restricted to these options. Any conversations with bad actors are done by two people from the response team, and notes from this conversation will be added to the record of the incident. Regarding apologies, do not place a reporter in a situation where they are pressured to accept apologies from the reported person.
 
-When deciding on a resolution, the basic goal is to address the report in an appropriate way, while also looking to prevent or reduce the risk of continuing harm in the future. For example, you may try to distinguish whether a violation occurred intentionally or not, especially in not too severe cases like inappropriate jokes. In intentional cases, or severe behaviour, stronger measures are probably appropriate. The response team can also use behaviour on social media, the conference slack or personal interactions to further build a picture of the person(s) involved.
+When deciding on a resolution, the basic goal is to address the report in an appropriate way, while also looking to prevent or reduce the risk of continuing harm in the future. For example, you may try to distinguish whether a violation occurred intentionally or not, especially in not too severe cases like inappropriate jokes. In intentional cases, or severe behaviour, stronger measures are probably appropriate. The response team can also use behaviour on social media, the conference Slack or personal interactions to further build a picture of the person(s) involved.
 
 To provide a number of examples, these are situations where immediate removal from a space is likely appropriate:
 

--- a/docs/code-of-conduct.rst
+++ b/docs/code-of-conduct.rst
@@ -119,7 +119,7 @@ In your report please include, when possible:
 * Your contact info (so we can get in touch with you)
 * Names or descriptions of anyone who was involved or who witnessed the incident.
 * When and where the incident occurred. Please be as specific as possible.
-* Your account of what occurred. If there is a written record (e.g. tweets or slack messages) please include screenshots, or otherwise a link.
+* Your account of what occurred. If there is a written record (e.g. tweets or Slack messages) please include screenshots, or otherwise a link.
 * Any extra context you believe existed for the incident.
 * If you believe this incident is ongoing.
 * Any other information you believe we should have.

--- a/docs/conf/atlantic/2023/cfp-email-templates.rst
+++ b/docs/conf/atlantic/2023/cfp-email-templates.rst
@@ -121,11 +121,11 @@ Subject:
 
    Just wanted to drop you all a quick note covering some logistics. Talks are pre-recorded again this year, we'd love to get those recordings from you before {{cfp.video_by}}. We do have a videographer who can help you record remotely, drop us a line if that is something you're interested in. We're finalizing details on the live Q&A for each talk.
 
-   ○  I've added some questions to our [CFP tool (Pretalx)]({{cfp.url}}) about your pronouns, interesting facts, name pronunciation, and slack username. Please log in at {{cfp.url}} and answer those (although we'll only need them closer to the event).
+   ○  I've added some questions to our [CFP tool (Pretalx)]({{cfp.url}}) about your pronouns, interesting facts, name pronunciation, and Slack username. Please log in at {{cfp.url}} and answer those (although we'll only need them closer to the event).
 
    ○ If you haven't done so already, please upload a speaker pic to your Pretalx account while you're there, it'll look so much better than the anonymous outline.
 
-   ○ Private speaker slack channel! If you're not on the slack already, [join the WTD slack]({{slack_join}}). Once you're signed up, or if you're already on there, ping me @plaindocs so I can add you to the private speaker channel. It contains all of our past speakers, who will be happy to offer advice or answer questions.
+   ○ Private speaker Slack channel! If you're not on the Slack already, [join the WTD Slack]({{slack_join}}). Once you're signed up, or if you're already on there, ping me @plaindocs so I can add you to the private speaker channel. It contains all of our past speakers, who will be happy to offer advice or answer questions.
 
    ○ [Speaker mentoring guidelines](https://www.writethedocs.org/organizer-guide/confs/cfp/#speaker-mentoring) -- let us know if you'd like to talk over your proposal or slide deck with a speaker from a previous year.
 

--- a/docs/conf/portland/2020/writing-day.rst
+++ b/docs/conf/portland/2020/writing-day.rst
@@ -50,7 +50,7 @@ Reach out to @alyssa and @cameronshorter on WTD Slack if interested. (@cameronsh
 
 **General chit-chat**
 
-We hang out in [a group Slack workspace](https://join.slack.com/t/thegooddocs/shared_invite/enQtODkyNjI5MDc0NjE0LTUyNGFiZmU1MjIzNDMwN2E3NmQwODQwZmRkYWI5MDhlMzdjYzg4Nzg4YjM3ODA0NGE4MTgyYzdkMGViMTI2MDM).
+We hang out in [The Good Docs Slack workspace](https://join.slack.com/t/thegooddocs/shared_invite/enQtODkyNjI5MDc0NjE0LTUyNGFiZmU1MjIzNDMwN2E3NmQwODQwZmRkYWI5MDhlMzdjYzg4Nzg4YjM3ODA0NGE4MTgyYzdkMGViMTI2MDM).
 
 Write the Docs Meetups
 ----------------------

--- a/docs/conf/portland/2020/writing-day.rst
+++ b/docs/conf/portland/2020/writing-day.rst
@@ -28,25 +28,25 @@ You've just been asked by your team to create documentation for your project. Bu
 
 We're working on a set of templates to make it easier to write documentation by suggesting the content needed to create the minimum viable set of documentation for your project. Drop by if you have new documentation to create, or if you want to try your existing docs against our checklists, or if you just want to talk about templates.
 
-Reach out to @ccromwell on WTD slack if interested.
+Reach out to @ccromwell on WTD Slack if interested.
 
 **How would you customize a style guide?**
 
 We have a draft `Style guide template <https://docs.google.com/document/d/1HxtaiayAJZvF0ZfNjLvRH3vYMvGTEki_TK8hFilQNJ0>`_ and would love feedback from tech writers. (Please use comments rather than track changes in the doc - it is easier to maintain.)
 
-Reach out to @alyssa on WTD slack if interested.
+Reach out to @alyssa on WTD Slack if interested.
 
 **Transform templates to your wiki format**
 
 We want to be able to convert our markdown templates to your format? What tools, configuration settings, and how-tos should we have for this?
 
-Reach out to @ScriptAutomate on WTD slack if interested.
+Reach out to @ScriptAutomate on WTD Slack if interested.
 
 **What should a glossary or word list look like?**
 
 We are kicking off a pilot to define best practices for `cross-domain management of glossaries <https://docs.google.com/document/d/1Fjrl34ErnYammel9WmvXJ3rMWFANjoSiiGyyNSYOXUg/>`_. We want help defining what an ideal glossary entry or preferred word list entry should look like. Work will happen in this `glossary entry <https://docs.google.com/document/d/1wsSLQ_T8skVdlvjF5ayZa5IhKbTazdqm97lHX0qc16Q>`_ page.
 
-Reach out to @alyssa and @cameronshorter on WTD slack if interested. (@cameronshorter is in the Australian timezone.)
+Reach out to @alyssa and @cameronshorter on WTD Slack if interested. (@cameronshorter is in the Australian timezone.)
 
 **General chit-chat**
 
@@ -88,7 +88,7 @@ Yet, MDN Web Docs needs help from documentarians—whether you are a programmer,
 
 We have `tasks for you to help with content issues and editorial reviews <https://docs.google.com/document/d/1q6BiE1-RJPFoe2IAghqhRbm0vci24k2nBLqdd_Dqn7o/edit?usp=sharing>`_.
 
-Look for `@jmswisher` in the WTD slack for help and questions.
+Look for `@jmswisher` in the WTD Slack for help and questions.
 
 
 

--- a/docs/conf/portland/2020/writing-day.rst
+++ b/docs/conf/portland/2020/writing-day.rst
@@ -50,7 +50,7 @@ Reach out to @alyssa and @cameronshorter on WTD Slack if interested. (@cameronsh
 
 **General chit-chat**
 
-We hang out in `thegooddocs.slack.com <https://join.slack.com/t/thegooddocs/shared_invite/enQtODkyNjI5MDc0NjE0LTUyNGFiZmU1MjIzNDMwN2E3NmQwODQwZmRkYWI5MDhlMzdjYzg4Nzg4YjM3ODA0NGE4MTgyYzdkMGViMTI2MDM>`_.
+We hang out in [a group Slack workspace](https://join.slack.com/t/thegooddocs/shared_invite/enQtODkyNjI5MDc0NjE0LTUyNGFiZmU1MjIzNDMwN2E3NmQwODQwZmRkYWI5MDhlMzdjYzg4Nzg4YjM3ODA0NGE4MTgyYzdkMGViMTI2MDM).
 
 Write the Docs Meetups
 ----------------------

--- a/docs/conf/portland/2022/cfp-email-templates.rst
+++ b/docs/conf/portland/2022/cfp-email-templates.rst
@@ -124,11 +124,11 @@ Subject:
 
    Just wanted to drop you all a quick note covering some logistics. Talks are pre-recorded again this year, we'd love to get those recordings from you before {{cfp.video_by}}. We do have a videographer who can help you record remotely, drop us a line if that is something you're interested in. We're finzalizing details on the live Q&A for each talk.
 
-   ○  I've added some questions to our [CFP tool (Pretalx)]({{cfp.url}}) about your pronouns, interesting facts, name pronunciation, and slack username. Please log in at {{cfp.url}} and answer those (although we'll only need them closer to the event).
+   ○  I've added some questions to our [CFP tool (Pretalx)]({{cfp.url}}) about your pronouns, interesting facts, name pronunciation, and Slack username. Please log in at {{cfp.url}} and answer those (although we'll only need them closer to the event).
 
    ○ If you haven't done so already, please upload a speaker pic to your Pretalx account while you're there, it'll look so much better than the anonymous outline.
 
-   ○ Private speaker slack channel! If you're not on the slack already, [join the WTD slack]({{slack_join}}). Once you're signed up, or if you're already on there, ping me @plaindocs so I can add you to the private speaker channel. It contains all of our past speakers, who will be happy to offer advice or answer questions.
+   ○ Private speaker Slack channel! If you're not on the Slack already, [join the WTD Slack]({{slack_join}}). Once you're signed up, or if you're already on there, ping me @plaindocs so I can add you to the private speaker channel. It contains all of our past speakers, who will be happy to offer advice or answer questions.
 
    ○ [Speaker mentoring guidelines](https://www.writethedocs.org/organizer-guide/confs/cfp/#speaker-mentoring) -- let us know if you'd like to talk over your proposal or slide deck with a speaker from a previous year.
 

--- a/docs/conf/portland/2023/cfp-email-templates.rst
+++ b/docs/conf/portland/2023/cfp-email-templates.rst
@@ -123,9 +123,9 @@ Subject:
 
    Just wanted to drop you all a quick note covering some logistics.
 
-   ○  I've added some questions to our [CFP tool (Pretalx)]({{cfp.url}}) about your pronouns, interesting facts, name pronunciation, and slack username. Please log in at {{cfp.url}} and answer those.
+   ○  I've added some questions to our [CFP tool (Pretalx)]({{cfp.url}}) about your pronouns, interesting facts, name pronunciation, and Slack username. Please log in at {{cfp.url}} and answer those.
 
-   ○ Private speaker slack channel! If you're not on the slack already, [join the WTD slack](https://join.slack.com/t/writethedocs/shared_invite/zt-1qvx3xd9z-jOX_0QZXidaAESji2miYXQ). Once you're signed up, or if you're already on there, ping me @plaindocs so I can add you to the private speaker channel. It contains many of our past speakers, who will be happy to offer advice or answer questions.
+   ○ Private speaker Slack channel! If you're not on the Slack already, [join the WTD Slack](https://join.slack.com/t/writethedocs/shared_invite/zt-1qvx3xd9z-jOX_0QZXidaAESji2miYXQ). Once you're signed up, or if you're already on there, ping me @plaindocs so I can add you to the private speaker channel. It contains many of our past speakers, who will be happy to offer advice or answer questions.
 
    ○ We've got a [provisional schedule]({{cfp.preview}}) up, we're still tweaking a couple of things but it's mostly accurate. If you can't make your slot for any reason do let me know and I'll adjust. Note that we're trialing moderated Q&A in-person this year. We're hoping to publish the schedule on **Friday**.
 

--- a/docs/conf/portland/2023/welcome-wagon.rst
+++ b/docs/conf/portland/2023/welcome-wagon.rst
@@ -6,7 +6,7 @@ Welcome Wagon Guide
 Hello!
 
 We're your Welcome Wagon, and we're glad you're coming to Write the Docs!
-Feel free to ask questions in the Write the Docs Welcome Wagon slack channel or `email <mailto:canncrochet@gmail.com>`_ us if we can help make your first time at the conference easier.
+Feel free to ask questions in the Write the Docs Welcome Wagon Slack channel or `email <mailto:canncrochet@gmail.com>`_ us if we can help make your first time at the conference easier.
 When you get to the conference, come :ref:`say hello <say-hello-2023>`.
 
 We've gathered info here that will help you navigate the conference like a pro and make you feel more at home. The Welcome Wagon events give new attendees strategies and tips and connect them with people.

--- a/docs/conf/prague/2022/cfp-email-templates.rst
+++ b/docs/conf/prague/2022/cfp-email-templates.rst
@@ -121,11 +121,11 @@ Subject:
 
    Just wanted to drop you all a quick note covering some logistics. Talks are pre-recorded again this year, we'd love to get those recordings from you before {{cfp.video_by}}. We do have a videographer who can help you record remotely, drop us a line if that is something you're interested in. We're finalizing details on the live Q&A for each talk.
 
-   ○  I've added some questions to our [CFP tool (Pretalx)]({{cfp.url}}) about your pronouns, interesting facts, name pronunciation, and slack username. Please log in at {{cfp.url}} and answer those (although we'll only need them closer to the event).
+   ○  I've added some questions to our [CFP tool (Pretalx)]({{cfp.url}}) about your pronouns, interesting facts, name pronunciation, and Slack username. Please log in at {{cfp.url}} and answer those (although we'll only need them closer to the event).
 
    ○ If you haven't done so already, please upload a speaker pic to your Pretalx account while you're there, it'll look so much better than the anonymous outline.
 
-   ○ Private speaker slack channel! If you're not on the slack already, [join the WTD slack]({{slack_join}}). Once you're signed up, or if you're already on there, ping me @plaindocs so I can add you to the private speaker channel. It contains all of our past speakers, who will be happy to offer advice or answer questions.
+   ○ Private speaker Slack channel! If you're not on the Slack already, [join the WTD Slack]({{slack_join}}). Once you're signed up, or if you're already on there, ping me @plaindocs so I can add you to the private speaker channel. It contains all of our past speakers, who will be happy to offer advice or answer questions.
 
    ○ [Speaker mentoring guidelines](https://www.writethedocs.org/organizer-guide/confs/cfp/#speaker-mentoring) -- let us know if you'd like to talk over your proposal or slide deck with a speaker from a previous year.
 

--- a/docs/include/conf/coc/eu-coc.rst
+++ b/docs/include/conf/coc/eu-coc.rst
@@ -1,14 +1,14 @@
 **Eric Holscher**
 
 * eric@writethedocs.org
-* slack: ericholscher
+* Slack: ericholscher
 
 **Mikey Ariel**
 
 * mikey@writethedocs.org
-* slack: thatdocslady
+* Slack: thatdocslady
 
 **Sasha Romijn**
 
 * sasha@writethedocs.org
-* slack: sasha
+* Slack: sasha

--- a/docs/include/conf/coc/na-coc.rst
+++ b/docs/include/conf/coc/na-coc.rst
@@ -2,9 +2,9 @@
 
 * eric@writethedocs.org
 * Phone: 757-705-0532
-* slack: ericholscher
+* Slack: ericholscher
 
 **Samuel Wright**
 
 * sam@writethedocs.org
-* slack: plaindocs
+* Slack: plaindocs

--- a/docs/include/conf/coc/vilnius-coc.rst
+++ b/docs/include/conf/coc/vilnius-coc.rst
@@ -1,9 +1,9 @@
 **Karina Klinkeviciute**
 
 * karina.klinkeviciute@gmail.com
-* slack: 
+* Slack: 
 
 **Aidis Stukas**
 
 * aidiss@gmail.com 
-* slack: aidiss
+* Slack: aidiss

--- a/docs/include/slack.md
+++ b/docs/include/slack.md
@@ -1,3 +1,5 @@
+<!-- Just left here from https://github.com/writethedocs/www/pull/767 -->
+
 Welcome to the Write the Docs Slack! We're glad you're here, and we look forward to your contributions to our community.
 
 We've written some guidelines to help you get the most out of this Slack. Please take a few minutes to learn about some of our channels, and familiarize yourself with our Slack guidelines. All this information is on [our Slack page](https://www.writethedocs.org/slack/) -- make sure to look through the whole page. We are grounded in the principles of open source, and we pride ourselves on being one of the most welcoming communities in tech. Our guidelines are an important tool to further this goal!

--- a/docs/include/slack.txt
+++ b/docs/include/slack.txt
@@ -1,6 +1,6 @@
 Welcome to the Write the Docs Slack! We're glad you're here, and we look forward to your contributions to our community.
 
-We've written some guidelines to help you get the most out of this Slack. Please take a few minutes to learn about some of our channels, and familiarize yourself with our Slack guidelines. All this information is at <https://www.writethedocs.org/slack/> -- make sure to look through the whole page. We are grounded in the principles of open source, and we pride ourselves on being one of the most welcoming communities in tech. Our guidelines are an important tool to further this goal!
+We've written some guidelines to help you get the most out of this Slack. Please take a few minutes to learn about some of our channels, and familiarize yourself with our Slack guidelines. All this information is on [our Slack page](https://www.writethedocs.org/slack/) -- make sure to look through the whole page. We are grounded in the principles of open source, and we pride ourselves on being one of the most welcoming communities in tech. Our guidelines are an important tool to further this goal!
 
 If you're new to Write the Docs, we also invite you to learn more about our community: 
 - Check out how we got started at https://www.writethedocs.org/origin-story/

--- a/docs/include/slack.txt
+++ b/docs/include/slack.txt
@@ -1,6 +1,6 @@
 Welcome to the Write the Docs Slack! We're glad you're here, and we look forward to your contributions to our community.
 
-We've written some guidelines to help you get the most out of this Slack. Please take a few minutes to learn about some of our channels, and familiarize yourself with our Slack guidelines. All this information is at https://www.writethedocs.org/slack/ -- make sure to look through the whole page. We are grounded in the principles of open source, and we pride ourselves on being one of the most welcoming communities in tech. Our guidelines are an important tool to further this goal!
+We've written some guidelines to help you get the most out of this Slack. Please take a few minutes to learn about some of our channels, and familiarize yourself with our Slack guidelines. All this information is at <https://www.writethedocs.org/slack/> -- make sure to look through the whole page. We are grounded in the principles of open source, and we pride ourselves on being one of the most welcoming communities in tech. Our guidelines are an important tool to further this goal!
 
 If you're new to Write the Docs, we also invite you to learn more about our community: 
 - Check out how we got started at https://www.writethedocs.org/origin-story/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,7 +25,7 @@ Connect with the community
 
 Get more information on how to meet the community, get involved, stay in touch.
 
-* Join our :doc:`slack network </slack>` with thousands of other documentarians
+* Join our :doc:`Slack network </slack>` with thousands of other documentarians
 * Join a :doc:`local or online meetup </meetups/index>` to dive deeper into the community
 * Learn more about our :doc:`sponsorship options <sponsorship/index>` for your company
 

--- a/docs/organizer-guide/confs/communication.rst
+++ b/docs/organizer-guide/confs/communication.rst
@@ -133,7 +133,7 @@ Thank you
 * **"Thank you":** Give stats if you have any and thank people for coming.
 * **"Survey":** Put a link to attendees survey if relevant.
 * **"Video":** Put a link to talks' video if they're already online.
-* **"How to keep in touch sections":** Make different sections for meetups, WTD's slack, WTD's forum, mailing list, etc.
+* **"How to keep in touch sections":** Make different sections for meetups, WTD's Slack, WTD's forum, mailing list, etc.
 * **"Notes":** Ask people who were attending unrecorded events (unconference) if they have any notes they could share. Tell them how to do it.
 * **"Conclusion":** Thank people again and invite them to next year conference.
 

--- a/docs/organizer-guide/meetups/livestreaming-meetups.rst
+++ b/docs/organizer-guide/meetups/livestreaming-meetups.rst
@@ -12,7 +12,7 @@ As a Meetup organizer you are welcome to livestream your events or upload record
 You can request access to our YouTube Studio channel:
 
 * Request access when you fill out the *Meetup organizer contact information* form (available on Slack).
-* Reach out to the Meetup team lead, Rose Williams on slack or by email.
+* Reach out to the Meetup team lead, Rose Williams on Slack or by email.
 
 After you have channel access, you can upload a recorded meetup or livestream future events.
 

--- a/docs/organizer-guide/meetups/starting.rst
+++ b/docs/organizer-guide/meetups/starting.rst
@@ -3,7 +3,7 @@ Starting a Meetup
 
 Write the Docs :doc:`/meetups/index` provide
 a great way to connect and continue the conversations sparked by our
-:doc:`/conf/index`, `slack channel
+:doc:`/conf/index`, `Slack channel
 <http://slack.writethedocs.org/>`_ and `forum <http://forum.writethedocs.org/>`_ .
 If you don't have a Write the Docs Meetup nearby, we can help you get one started.
 With a little help, you can make it happen with a Meetup in your area!

--- a/vale/WTD/Branding.yml
+++ b/vale/WTD/Branding.yml
@@ -4,3 +4,4 @@ level: error
 swap:
   Write The Docs: Write the Docs
   Read The Docs: Read the Docs
+  slack: Slack


### PR DESCRIPTION
Hi! I think Slack wants to be a proper noun so I’m offering this stunning one-character PR.

<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--1994.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->