### PR TITLE
Include guidance on sharing content

### DIFF
--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -234,6 +234,10 @@ Please be mindful with the following behaviors:
 - **Avoid technology competitions.**
   It doesn't matter if your tool is faster or better in some metric.
   We care about creating great documentation for our users.
+- **Respect the Community's Privacy**
+  Do not share WtD Slack content externally without permission from participants of that discussion. 
+  Think of it like the `Chatham House Rule <https://en.wikipedia.org/wiki/Chatham_House_rule>`, and either ask for permission or sufficiently anonymize the content where no one could reasonably guess the author or source.
+  Violating this rule may lead to an immediate ban of your account.
 
 Posting rules
 ~~~~~~~~~~~~~

--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -234,10 +234,10 @@ Please be mindful with the following behaviors:
 - **Avoid technology competitions.**
   It doesn't matter if your tool is faster or better in some metric.
   We care about creating great documentation for our users.
-- **Respect the Community's Privacy**
-  Do not share WtD Slack content externally without permission from participants of that discussion. 
-  Think of it like the `Chatham House Rule <https://en.wikipedia.org/wiki/Chatham_House_rule>`, and either ask for permission or anonymize the content.
-  It is your responsibility, not the participants, to ensure that everyone has consented to your sharing of the content.
+- **Respect the privacy of your fellow community members.**
+  We love it when people get inspired by the conversations they have in the Write the Docs Slack! When doing so, make sure you follow best practices when sharing information about those conversations in things like blog and LinkedIn posts.
+  Make sure you always get permission in a public channel from participants in a discussion before sharing anything with any names attached. It is your responsibility, not the participants', to ensure that everyone has consented to be named in any external publications.
+  Otherwise, you can use the `Chatham House Rule <https://en.wikipedia.org/wiki/Chatham_House_rule>`as a guideline, and anonymize the content where no one could reasonably guess the author(s) or source.
 
 Posting rules
 ~~~~~~~~~~~~~

--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -237,7 +237,7 @@ Please be mindful with the following behaviors:
 - **Honor the community's trust and confidence.**
   In the Write the Docs Slack, we are privileged to be able to discuss complex or sensitive situations with other docs practitioners.
   But those discussions can only happen in an environment of discretion and trust.
-  The Chatham House Rule <https://www.chathamhouse.org/about-us/chatham-house-rule>`_ applies: you're welcome to use the information shared, but never reveal names, job titles, employers, or other identifying information about other participants outside of Slack, unless you've recieved their explicit permission to do so.
+  The Chatham House Rule <https://www.chathamhouse.org/about-us/chatham-house-rule>`_ applies: you're welcome to use the information shared, but never reveal names, job titles, employers, or other identifying information about other participants outside of Slack, unless you've received their explicit permission to do so.
 
 Posting rules
 ~~~~~~~~~~~~~

--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -237,7 +237,7 @@ Please be mindful with the following behaviors:
 - **Respect the Community's Privacy**
   Do not share WtD Slack content externally without permission from participants of that discussion. 
   Think of it like the `Chatham House Rule <https://en.wikipedia.org/wiki/Chatham_House_rule>`, and either ask for permission or anonymize the content.
-  Violating this rule may lead to an immediate ban of your account.
+  It is your responsibility, not the participants, to ensure that everyone has consented to your sharing of the content.
 
 Posting rules
 ~~~~~~~~~~~~~

--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -237,7 +237,7 @@ Please be mindful with the following behaviors:
 - **Respect the privacy of your fellow community members.**
   We love it when people get inspired by the conversations they have in the Write the Docs Slack! When doing so, make sure you follow best practices when sharing information about those conversations in things like blog and LinkedIn posts.
   Make sure you always get permission in a public channel from participants in a discussion before sharing anything with any names attached. It is your responsibility, not the participants', to ensure that everyone has consented to be named in any external publications.
-  Otherwise, you can use the `Chatham House Rule <https://en.wikipedia.org/wiki/Chatham_House_rule>`as a guideline, and anonymize the content where no one could reasonably guess the author(s) or source.
+  Otherwise, you can use the `Chatham House Rule <https://en.wikipedia.org/wiki/Chatham_House_rule>`_ as a guideline, and anonymize the content where no one could reasonably guess the author(s) or source.
 
 Posting rules
 ~~~~~~~~~~~~~

--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -234,10 +234,10 @@ Please be mindful with the following behaviors:
 - **Avoid technology competitions.**
   It doesn't matter if your tool is faster or better in some metric.
   We care about creating great documentation for our users.
-- **Respect the privacy of your fellow community members.**
-  We love it when people get inspired by the conversations they have in the Write the Docs Slack! When doing so, make sure you follow best practices when sharing information about those conversations in things like blog and LinkedIn posts.
-  Make sure you always get permission in a public channel from participants in a discussion before sharing anything with any names attached. It is your responsibility, not the participants', to ensure that everyone has consented to be named in any external publications.
-  Otherwise, you can use the `Chatham House Rule <https://en.wikipedia.org/wiki/Chatham_House_rule>`_ as a guideline, and anonymize the content where no one could reasonably guess the author(s) or source.
+- **Honor the community's trust and confidence.**
+  In the Write the Docs Slack, we are privileged to be able to discuss complex or sensitive situations with other docs practitioners.
+  But those discussions can only happen in an environment of discretion and trust.
+  The Chatham House Rule <https://www.chathamhouse.org/about-us/chatham-house-rule>`_ applies: you're welcome to use the information shared, but never reveal names, job titles, employers, or other identifying information about other participants outside of Slack, unless you've recieved their explicit permission to do so.
 
 Posting rules
 ~~~~~~~~~~~~~

--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -236,7 +236,7 @@ Please be mindful with the following behaviors:
   We care about creating great documentation for our users.
 - **Respect the Community's Privacy**
   Do not share WtD Slack content externally without permission from participants of that discussion. 
-  Think of it like the `Chatham House Rule <https://en.wikipedia.org/wiki/Chatham_House_rule>`, and either ask for permission or sufficiently anonymize the content where no one could reasonably guess the author or source.
+  Think of it like the `Chatham House Rule <https://en.wikipedia.org/wiki/Chatham_House_rule>`, and either ask for permission or anonymize the content.
   Violating this rule may lead to an immediate ban of your account.
 
 Posting rules


### PR DESCRIPTION
Based on a discussion today in WtD, we'd like to make explicit that sharing content within WtD requires either

1. Explicit permission from those involved in the discussion, or
2. Anonymization of content that reasonably obscures the authors

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2117.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->