### PR TITLE
Clarify the purpose of starting.rst

### DIFF
--- a/docs/guide/starting.rst
+++ b/docs/guide/starting.rst
@@ -1,42 +1,31 @@
-============
-Starting off
-============
+=======================================================================
+Starting off: documentation best practices for developers
+=======================================================================
 
-So, you want to write the docs for your project?
+Want to write the docs for your project?
+You've come to the write [sic] place.
 
-    *Where on earth do I start?*
-
-Well, you've come to the write [sic] place.
-
-The goal here is to explain how to write docs,
-how to get the time to write docs,
-and what you should be striving for with those docs.
-A lot of projects are different, and a lot are the same.
-We will be covering the tactics for a few different groups.
+Developers need to write documentation for many situations.
+This guide leads you to relevant writing tactics for several situations. 
 
 Open source developers
 ----------------------
 
-You have some awesome open source code, but nobody knows how to use it.
-The chance of someone discovering and using your awesome code goes up
-greatly with good documentation.
+You have awesome open-source code, but do people know how to use it?
+Good documentation improves the chance of someone discovering and using your code.
 
-Start with the :doc:`writing/beginners-guide-to-docs`,
-which provides practical advice on getting started.
-
+If you are an open-source developer, start with :doc:`writing/beginners-guide-to-docs`,
+for practical advice on getting started.
 
 Developers at a company
 -----------------------
 
-You need help justifying writing documentation for your project.
-It seems the timelines you're given hardly allow any time to write tests,
-and docs always get put off until the end.
-Well, here are some ways that you can show value to your boss,
-and hopefully get the time to write the docs.
+How do you justify writing documentation for your project?
+Your deadlines hardly allow time to write tests,
+and docs are always delayed until the end.
 
-Get started with :doc:`writing/mindshare`,
-which should give you a blueprint for how you can implement a documentation
-solution in your company.
+To show the value of documentation to your boss, see :doc:`writing/mindshare`
+for a blueprint on implementing a documentation solution at your company.
 
 Enterprise users
 ----------------

--- a/docs/guide/starting.rst
+++ b/docs/guide/starting.rst
@@ -1,5 +1,5 @@
 =======================================================================
-Starting off: documentation best practices for developers
+Getting started: documentation best practices for developers
 =======================================================================
 
 Are you a developer who wants to write the docs for your project?

--- a/docs/guide/starting.rst
+++ b/docs/guide/starting.rst
@@ -2,11 +2,10 @@
 Starting off: documentation best practices for developers
 =======================================================================
 
-Want to write the docs for your project?
+Are you a developer who wants to write the docs for your project?
 You've come to the *write* place.
 
-Developers need to write documentation for many situations.
-This guide leads you to relevant documentation tactics for several situations. 
+Use this guide to find relevant documentation best practices depending on your situation. 
 
 Writing documentation as an open-source developer
 -------------------------------------------------

--- a/docs/guide/starting.rst
+++ b/docs/guide/starting.rst
@@ -6,37 +6,23 @@ Want to write the docs for your project?
 You've come to the write [sic] place.
 
 Developers need to write documentation for many situations.
-This guide leads you to relevant writing tactics for several situations. 
+This guide leads you to relevant documentation tactics for several situations. 
 
-Open source developers
-----------------------
+Writing documentation as an open-source developer
+-------------------------------------------------
 
 You have awesome open-source code, but do people know how to use it?
 Good documentation improves the chance of someone discovering and using your code.
 
-If you are an open-source developer, start with :doc:`writing/beginners-guide-to-docs`,
+If you are an open-source developer, see :doc:`writing/beginners-guide-to-docs`,
 for practical advice on getting started.
 
-Developers at a company
------------------------
+Justifying documentation as a developer at a company
+----------------------------------------------------
 
 How do you justify writing documentation for your project?
 Your deadlines hardly allow time to write tests,
 and docs are always delayed until the end.
 
-To show the value of documentation to your boss, see :doc:`writing/mindshare`
-for a blueprint on implementing a documentation solution at your company.
-
-Enterprise users
-----------------
-
-You are a SAAS or Services company and you have developers as your target
-audience.
-If you don't have great documentation,
-your competitors will leave you in the dust.
-It will also jack up your support costs,
-because customers can't help themselves.
-
-This page of :ref:`interesting-approaches` is a good starting point to see
-some documentation that is well done.
-
+To show the value of documentation to your boss and get a blueprint for 
+implementing a documentation solution at your company, see :doc:`writing/mindshare`.

--- a/docs/guide/starting.rst
+++ b/docs/guide/starting.rst
@@ -3,7 +3,7 @@ Starting off: documentation best practices for developers
 =======================================================================
 
 Want to write the docs for your project?
-You've come to the write [sic] place.
+You've come to the *write* place.
 
 Developers need to write documentation for many situations.
 This guide leads you to relevant documentation tactics for several situations. 


### PR DESCRIPTION
We have several confusing pathways into multiple "getting started" types of content. Looking at the main software documentation landing page or knowing where to click from a search becomes confusing. I tried cleaning up this content and giving it a purpose, but there really looks to be only two valid scenarios the doc presents (the enterprise users section doesn't count because it links to the "interesting approaches" content instead of an actionable guide related to the topic of enterprise users.

Overall, this page may not be tangible in any meaningful way, so just wanted to hear other's thoughts...should we just delete or archive this content