### PR TITLE
Blog: Writing Day project announcement

### DIFF
--- a/docs/conf/portland/2024/news/announcing-writing-day-projects.rst
+++ b/docs/conf/portland/2024/news/announcing-writing-day-projects.rst
@@ -1,0 +1,77 @@
+:template: {{year}}/generic.html
+:og:image: /_static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
+
+.. post:: Apr 4, 2024
+   :tags: {{shortcode}}-{{year}}, writing day, projects, oss projects
+
+Meet the first 5 Writing Day 2024 Projects
+==========================================
+
+Who's ready for Writing Day?! I know of at least 5 project organizers who are so ready they submitted their project to us pre-conference. In honor of their awesome prep, I'm going to give you a sneak peak of the projects list so you can get pumped for Writing Day.
+
+Didn't have a moment to submit your project early? Fear not, you can `submit it at any time <https://www.writethedocs.org/conf/portland/2024/writing-day/#call-for-project-submissions>`__ between now and April 13 or you can bring it and submit it live during Writing Day. Day of project submissions are a time honored WTD tradition that we look forward to seeing continue.
+
+Get excited, get delighted, and get ready to meet our first **5 Writing Day projects** for Write the Docs Portland 2024:
+
+Docs as Tests & Doc Detective: Help us test your docs!
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Returning to us for their second Writing Day is Doc Detective with organizer Manny Silva, he/him. 
+
+"Does your project or product have a UI? APIs? SDKs? We can help you test them and keep your docs accurate." Check out their `project listing <https://www.writethedocs.org/conf/portland/2024/writing-day/#docs-as-tests-doc-detective-help-us-test-your-docs>`__ for more details.
+
+Mutual Aid for Tech Writer/Documentarian Job Hunters
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+They are joined by another fantastic returning project coordinated by Kenzie Woodbridge, they/them. Kenzie has hosted this `Writing Day session <https://www.writethedocs.org/conf/portland/2024/writing-day/#mutual-aid-for-tech-writer-documentarian-job-hunters>`__ at multiple Write the Docs conferences and we are absolutely thrilled that they continue to host it.
+
+"Let's get together and offer each other feedback on the important documentation we're using to move our careers forward."
+
+Meet the new GitBook (Sponsor)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Long time sponsor but first time submitter to Writing Day, swing by to `Meet the new GitBook <https://www.writethedocs.org/conf/portland/2024/writing-day/#meet-the-new-gitbook-sponsor>`__ and give a wave to Addison Schultz, he/him.
+
+"Our Writing Day goal is to teach you how to use your team's internal knowledge to the fullest."
+
+That's not all, GitBook's Writing Day activities include 3 challenges. Completing each challenge gets you a raffle ticket for a sweet swag box.
+
+Use OpenAPI with the Museum API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you're an API enthusiast or want to be, find Heather Cloward, she/her, and check out the `Museum API <https://www.writethedocs.org/conf/portland/2024/writing-day/#use-openapi-with-the-museum-api>`__ project. The Museum API was built by our sponsor, Redocly, for educational purposes.
+
+"Our Writing Day goal is to onboard contributors and improve the Museum API definition... The Museum API was built specifically to teach OpenAPI concepts and to create a better developer experience. The more realistic and complex the Museum API is, the better it can demonstrate all that OpenAPI has to offer."
+
+Write the Docs Documentation Salary Survey
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Have you ever wanted to edit or suggest a question for the `WTD Documentation Salary Survey <https://www.writethedocs.org/conf/portland/2024/writing-day/#write-the-docs-documentation-salary-survey>`__? It is finally your moment!
+
+Join project organizer Kay Smoljak, she/her, for an afternoon only session focused on updating the salary survey.
+
+"Our Writing Day goal is to improve the clarity, inclusivity, neutrality, and relevance of the questions, the instructions, and the general flow of the survey... Everyone who works in documentation is a subject matter expert on this topic, and we want your ideas on how to make the survey better benefit the community as a whole." 
+
+Tabletop Game Rules Writing Workshop
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For those crafting tabletop games and their rulebooks, `this session <https://www.writethedocs.org/conf/portland/2024/writing-day/#tabletop-game-rules-writing-workshop>`__ is for you. Ryan Macklin, he/they, invites you to bring your enthusiasm and your own work-in-progress rules documents.
+
+"Tabletop game rules are a neat and weird form of technical documentation!"
+
+Reminder for attendees, this is not a game design or playtesting session. It is purely a session about helping one another with the difficult task of rules writing.
+
+See you at Writing Day!
+^^^^^^^^^^^^^^^^^^^^^^^
+
+There you have it folks, the first 5 Writing Day projects in all of their glory!
+
+Remember, you can still `submit a project <https://www.writethedocs.org/conf/portland/2024/writing-day/#call-for-project-submissions>`__ before Writing Day and get it live on our `Project List <https://www.writethedocs.org/conf/portland/2024/writing-day/#project-list>`__ or surprise us day of with an onsite submission.
+
+No matter when you sign up, you are welcome here.
+
+With excitement, delightment, and enthusiam,
+
+Rose Williams 
+Writing Day Coordinator
+Write the Docs 2024

--- a/docs/conf/portland/2024/news/announcing-writing-day-projects.rst
+++ b/docs/conf/portland/2024/news/announcing-writing-day-projects.rst
@@ -9,7 +9,7 @@ Meet the first 5 Writing Day 2024 Projects
 
 Who's ready for Writing Day?! I know of at least 5 project organizers who are so ready they submitted their project to us pre-conference. In honor of their awesome prep, I'm going to give you a sneak peak of the projects list so you can get pumped for Writing Day.
 
-Didn't have a moment to submit your project early? Fear not, you can `submit it at any time <https://www.writethedocs.org/conf/portland/2024/writing-day/#call-for-project-submissions>`__ between now and April 13 or you can bring it and submit it live during Writing Day. Day of project submissions are a time honored WTD tradition that we look forward to seeing continue.
+Didn't have a moment to submit your project early? Fear not, you can `submit it at any time <https://www.writethedocs.org/conf/portland/2024/writing-day/#call-for-project-submissions>`__ between now and April 12 or you can bring it and submit it live during Writing Day. Day of project submissions are a time honored WTD tradition that we look forward to seeing continue.
 
 Get excited, get delighted, and get ready to meet our first **5 Writing Day projects** for Write the Docs Portland 2024:
 

--- a/docs/conf/portland/2024/news/announcing-writing-day-projects.rst
+++ b/docs/conf/portland/2024/news/announcing-writing-day-projects.rst
@@ -1,7 +1,7 @@
 :template: {{year}}/generic.html
 :og:image: /_static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
 
-.. post:: Apr 4, 2024
+.. post:: Apr 3, 2024
    :tags: {{shortcode}}-{{year}}, writing day, projects, oss projects
 
 Meet the first 5 Writing Day 2024 Projects

--- a/docs/conf/portland/2024/news/announcing-writing-day-projects.rst
+++ b/docs/conf/portland/2024/news/announcing-writing-day-projects.rst
@@ -70,7 +70,7 @@ Remember, you can still `submit a project <https://www.writethedocs.org/conf/por
 
 No matter when you sign up, you are welcome here.
 
-With excitement, delightment, and enthusiam,
+With excitement, delightment, and enthusiasm,
 
 Rose Williams 
 Writing Day Coordinator

--- a/docs/conf/portland/2024/news/announcing-writing-day-projects.rst
+++ b/docs/conf/portland/2024/news/announcing-writing-day-projects.rst
@@ -16,21 +16,21 @@ Get excited, get delighted, and get ready to meet our first **5 Writing Day proj
 Docs as Tests & Doc Detective: Help us test your docs!
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Returning to us for their second Writing Day is Doc Detective with organizer Manny Silva, he/him. 
+Returning to us for their second Writing Day is Doc Detective with organizer Manny Silva (he/him). 
 
 "Does your project or product have a UI? APIs? SDKs? We can help you test them and keep your docs accurate." Check out their `project listing <https://www.writethedocs.org/conf/portland/2024/writing-day/#docs-as-tests-doc-detective-help-us-test-your-docs>`__ for more details.
 
 Mutual Aid for Tech Writer/Documentarian Job Hunters
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-They are joined by another fantastic returning project coordinated by Kenzie Woodbridge, they/them. Kenzie has hosted this `Writing Day session <https://www.writethedocs.org/conf/portland/2024/writing-day/#mutual-aid-for-tech-writer-documentarian-job-hunters>`__ at multiple Write the Docs conferences and we are absolutely thrilled that they continue to host it.
+They are joined by another fantastic returning project coordinated by Kenzie Woodbridge (they/them). Kenzie has hosted this `Writing Day session <https://www.writethedocs.org/conf/portland/2024/writing-day/#mutual-aid-for-tech-writer-documentarian-job-hunters>`__ at multiple Write the Docs conferences and we are absolutely thrilled that they continue to host it.
 
 "Let's get together and offer each other feedback on the important documentation we're using to move our careers forward."
 
 Meet the new GitBook (Sponsor)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Long time sponsor but first time submitter to Writing Day, swing by to `Meet the new GitBook <https://www.writethedocs.org/conf/portland/2024/writing-day/#meet-the-new-gitbook-sponsor>`__ and give a wave to Addison Schultz, he/him.
+Long time sponsor but first time submitter to Writing Day, swing by to `Meet the new GitBook <https://www.writethedocs.org/conf/portland/2024/writing-day/#meet-the-new-gitbook-sponsor>`__ and give a wave to Addison Schultz (he/him).
 
 "Our Writing Day goal is to teach you how to use your team's internal knowledge to the fullest."
 
@@ -39,7 +39,7 @@ That's not all, GitBook's Writing Day activities include 3 challenges. Completin
 Use OpenAPI with the Museum API
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you're an API enthusiast or want to be, find Heather Cloward, she/her, and check out the `Museum API <https://www.writethedocs.org/conf/portland/2024/writing-day/#use-openapi-with-the-museum-api>`__ project. The Museum API was built by our sponsor, Redocly, for educational purposes.
+If you're an API enthusiast or want to be, find Heather Cloward (she/her), and check out the `Museum API <https://www.writethedocs.org/conf/portland/2024/writing-day/#use-openapi-with-the-museum-api>`__ project. The Museum API was built by our sponsor, Redocly, for educational purposes.
 
 "Our Writing Day goal is to onboard contributors and improve the Museum API definition... The Museum API was built specifically to teach OpenAPI concepts and to create a better developer experience. The more realistic and complex the Museum API is, the better it can demonstrate all that OpenAPI has to offer."
 
@@ -48,14 +48,16 @@ Write the Docs Documentation Salary Survey
 
 Have you ever wanted to edit or suggest a question for the `WTD Documentation Salary Survey <https://www.writethedocs.org/conf/portland/2024/writing-day/#write-the-docs-documentation-salary-survey>`__? It is finally your moment!
 
-Join project organizer Kay Smoljak, she/her, for an afternoon only session focused on updating the salary survey.
+Join project organizer Kay Smoljak (she/her), for an afternoon only session focused on updating the salary survey.
 
-"Our Writing Day goal is to improve the clarity, inclusivity, neutrality, and relevance of the questions, the instructions, and the general flow of the survey... Everyone who works in documentation is a subject matter expert on this topic, and we want your ideas on how to make the survey better benefit the community as a whole." 
+"Our Writing Day goal is to improve the clarity, inclusivity, neutrality, and relevance of the questions, the instructions, and the flow of the survey.
+
+Everyone who works in documentation is a subject matter expert on this topic, and we want your ideas on how to make the survey better benefit the community as a whole." 
 
 Tabletop Game Rules Writing Workshop
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-For those crafting tabletop games and their rulebooks, `this session <https://www.writethedocs.org/conf/portland/2024/writing-day/#tabletop-game-rules-writing-workshop>`__ is for you. Ryan Macklin, he/they, invites you to bring your enthusiasm and your own work-in-progress rules documents.
+For those crafting tabletop games and their rulebooks, `this session <https://www.writethedocs.org/conf/portland/2024/writing-day/#tabletop-game-rules-writing-workshop>`__ is for you. Ryan Macklin (he/they), invites you to bring your enthusiasm and your own work-in-progress rules documents.
 
 "Tabletop game rules are a neat and weird form of technical documentation!"
 

--- a/docs/conf/portland/2024/news/announcing-writing-day-projects.rst
+++ b/docs/conf/portland/2024/news/announcing-writing-day-projects.rst
@@ -4,14 +4,18 @@
 .. post:: Apr 3, 2024
    :tags: {{shortcode}}-{{year}}, writing day, projects, oss projects
 
-Meet the first 5 Writing Day 2024 Projects
+Meet the first Writing Day 2024 Projects
 ==========================================
 
-Who's ready for Writing Day?! I know of at least 5 project organizers who are so ready they submitted their project to us pre-conference. In honor of their awesome prep, I'm going to give you a sneak peak of the projects list so you can get pumped for Writing Day.
+Who's ready for Writing Day?! I know of at least six project organizers who are so ready they submitted their project to us pre-conference. In honor of their awesome prep, I'm going to give you a sneak peak of the projects list so you can get pumped for Writing Day.
 
 Didn't have a moment to submit your project early? Fear not, you can `submit it at any time <https://www.writethedocs.org/conf/portland/2024/writing-day/#call-for-project-submissions>`__ between now and April 12 or you can bring it and submit it live during Writing Day. Day of project submissions are a time honored WTD tradition that we look forward to seeing continue.
 
-Get excited, get delighted, and get ready to meet our first **5 Writing Day projects** for Write the Docs Portland 2024:
+Get excited, get delighted, and get ready to meet our first **Writing Day projects** for Write the Docs Portland 2024:
+
+.. contents::
+   :depth: 2
+   :local:
 
 Docs as Tests & Doc Detective: Help us test your docs!
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -66,7 +70,7 @@ Reminder for attendees, this is not a game design or playtesting session. It is 
 See you at Writing Day!
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-There you have it folks, the first 5 Writing Day projects in all of their glory!
+There you have it folks, the first Writing Day projects in all of their glory!
 
 Remember, you can still `submit a project <https://www.writethedocs.org/conf/portland/2024/writing-day/#call-for-project-submissions>`__ before Writing Day and get it live on our `Project List <https://www.writethedocs.org/conf/portland/2024/writing-day/#project-list>`__ or surprise us day of with an onsite submission.
 


### PR DESCRIPTION
I was trying to thread the fine line between conversational announcements, plus invitation to continue submissions, and overall enthusiasm. Feedback welcome, I will do my best to apply edits and suggestions ASAP so we can get this queued for tomorrow and attached to the social media.

<!-- readthedocs-preview writethedocs-www start -->
----
Direct preview link: https://writethedocs-www--2126.org.readthedocs.build/conf/portland/2024/news/announcing-writing-day-projects/

📚 Documentation preview 📚: https://writethedocs-www--2126.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->