### PR TITLE
WD: WTD Meetup organizer resources proj

### DIFF
--- a/docs/conf/atlantic/2024/writing-day.rst
+++ b/docs/conf/atlantic/2024/writing-day.rst
@@ -127,3 +127,68 @@ Project list
 ------------
 
 Submit your project using our `Writing Day project form <https://forms.gle/uTkWHV3fesyNQEyk9>`_ or send us a PR with your project info!
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+WTD Meetup resources for organizers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Join project organizer, Rose Williams, for the second Writing Day session.
+
+Our goal is to update the content infrastructure, consolidate resources, and add templates to better support Write the Docs Meetup organizers.
+
+Agenda:
+
+- Strategize to create a better content infrastructure for Meetup related pages.
+- Update the `Starting a Meetup <https://www.writethedocs.org/organizer-guide/meetups/starting/>`__ page
+- Update the `Make your Meetups more sustainable <https://www.writethedocs.org/organizer-guide/meetups/sustainable-meetups/>`__
+- Review the `Meetup FAQ <https://www.writethedocs.org/organizer-guide/meetups/faq-meetups/>`__
+
+I recommend contributing to this project using the built in `GitHub web-based editor <https://docs.github.com/en/codespaces/the-githubdev-web-based-editor>`__. Mostly because I am not a Git or GitHub expert.


### PR DESCRIPTION
Atlantic 2024 Writing Day project, WTD Meetup organizer resources.

Steps before publishing:

- [x]  Staff review of project to confirm Writing Day suitability
- [x]  WD project lead/organizer review to ensure project is described properly
- [x]  Final staff review before publishing

Note: This is for the second session only. Since I have the luxury of a second Writing Day coordinator, I wanted to take advantage of that and host this project. Totally optional for me to do so, however, traditionally the second part of Writing Day has been a lighter lift. I will of course be available if needed.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2203.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->