### PR TITLE
WD: Add tabletop game project

### DIFF
--- a/docs/conf/portland/2024/writing-day.rst
+++ b/docs/conf/portland/2024/writing-day.rst
@@ -156,7 +156,7 @@ Already familiar with GitBook? We're looking for people like you to brainstorm f
 Use OpenAPI with the Museum API
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Project organizer Heather Cloward, she/her. The `Museum API <https://github.com/Redocly/museum-openapi-example/tree/main>`__ wass built by Redocly for educational purposes.
+Project organizer Heather Cloward, she/her. The `Museum API <https://github.com/Redocly/museum-openapi-example/tree/main>`__ was built by Redocly for educational purposes.
 
 The Museum API is a sample OpenAPI description. It offers a set of endpoints to interact with a museum's services -- such as retrieving museum hours, managing special events, and purchasing tickets.
 
@@ -167,7 +167,7 @@ The Museum API was built specifically to teach OpenAPI concepts and to create a 
 Write the Docs Documentation Salary Survey
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Project Organizer Kay Smoljak, she/her. Afternoon session.
+Project Organizer Kay Smoljak, she/her. Afternoon only session.
 
 The WTD Salary Survey has been running annually since 2019, with the goal of identifying appropriate salary ranges and providing a basis for pay negotiations. It has sparked discussions on other topics such as remote work, pay transparency, and job satisfaction.
 
@@ -188,6 +188,22 @@ We're particularly interested in:
 * Exploring ways to expand the respondent base.
 
 This is where we need you the most! Everyone who works in documentation is a subject matter expert on this topic, and we want your ideas on how to make the survey better benefit the community as a whole.
+
+Tabletop game rules writing workshop
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Project Organizer Ryan Macklin, they/he. Afternoon only session.
+
+Tabletop game rules are a neat and weird form of technical documentation! 
+
+If you're working on writing tabletop game rules or are interested in learning about that, join me during the Writing Day afternoon session. You can bring your own work-in-progress rules documents, and I'll have some work-in-progress rules as well. 
+
+The purpose for this Writing Day workship is to help:
+
+* Technical writers, who are also tabletop game writers, with their rules writing
+* Tabletop game writers understand that their skills are applicable to technical writing as a career
+
+**Note**: This is not a game design or playtesting session, purely a session about helping one another with the difficult task of rules writing.
 
 *More projects coming, get excited!*
 

--- a/docs/conf/portland/2024/writing-day.rst
+++ b/docs/conf/portland/2024/writing-day.rst
@@ -192,7 +192,7 @@ This is where we need you the most! Everyone who works in documentation is a sub
 Tabletop game rules writing workshop
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Project Organizer Ryan Macklin, they/he. Afternoon only session.
+Project Organizer Ryan Macklin, he/they. Afternoon only session.
 
 Tabletop game rules are a neat and weird form of technical documentation! 
 
@@ -200,7 +200,7 @@ If you're working on writing tabletop game rules or are interested in learning a
 
 The purpose for this Writing Day workship is to help:
 
-* Technical writers, who are also tabletop game writers, with their rules writing
+* Technical writers turning their craft toward game rules writing
 * Tabletop game writers understand that their skills are applicable to technical writing as a career
 
 **Note**: This is not a game design or playtesting session, purely a session about helping one another with the difficult task of rules writing.


### PR DESCRIPTION
Next steps:

- Project organizer review
- WTD staff final review
- Publish and get the project on the site

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2125.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->