### PR TITLE
fix:  ``--help`` was being represented incorrectly...

### DIFF
--- a/docs/guide/writing/docs-principles.rst
+++ b/docs/guide/writing/docs-principles.rst
@@ -207,8 +207,8 @@ It may be static or interactive — digital or paper. Multiple
 publications may be created from a single source (such as web and PDF
 versions of the same manual). Although rarer, multiple sources may
 be used to create a single publication. More examples of
-publications include: API reference, man page, command line
-``--help`` output, in-application help tips, online tutorials,
+publications include: API reference, man page, command line*
+``--help`` *output, in-application help tips, online tutorials,
 internal engineering manuals, and others too.*
 
 Each **publication** should be...


### PR DESCRIPTION
...on page `https://www.writethedocs.org/guide/writing/docs-principles/` because the \`\` directive was not being parsed by `sphinx` inside an italics paragraph just under the "Principles for publications" heading.

This was fixed by terminating the italics block and re-starting it just before and after the ``--help`` respectively.  It now appears as originally intended.

No issue was created about this.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2213.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->