### PR TITLE
Writing Day blog post and content updates

### DIFF
--- a/docs/conf/atlantic/2024/convince-your-manager.rst
+++ b/docs/conf/atlantic/2024/convince-your-manager.rst
@@ -1,14 +1,17 @@
 :template: {{year}}/generic.html
 
+Convince Your Organization
+==========================
+
 Convince Your Manager
-=====================
+---------------------
 
 Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 
 Sample email
--------------
+^^^^^^^^^^^^^
 
 Remember to change the things in `[brackets]`!
 
@@ -20,12 +23,12 @@ Remember to change the things in `[brackets]`!
 
   SUBJECT: Professional Development: Documentation Community Conference
 
-  I'd like to attend Write the Docs {{city}}, which takes place {{ date.main }}. This three-day online event explores the art and science of documentation, and covers a diverse range of topics related to documentation in the software industry.
+  I'd like to attend Write the Docs {{city}}, which takes place {{ date.main }}. This three-day event explores the art and science of documentation, and covers a diverse range of topics related to documentation in the software industry.
 
   Write the Docs conferences bring together everyone who writes the docs – Tech Writers, Developers, Developer Relations, Customer Support – making the events an ideal networking opportunity.
   Each conference successfully combines a number of different event formats to deliver engaging, practical, and timely content.
 
-  There is a single track of talks, a parallel unconference event, and a community writing day. The `sessions from last year </conf/prague/2022/speakers/>`_ will give you a good idea of the kinds of topics covered, many of which are relevant to my work.
+  There is a single track of talks, a parallel unconference event, and a community writing day. The `sessions from last year </conf/{{ shortcode }}/{{year-1}}/speakers/>`_ will give you a good idea of the kinds of topics covered, many of which are relevant to my work.
 
   Costs:
 
@@ -43,8 +46,8 @@ Remember to change the things in `[brackets]`!
 
 ----
 
-Resources
----------
+Corporate Resources
+^^^^^^^^^^^^^^^^^^^
 
 When discussing how to pitch the conference, a few generally helpful tips emerged:
 
@@ -52,6 +55,84 @@ When discussing how to pitch the conference, a few generally helpful tips emerge
 * If your company is looking to hire another documentarian, the job fair and networking at the event are an excellent resource.
 * Don't forget that one of the benefits to your attendance is that it raises the visibility of your company in the community. If your team wants a reputation for caring about their docs, having people at Write the Docs is a great way to do that.
 
-In addition, it can be useful to share some info about previous conferences. You can find the websites for previous events on :doc:`/conf/index/`, and a quick list of last year's talks down below.
-But perhaps more useful might be some of the info in our :doc:`press-kit/`, which includes community testimonials, photos, and more.
+In addition, it can be useful to share some info about previous conferences. View the `main page overview </conf/{{shortcode}}/{{year}}/#schedule-overview>`_ explaining what is Write the Docs, history and schedule overview.
 
+Convince Your Community
+-----------------------
+
+Do you need help justifying why your community or employer should attend Write the Docs 
+and bring their project to Writing Day? 
+
+Don't worry, you're not alone. Based on the experiences of some of our previous attendees, 
+we've put together a sample email and list of resources below.
+
+Feel free to adapt and share with your community or employer to show them the many benefits of attending!
+
+Sample email
+^^^^^^^^^^^^
+
+Remember to change the things in `[brackets]`! You can edit this to work for more casual communication
+methods, such as Slack, Discord, etc.
+
+----
+
+  FROM: [your name]
+
+  TO: [your employer or community lead's name]
+
+  SUBJECT: Docs hackathon: Documentation Community Conference
+
+  I'd like to attend Write the Docs {{city}}, which takes place {{ date.main }}. This three-day 
+  event explores the art and science of documentation, and covers a diverse range of topics 
+  related to documentation in the software industry. I am particularly interested in Writing Day, 
+  I believe this event can positively impact our project and community.
+  
+  Writing Day is a community event modeled after the concept of “code sprints” or “hackathons”, 
+  which are common in open-source conferences. The idea is to get a bunch of people together 
+  and have them work towards a shared goal, in this case the goal is creating or improving 
+  documentation or other related projects.
+
+  Costs:
+
+  * Conference ticket
+
+  Writing Day Benefits:
+
+  * Introduce our project and community to a new audience and demographic in our industry
+  * Get highlighted as a project in the conference blog and announcements
+  * Onboard documentation enthusiasts to increase the likelihood of post-conference contributions
+  * Strategically tackle documentation tickets and requests
+  * Update existing documentation
+  * Peer review new and existing documentation
+
+  Conference Benefits:
+
+  * Exposure to the latest ideas, techniques, and tools for software docs
+  * Opportunity to learn from the best doc teams in the industry
+  * Building professional connections with other documentarians
+
+Bringing our project to Writing Day benefits us as a community. It gives us the opportunity to 
+improve our documentation and create a more inclusive project.
+
+  Thanks in advance,
+  [your name]
+
+----
+
+Writing Day Resources
+^^^^^^^^^^^^^^^^^^^^^
+
+When discussing how to pitch Writing Day, a few helpful tips emerged:
+
+* Highlight a few specific projects that attended a previous Writing Day, such as `Writing Day, Portland 2023 <https://www.writethedocs.org/conf/portland/2023/writing-day/#project-listing>`_. 
+* If your community is looking for regular documentation contributions, Writing Day 
+  is a great place to onboard potential contributors and editors.
+* Don't forget that one of the benefits to your attendance is that it raises the 
+  visibility of your community and/or company in the Write the Docs community. 
+  If your project wants a reputation for caring about their docs, having people 
+  at Write the Docs is a great way to do that.
+
+You may find it useful to review the `tips and tricks for leading a project <https://www.writethedocs.org/conf/atlantic/2024/writing-day/#lead-a-project>`_ at Writing Day.
+
+In addition, it can be useful to share some info about previous conferences. 
+View the `main page overview </conf/{{shortcode}}/{{year}}/#schedule-overview>`_ explaining what is Write the Docs, history, and schedule overview.

--- a/docs/conf/atlantic/2024/news/writing-day-call-for-projects.rst
+++ b/docs/conf/atlantic/2024/news/writing-day-call-for-projects.rst
@@ -1,0 +1,46 @@
+:template: {{year}}/generic.html
+:og:image: /_static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
+
+.. post:: Aug 10, 2024
+   :tags: {{shortcode}}-{{year}}, writing day, projects, oss projects
+
+Announcing the Writing Day Call for Projects
+============================================
+
+Hey folks! We were so thrilled with your response to Writing Day last year that we are launching 
+a `Call for Projects submission form <https://forms.gle/uTkWHV3fesyNQEyk9>`_!
+
+For projects submitted by Friday, September 6, 2024, we'll highlight your project on our social media, as we learned last year that projects that submit their information before the conference have higher attendance. In fact, perusing project details encourages documentarians to join us earlier, stay longer, and check out multiple projects.
+
+Our attendees are curious and want to know about you, your project, and your community - so 
+let's give the people what they want!
+
+You are of course welcome to submit and announce your project at Writing Day. This is a time honored 
+tradition and we appreciate all of our projects.
+
+Call for Projects
+-----------------
+
+Bringing your project to Writing Day is a wonderful way to introduce your mission and community to 
+Write the Docs attendees.
+
+The Write the Docs conference has many enthusiastic attendees. These attendees, documentarians, want 
+to learn new technologies, sharpen their skills, and add to their portfolios. The world of open 
+source has a seemingly endless number of wonderful open source projects. Documentarians want to write 
+the docs, your open source project docs.
+
+We are looking for community/OSS projects for our virtual Writing Day at the Atlantic conference on 
+September 22.
+
+The `Call for Proposals submission form <https://forms.gle/uTkWHV3fesyNQEyk9>`_ is open until *11:59 PM, September 6, 2024 UTC*.
+
+Writing Day Resources
+^^^^^^^^^^^^^^^^^^^^^
+
+You don't have to be a developer advocate, community manager, or project lead - though you're all 
+welcome. Anyone with enthusiasm for their project and community is welcome to bring it to Writing Day!
+
+If you’re excited about Writing Day and want to lead a project but not sure where to begin, we have `tips and tricks for project leaders <https://www.writethedocs.org/conf/atlantic/{{year}}/writing-day/#lead-a-project>`_ to help maximize your experience. 
+
+If you need additional information to advocate for Writing Day in your community, or help persuading 
+your corporate benefactors on the benefits of attending Writing Day, see the `Convince Your Community <https://www.writethedocs.org/conf/atlantic/{{year}}/convince-day-manager/#convince-your-community>`_ resource.

--- a/docs/conf/atlantic/2024/news/writing-day-call-for-projects.rst
+++ b/docs/conf/atlantic/2024/news/writing-day-call-for-projects.rst
@@ -15,7 +15,7 @@ For projects submitted by Friday, September 6, 2024, we'll highlight your projec
 Our attendees are curious and want to know about you, your project, and your community - so 
 let's give the people what they want!
 
-You are of course welcome to submit and announce your project at Writing Day. This is a time honored 
+You are of course welcome to submit and announce your project at Writing Day. This is a time-honored 
 tradition and we appreciate all of our projects.
 
 Call for Projects
@@ -27,7 +27,7 @@ Write the Docs attendees.
 The Write the Docs conference has many enthusiastic attendees. These attendees, documentarians, want 
 to learn new technologies, sharpen their skills, and add to their portfolios. The world of open 
 source has a seemingly endless number of wonderful open source projects. Documentarians want to write 
-the docs, your open source project docs.
+the docs, e.g., your open source project docs.
 
 We are looking for community/OSS projects for our virtual Writing Day at the Atlantic conference on 
 September 22.

--- a/docs/conf/atlantic/2024/news/writing-day-call-for-projects.rst
+++ b/docs/conf/atlantic/2024/news/writing-day-call-for-projects.rst
@@ -1,7 +1,7 @@
 :template: {{year}}/generic.html
 :og:image: /_static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
 
-.. post:: Aug 10, 2024
+.. post:: Aug 15, 2024
    :tags: {{shortcode}}-{{year}}, writing day, projects, oss projects
 
 Announcing the Writing Day Call for Projects

--- a/docs/conf/atlantic/2024/writing-day-project-faq.rst
+++ b/docs/conf/atlantic/2024/writing-day-project-faq.rst
@@ -1,7 +1,0 @@
-:template: {{year}}/generic.html
-:banner: _static/conf/images/headers/writing-day.png
-
-Writing Day Cheat Sheet
-=======================
-
-{% include "conf/virtual/writing-day-project-faq.rst" %}

--- a/docs/conf/atlantic/2024/writing-day.rst
+++ b/docs/conf/atlantic/2024/writing-day.rst
@@ -4,10 +4,93 @@
 Writing Day
 ===========
 
-{% include "conf/events/writing-day.rst" %}
+What is Writing Day? 
+--------------------
+
+Writing Day is modeled after the concept of "sprints" or “hackathons”, which are common in open-source (OSS) conferences. 
+
+Held on Sunday, the first day of the conference, attendees are encouraged to bring a project or contribute to someone else's project. 
+
+The main goal is to get interesting people in the same room, sharing their passion and goals and collaborating to find creative solutions to solve a problem or issue.
+
+Attendees are invited to submit their project pre-conference! It's a great way to get other attendees excited about contributing.
+
+**There are two main types of Writing Day attendees:**
+
+- Project leads: Attendees bringing ideas, content, or OSS projects to work on with contributors.
+- Contributors: Attendees looking to contribute to various content projects.
+
+**Here are examples of projects that you might see at the conference:**
+
+-  Open-source software documentation
+-  General documentation writing
+-  Best practices manual (for your company, or the world)
+-  Resume, cover letter, and portfolio reviews
+-  Blog posts
+-  Tips and tricks
+-  Great works of fiction
+-  Love letters
+-  The Documentarian Manifesto
+
+If you find specific examples helpful, check out the `Portland Writing Day 2023 project list <https://www.writethedocs.org/conf/portland/2023/writing-day/#project-listing>`_.
+
+
+Lead a Project
+^^^^^^^^^^^^^^
+
+Leading a project at Writing Day is a wonderful opportunity to engage with documentarians from a variety of backgrounds, experience, and expertise. Their collective wealth of experience can help upgrade your documentation and create a more inclusive project. This empowers all of us to work together to create opportunities for each other and bigger, better communities.
+
+
+**Tips to create and lead a new project effectively:** 
+
+-  **Provide a project overview with a specific focus or goals:** Your project overview is a 2 minute pitch that describes your project and clearly defines a focus area or goal. Here’s a good example from Writing Day 2022, the `Open Web Docs project <https://www.writethedocs.org/conf/portland/2022/writing-day/#open-web-docs>`_.
+-  **Pre-label tasks and issues:** Create a specific event label and label documentation tasks and issues. This empowers new contributors to find tasks that interest them.
+-  **Create a task filter:** This  helps contributors find issues more easily and see which issues have been assigned.
+-  **Clear onboarding:** Ensure your ReadMe, contribution guidelines, or onboarding instructions are accurate and up to date.
+-  **Submit your Writing Day Project:** Adding your project to the Writing Day project list promotes your project to our attendees before the event. Many attendees have told us that their curiosity about certain projects incentivised their attendance.
+-  **Project Experts:** We recommend having 1-2 project experts on your project. We love our developer advocates, community managers, and subject matter experts! You’re welcome to call for virtual reinforcements from your community as well.
+-  **Flexibility and Understanding:** Reminder that attendees may need additional info to be successful in onboarding to your project.
+
+These are suggestions and not requirements. It is perfectly valid to show up to Writing Day, tell us about your project day of, and ask for volunteers! It’s been done before and it will be done again.
+
+
+Contribute to a Project
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Writing Day is the perfect opportunity to learn about new projects and technologies. Some attendees stay at one table all day, others table hop. Do what feels right to you.
+
+Check out the project list! Keep in mind that some attendees choose to announce their projects during Writing Day and the information is not available on the project list.
+
+**Tips to contribute to a project:**
+
+-  **No matter your experience level, you are welcome!** We are glad you’re here. Even if you `feel <http://en.wikipedia.org/wiki/Impostor_syndrome>`__ as though you don't have the right skills or experience or have never attended an event like Writing Day before, you’ll be surprised how much you can share.
+-  **Check out our guide to writing documentation.** Our `beginners guide <https://www.writethedocs.org/guide/writing/beginners-guide-to-docs/>`_ will help you get started, and give you some ideas for how you can contribute to a project.
+-  **Ask people for help if you have a question.** If at any time you get stuck with new concepts and tools, you are in a room full of friendly people from diverse backgrounds and experiences.  If you are not sure who to ask, ask the Welcome Wagon or Registration staff or volunteers. We will help you find someone!
+
+Logistics
+---------
+
+**Come prepared with the following tools:**
+
+-  Laptop, tablet, or other device 
+-  `GitHub account <https://github.com/>`_ (you may also want a `GitLab account <https://about.gitlab.com/>`_)
+-  Text editor of your choice for coding or content creation
+
+
+Call for Project Submissions
+----------------------------
+
+We strongly recommend that you `submit your Writing Day project in advance <https://forms.gle/uTkWHV3fesyNQEyk9>`__! **Projects submitted by *September 6, 2024* are promoted in our pre-conference Writing Day blog post and email.**
+
+As usual, virtual walk-on projects are always welcome. All attendees always have the option to bring a project, sign up on site, and announce it during Writing Day.
+
+If you need additional information to advocate for Writing Day in your community or organization, see the `Convince Your Community <https://www.writethedocs.org/conf/atlantic/{{year}}/convince-day-manager/#convince-your-community>`_ resource.
 
 Schedule
 --------
+
+Writing Day is an all day event that is designed with flexibility in mind. Feel free to check out as many projects as make sense for you and your schedule!
+
 
 - Date & Time: **{{date.day_two.dotw}}, {{date.day_two.date}}, {{date.day_two.writing_day_time}} {{tz}}**.
 - Location: **{{about.venue}}**.
@@ -15,16 +98,23 @@ Schedule
 Writing Day projects are welcome to join us for the entire event, the first session, or the second session. 
 The first and second session time blocks are separated by a 30 minute snack break.
 
-First session:
+We will do a shared intro session at 10:30 UTC and 14:30 UTC. Project leaders should join the platform early to acclimate to the space and test your audio/video.
+
+Project setup:
+
+* 10:00 UTC to 10:30 UTC
+* 12:00 CEST to 12:30 CEST
+* 06:00 EDT to 06:30 EDT
+
+First session and introductions:
 
 * 10:30 UTC to 14:00 UTC 
 * 12:30 CEST to 16:00 CEST 
 * 06:30 EDT to 10:00 EDT
 
-We will do a shared intro session at 11:00 UTC where projects can pitch their plans.
-If you'd like to pitch a project, please join the platform early to acclimate to the space and test your audio/video.
+Snack break: 14:00 - 14:30 UTC
 
-Second session:
+Second session and announcements:
 
 * 14:30 UTC to 17:00 UTC
 * 16:30 CEST to 19:00 CEST
@@ -33,7 +123,7 @@ Second session:
 Project list
 ------------
 
-Submit your project using our `Writing Day project form <https://forms.gle/B2pWvz9e1igC4cS56>`_ or send us a PR with your project info!
+Submit your project using our `Writing Day project form <https://forms.gle/uTkWHV3fesyNQEyk9>`_ or send us a PR with your project info!
 
 Check out the :doc:`/conf/{{shortcode}}/{{year}}/writing-day-project-faq` to review what information is 
 needed for your project submission as well as ways to maximize your event experience.

--- a/docs/conf/atlantic/2024/writing-day.rst
+++ b/docs/conf/atlantic/2024/writing-day.rst
@@ -15,6 +15,9 @@ The main goal is to get interesting people in the same room, sharing their passi
 
 Attendees are invited to submit their project pre-conference! It's a great way to get other attendees excited about contributing.
 
+Note that a ticket for the conference is required to participate in Writing Day.
+This of course also grants entry to the other two conference days, with talks, unconference sessions and other activities.
+
 **There are two main types of Writing Day attendees:**
 
 - Project leads: Attendees bringing ideas, content, or OSS projects to work on with contributors.

--- a/docs/conf/atlantic/2024/writing-day.rst
+++ b/docs/conf/atlantic/2024/writing-day.rst
@@ -49,7 +49,7 @@ Leading a project at Writing Day is a wonderful opportunity to engage with docum
 -  **Provide a clear onboarding process:** Ensure your ReadMe, contribution guidelines, or onboarding instructions are accurate and up to date.
 -  **Add your project to the Writing Day project list:** Adding your project to the list promotes your project to our attendees before the event. Many attendees have told us that their curiosity about certain projects incentivised their attendance.
 -  **Invite project experts to attend:** We recommend having 1-2 project experts on your project. We love our developer advocates, community managers, and subject matter experts! You’re welcome to call for virtual reinforcements from your community as well.
--  **Practice flexibility and understanding:** Rememember, some attendees may need additional info to successfully onboard to your project.
+-  **Practice flexibility and understanding:** Remember, some attendees may need additional info to successfully onboard to your project.
 
 These are suggestions and not requirements. It is perfectly valid to show up to Writing Day, tell us about your project the day of, and ask for volunteers! It’s been done before and it will be done again.
 

--- a/docs/conf/atlantic/2024/writing-day.rst
+++ b/docs/conf/atlantic/2024/writing-day.rst
@@ -43,27 +43,27 @@ Leading a project at Writing Day is a wonderful opportunity to engage with docum
 
 **Tips to create and lead a new project effectively:** 
 
--  **Provide a project overview with a specific focus or goals:** Your project overview is a 2 minute pitch that describes your project and clearly defines a focus area or goal. Here’s a good example from Writing Day 2022, the `Open Web Docs project <https://www.writethedocs.org/conf/portland/2022/writing-day/#open-web-docs>`_.
+-  **Provide a project overview with a specific focus or goals:** Your project overview is a 2-minute pitch (when read aloud) that describes your project and clearly defines a focus area or goal. Here’s a good example from Writing Day 2022: the `Open Web Docs project <https://www.writethedocs.org/conf/portland/2022/writing-day/#open-web-docs>`_.
 -  **Pre-label tasks and issues:** Create a specific event label and label documentation tasks and issues. This empowers new contributors to find tasks that interest them.
--  **Create a task filter:** This  helps contributors find issues more easily and see which issues have been assigned.
--  **Clear onboarding:** Ensure your ReadMe, contribution guidelines, or onboarding instructions are accurate and up to date.
--  **Submit your Writing Day Project:** Adding your project to the Writing Day project list promotes your project to our attendees before the event. Many attendees have told us that their curiosity about certain projects incentivised their attendance.
--  **Project Experts:** We recommend having 1-2 project experts on your project. We love our developer advocates, community managers, and subject matter experts! You’re welcome to call for virtual reinforcements from your community as well.
--  **Flexibility and Understanding:** Reminder that attendees may need additional info to be successful in onboarding to your project.
+-  **Create a task filter:** This  helps contributors track and find issues more easily and see which issues have already been assigned.
+-  **Provide a clear onboarding process:** Ensure your ReadMe, contribution guidelines, or onboarding instructions are accurate and up to date.
+-  **Add your project to the Writing Day project list:** Adding your project to the list promotes your project to our attendees before the event. Many attendees have told us that their curiosity about certain projects incentivised their attendance.
+-  **Invite project experts to attend:** We recommend having 1-2 project experts on your project. We love our developer advocates, community managers, and subject matter experts! You’re welcome to call for virtual reinforcements from your community as well.
+-  **Practice flexibility and understanding:** Rememember, some attendees may need additional info to successfully onboard to your project.
 
-These are suggestions and not requirements. It is perfectly valid to show up to Writing Day, tell us about your project day of, and ask for volunteers! It’s been done before and it will be done again.
+These are suggestions and not requirements. It is perfectly valid to show up to Writing Day, tell us about your project the day of, and ask for volunteers! It’s been done before and it will be done again.
 
 
 Contribute to a Project
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-Writing Day is the perfect opportunity to learn about new projects and technologies. Some attendees stay at one table all day, others table hop. Do what feels right to you.
+Writing Day is the perfect opportunity to learn about new projects and technologies. Some attendees stay at one table all day, others table-hop. Do what feels right to you.
 
-Check out the project list! Keep in mind that some attendees choose to announce their projects during Writing Day and the information is not available on the project list.
+Check out the project list! Keep in mind that some attendees choose to announce their projects during Writing Day, so their project information would not be available on the project list.
 
 **Tips to contribute to a project:**
 
--  **No matter your experience level, you are welcome!** We are glad you’re here. Even if you `feel <http://en.wikipedia.org/wiki/Impostor_syndrome>`__ as though you don't have the right skills or experience or have never attended an event like Writing Day before, you’ll be surprised how much you can share.
+-  **No matter your experience level, you are welcome!** We are glad you’re here. Even if you `feel <http://en.wikipedia.org/wiki/Impostor_syndrome>`__ you don't have the right skills or experience or have never attended an event like Writing Day before, you’ll be surprised how much you can share.
 -  **Check out our guide to writing documentation.** Our `beginners guide <https://www.writethedocs.org/guide/writing/beginners-guide-to-docs/>`_ will help you get started, and give you some ideas for how you can contribute to a project.
 -  **Ask people for help if you have a question.** If at any time you get stuck with new concepts and tools, you are in a room full of friendly people from diverse backgrounds and experiences.  If you are not sure who to ask, ask the Welcome Wagon or Registration staff or volunteers. We will help you find someone!
 
@@ -82,7 +82,7 @@ Call for Project Submissions
 
 We strongly recommend that you `submit your Writing Day project in advance <https://forms.gle/uTkWHV3fesyNQEyk9>`__! **Projects submitted by *September 6, 2024* are promoted in our pre-conference Writing Day blog post and email.**
 
-As usual, virtual walk-on projects are always welcome. All attendees always have the option to bring a project, sign up on site, and announce it during Writing Day.
+As usual, virtual walk-on projects are always welcome. All attendees always have the option to bring a project, sign up onsite, and announce it during Writing Day.
 
 If you need additional information to advocate for Writing Day in your community or organization, see the `Convince Your Community <https://www.writethedocs.org/conf/atlantic/{{year}}/convince-day-manager/#convince-your-community>`_ resource.
 
@@ -96,9 +96,9 @@ Writing Day is an all day event that is designed with flexibility in mind. Feel 
 - Location: **{{about.venue}}**.
 
 Writing Day projects are welcome to join us for the entire event, the first session, or the second session. 
-The first and second session time blocks are separated by a 30 minute snack break.
+The first and second session time blocks are separated by a 30-minute snack break.
 
-We will do a shared intro session at 10:30 UTC and 14:30 UTC. Project leaders should join the platform early to acclimate to the space and test your audio/video.
+We will do a shared intro session at 10:30 UTC and 14:30 UTC. Project leaders, please join the platform early to acclimate to the space and test your audio/video.
 
 Project setup:
 
@@ -124,6 +124,3 @@ Project list
 ------------
 
 Submit your project using our `Writing Day project form <https://forms.gle/uTkWHV3fesyNQEyk9>`_ or send us a PR with your project info!
-
-Check out the :doc:`/conf/{{shortcode}}/{{year}}/writing-day-project-faq` to review what information is 
-needed for your project submission as well as ways to maximize your event experience.


### PR DESCRIPTION
Created Writing Day blog post: Call for Project submissions.

Updated the following pages to match the content edits made for Portland 2024:

* Writing Day (main page)
* Convince your manager (added Convince your Community section)
* Removed redundant FAQ page (content is now divided between Writing Day landing page and the Cheatsheet

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: 

- Writing Day: https://writethedocs-www--2189.org.readthedocs.build/conf/atlantic/2024/writing-day/
- Convince your manager: https://writethedocs-www--2189.org.readthedocs.build/conf/atlantic/2024/convince-your-manager/
- Blog post: https://writethedocs-www--2189.org.readthedocs.build/conf/atlantic/2024/news/writing-day-call-for-projects/

<!-- readthedocs-preview writethedocs-www end -->