### PR TITLE
Add Atlantic 2024 CFP/ticket reminder

### DIFF
--- a/docs/conf/atlantic/2024/news/cfp-reminder.rst
+++ b/docs/conf/atlantic/2024/news/cfp-reminder.rst
@@ -1,0 +1,44 @@
+:template: {{year}}/generic.html
+
+.. post:: May 2nd, 2024
+   :tags: {{shortcode}}-{{year}}, website, cfp, tickets
+
+Call for Proposals Reminder
+===========================
+
+Greetings, documentarians! Just a reminder that the `Call for Proposals <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/cfp/>`_ will close at **Midnight {{tz}} on {{cfp.ends}}.**
+
+If there is something you’d really like to see a talk about this year, submit a proposal for it or refer someone else who would be good!
+And if you already have an idea but you’re having a hard time getting your proposal to come together, you can always ask for feedback on the `Write the Docs Slack <https://www.writethedocs.org/slack/>`_. The community is there to help!
+Our CFP page also has helpful tips on how to write a proposal.
+
+We’ll then be reviewing all the talk proposals, and will be contacting everyone who submitted a proposal by **{{ cfp.notification }}**.
+
+Get your ticket for the conference
+-----------------------------------
+
+**The Atlantic conference will be held online on {{ date.short }}.** The `full event website <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/>`_ is live, with some preliminary details, and we'll be filling in more as it gets closer.
+
+Tickets are already on sale, so go ahead and `register for your ticket now <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/>`_!
+
+Grant program
+-------------
+
+If the cost of our tickets is prohibitive to you, you can apply to our Opportunity Grant program.
+As a virtual event, we're excited to be able to offer free tickets to a larger number of people, since there are now minimal other costs to attend the event.
+
+You can apply until **{{ grants.ends }}** on `our website <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/opportunity-grants/>`_.
+
+Support our community by sponsoring
+-----------------------------------
+
+Every year we are fortunate to have the support of like-minded organizations and communities, who believe in the collaborative and welcoming community spirit and help us make our events great.
+
+We have published our `virtual sponsorship prospectus`_ for the conference,
+and are open for new sponsorship inquiries.
+
+.. _virtual sponsorship prospectus: https://www.writethedocs.org/conf/atlantic/{{year}}/sponsors/prospectus/
+
+Looking forward to seeing you all in our virtual space!
+
+The Write the Docs Team

--- a/docs/conf/atlantic/2024/news/cfp-reminder.rst
+++ b/docs/conf/atlantic/2024/news/cfp-reminder.rst
@@ -34,10 +34,10 @@ Support our community by sponsoring
 
 Every year we are fortunate to have the support of like-minded organizations and communities, who believe in the collaborative and welcoming community spirit and help us make our events great.
 
-We have published our `virtual sponsorship prospectus`_ for the conference,
+We have published our `virtual conference sponsorship prospectus`_ for the conference,
 and are open for new sponsorship inquiries.
 
-.. _virtual sponsorship prospectus: https://www.writethedocs.org/conf/atlantic/{{year}}/sponsors/prospectus/
+.. _virtual conference sponsorship prospectus: https://www.writethedocs.org/conf/atlantic/{{year}}/sponsors/prospectus/
 
 Looking forward to seeing you all in our virtual space!
 


### PR DESCRIPTION
Preview: https://writethedocs-www--2138.org.readthedocs.build/conf/atlantic/2024/news/cfp-reminder/

Social/slack announcement draft:
> Reminder: the Call for Proposals for Write the Docs Atlantic closes in less than two weeks. Submit your proposal before May 15th. See our CFP page for details and helpful tips: https://www.writethedocs.org/conf/atlantic/2024/cfp/