### PR TITLE
Update codespell action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,8 +84,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: codespell-project/codespell-problem-matcher@v1
-      - uses: codespell-project/actions-codespell@v1
+      - uses: codespell-project/codespell-problem-matcher@v2
+      - uses: codespell-project/actions-codespell@v2
         name: Check spelling
         with:
           skip: "*.pdf,*.svg,*.js,*.map,*.css,*.scss,docs/_data/201[5|6|7]*,docs/_static_html/*"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -84,7 +84,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: codespell-project/codespell-problem-matcher@v2
       - uses: codespell-project/actions-codespell@v2
         name: Check spelling
         with:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,8 @@ We have in-person and virtual conferences around the world:
 
 See all :doc:`our conferences </conf/index>` from past years.
 
+Conect
+
 Connect with the community
 --------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,8 +26,6 @@ We have in-person and virtual conferences around the world:
 
 See all :doc:`our conferences </conf/index>` from past years.
 
-Conect
-
 Connect with the community
 --------------------------
 


### PR DESCRIPTION
I don't entirely trust this. Locally with the same options I get

```sh
codespell --skip '*.pdf,*.svg,*.js,*.map,*.css,*.scss,docs/_data/201[5|6|7]*,docs/_static_html/*' --ignore-words codespell/ignore.txt docs
docs/include/conf/australia/visiting.rst:12: DiDi ==> did
docs/include/conf/australia/visiting.rst:45: DiDi ==> did
docs/include/conf/australia/visiting.rst:53: DiDi ==> did
docs/include/conf/australia/visiting.rst:53: DiDi ==> did
```

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2181.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->