### PR TITLE
Fix the UTC start time for the first session of the writing day

### DIFF
--- a/docs/conf/atlantic/2023/writing-day.rst
+++ b/docs/conf/atlantic/2023/writing-day.rst
@@ -17,7 +17,7 @@ The first and second session time blocks are separated by a 30 minute snack brea
 
 First session:
 
-* 11:30 UTC to 14:00 UTC 
+* 10:00 UTC to 14:00 UTC 
 * 12:00 CEST to 16:00 CEST 
 * 06:00 EDT to 10:00 EDT
 


### PR DESCRIPTION


<!-- readthedocs-preview writethedocs-www start -->
----
:books: Documentation preview :books:: https://writethedocs-www--2024.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->