### PR TITLE
docs: Add new book title in technical communication list

### DIFF
--- a/docs/books.rst
+++ b/docs/books.rst
@@ -17,6 +17,7 @@ Technical communication
 * `The Product is Docs <https://www.splunk.com/en_us/blog/splunklife/the-product-is-docs.html>`_, by Christopher Gales - **1st edition read in our book club**
 * `Wicked, Incomplete, and Uncertain: User Support in the Wild and the Role of Technical Communication <https://www.goodreads.com/book/show/37864792-wicked-incomplete-and-uncertain>`_, by Jason Swarts
 * `Software Technical Writing: A Guidebook <https://jamesg.blog/book.pdf>`_, by James Gallagher
+* `The Docs as Code Primer: A practical handbook <https://leanpub.com/thedocsascodeprimer>`_, by Gijs Reijn
 
 E-Learning
 -----------


### PR DESCRIPTION
Add new book title "The Docs as Code Primer: A practical handbook"

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2085.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->