### PR TITLE
RST syntax error

### DIFF
--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -237,7 +237,7 @@ Please be mindful with the following behaviors:
 - **Honor the community's trust and confidence.**
   In the Write the Docs Slack, we are privileged to be able to discuss complex or sensitive situations with other docs practitioners.
   But those discussions can only happen in an environment of discretion and trust.
-  The Chatham House Rule <https://www.chathamhouse.org/about-us/chatham-house-rule>`_ applies: you're welcome to use the information shared, but never reveal names, job titles, employers, or other identifying information about other participants outside of Slack, unless you've received their explicit permission to do so.
+  The Chatham House Rule `<https://www.chathamhouse.org/about-us/chatham-house-rule>`_ applies: you're welcome to use the information shared, but never reveal names, job titles, employers, or other identifying information about other participants outside of Slack, unless you've received their explicit permission to do so.
 
 Posting rules
 ~~~~~~~~~~~~~

--- a/docs/slack.rst
+++ b/docs/slack.rst
@@ -237,7 +237,7 @@ Please be mindful with the following behaviors:
 - **Honor the community's trust and confidence.**
   In the Write the Docs Slack, we are privileged to be able to discuss complex or sensitive situations with other docs practitioners.
   But those discussions can only happen in an environment of discretion and trust.
-  The Chatham House Rule `<https://www.chathamhouse.org/about-us/chatham-house-rule>`_ applies: you're welcome to use the information shared, but never reveal names, job titles, employers, or other identifying information about other participants outside of Slack, unless you've received their explicit permission to do so.
+  The `Chatham House Rule <https://www.chathamhouse.org/about-us/chatham-house-rule>`_ applies: you're welcome to use the information shared, but never reveal names, job titles, employers, or other identifying information about other participants outside of Slack, unless you've received their explicit permission to do so.
 
 Posting rules
 ~~~~~~~~~~~~~


### PR DESCRIPTION
Pay no attention to the backtick that was not behind the curtain

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2142.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->