### PR TITLE
Writing Day form url edit

### DIFF
--- a/docs/conf/atlantic/2023/writing-day.rst
+++ b/docs/conf/atlantic/2023/writing-day.rst
@@ -20,7 +20,7 @@ Coming soon!
 Your project here
 ^^^^^^^^^^^^^^^^^
 
-Submit your project using our `Writing Day project form <https://forms.gle/KPo1ZPuRHqf7UZy37>` or send us a PR with your project info!
+Submit your project using our `Writing Day project form <https://forms.gle/KPo1ZPuRHqf7UZy37>`_ or send us a PR with your project info!
 
 Check out the :doc:`/conf/{{shortcode}}/{{year}}/writing-day-project-faq` to review what information is 
 needed for your project submission as well as ways to maximize your event experience.


### PR DESCRIPTION
Form url isn't displaying properly.

<img width="450" alt="image" src="https://github.com/writethedocs/www/assets/11397899/127155ed-1428-4d5b-a131-48a6d378509e">


<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--2003.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->