### PR TITLE
Remove KnowledgeOwl as a sponsor :(

### DIFF
--- a/docs/_data/portland-2024-config.yaml
+++ b/docs/_data/portland-2024-config.yaml
@@ -210,9 +210,9 @@ sponsors:
     #   link: https://slack.com/
     #   brand: Slack
   second:
-    - name: knowledgeowl
-      link: https://www.knowledgeowl.com?ref=writethedocs
-      brand: KnowledgeOwl
+    # - name: knowledgeowl
+    #   link: https://www.knowledgeowl.com?ref=writethedocs
+    #   brand: KnowledgeOwl
     - name: readthedocs
       link: https://about.readthedocs.com/?ref=writethedocs
       brand: Read the Docs


### PR DESCRIPTION
They had to pull back from attending this year,
so wanted to be removed.


<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2081.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->