### PR TITLE
heading updates to main software documentation page

### DIFF
--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -65,7 +65,7 @@ Documentation tools
 .. _api-documentation:
 
 How to write API documentation
------------------
+------------------------------
 
 .. toctree::
    :maxdepth: 2

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -6,8 +6,8 @@ Since then, the focus and community of Write the Docs has expanded.
 
 **This is a living, breathing guide.** If you'd like to contribute, take a look at the :doc:`guidelines for contributing to the guide <contributing>`. 
 
-New to documentation?
----------------------
+How to start writing technical documentation
+---------------------------------------------
 
 .. toctree::
    :maxdepth: 2
@@ -19,8 +19,8 @@ New to documentation?
    imposter
 
 
-Resources for documentarians
--------------------------------
+Resources for creating documentation
+-------------------------------------
 
 .. toctree::
    :maxdepth: 2
@@ -52,8 +52,8 @@ Markup languages
    writing/xml
    writing/asciidoc
 
-Tools of the trade
-------------------
+Documentation tools
+--------------------
 
 .. toctree::
    :maxdepth: 2

--- a/docs/guide/index.rst
+++ b/docs/guide/index.rst
@@ -41,8 +41,8 @@ Approaches to creating documentation
    doc-ops
 
 
-Markup languages
-----------------
+Understanding markup languages
+-------------------------------
 
 .. toctree::
    :maxdepth: 2
@@ -64,7 +64,7 @@ Documentation tools
 
 .. _api-documentation:
 
-API documentation
+How to write API documentation
 -----------------
 
 .. toctree::
@@ -72,8 +72,8 @@ API documentation
 
    api/api-documentation-tools
 
-Contribution information
-------------------------
+Contributing to Write the Docs
+-------------------------------
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
These updates should make it more obvious at a glance what to expect in each section and improve SEO. They also get rid of the "tools of the trade" idiom.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2183.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->