### PR TITLE
Blog: Writing Day project announcements

### DIFF
--- a/docs/conf/atlantic/2024/news/announcing-wd-projects.rst
+++ b/docs/conf/atlantic/2024/news/announcing-wd-projects.rst
@@ -1,6 +1,6 @@
 :template: {{year}}/generic.html
 
-.. post:: Sept 11, 2024
+.. post:: Sept 14, 2024
    :tags: atlantic-2024, speakers, tickets, shirts
 
 Let's meet the Writing Day projects!

--- a/docs/conf/atlantic/2024/news/announcing-wd-projects.rst
+++ b/docs/conf/atlantic/2024/news/announcing-wd-projects.rst
@@ -8,16 +8,16 @@ Let's meet the Writing Day projects!
 
 Welcome to the pre-conference, Writing Day project sneak peak. Let's get pumped for Writing Day!
 
-Didn't get the chance to submit your project early? Fear not, you can submit it at any time between now and September 20 or you can bring it and submit it live during Writing Day. Day of project submissions are a time honored WTD tradition that we look forward to seeing continue.
+Didn't get the chance to submit your project early? Fear not, you can submit it at any time between now and September 20, or you can bring it and submit it live during Writing Day. Day-of project submissions are a time-honored WTD tradition that we enjoy seeing, year after year.
 
-Get excited, get delighted, and get ready to meet our Writing Day projects for Write the Docs Atlantic 2024!
+Reminder: Writing Day is included in our conference tickets. Sales close Thursday, September 19, at 23:59 UTC, so `get your tickets soon <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/>`_.
 
-Writing Day is included in our conference tickets. Sales close Thursday, September 19, at 23:59 UTC, so `get your tickets soon <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/>`_.
+Drumroll: get excited, get delighted, and get ready to meet our Writing Day projects for Write the Docs Atlantic 2024!
 
 Mutual Aid for Tech Writer/Documentarian Job Hunters
 -----------------------------------------------------
 
-We are delighted to once again welcome the Mutual Aid for Dcoumentarians projects, lead by the fantastic Kenzie Woodbridge (they/them). Kenzie has hosted this Writing Day session at multiple Write the Docs conferences and we are absolutely thrilled with their continued effort and support for the Write the Docs community.
+We are delighted to once again welcome the Mutual Aid for Documentarians projects, lead by the fantastic Kenzie Woodbridge (they/them). Kenzie has hosted this Writing Day session at multiple Write the Docs conferences and we are absolutely thrilled with their continued effort and support for the Write the Docs community.
 
 WTD Meetup resources for organizers
 ------------------------------------
@@ -27,16 +27,16 @@ Writing Day co-organizer, Rose Williams (she/her), is thankful to have a co-orga
 Audinux - Plan and Publish a User Guide
 ---------------------------------------
 
-We are delighted to welcome Hank Lee and Audimux to their first Writing Day! Audinux is repository for FOSS music applications and pluginss. As a project, they want to empower creative people and help them use Audinux to its full potential! To do that, they need documentarians to help create a user guide.
+We are delighted to welcome Hank Lee and Audinux to their first Writing Day! Audinux is a repository for FOSS music applications and pluginss. As a project, they want to empower creative people and help them use Audinux to its full potential! To do that, they need documentarians to help create a user guide.
 
-Improve Open Source Docs with Ekline
+Improve Open Source Docs with EkLine
 ------------------------------------
 
-Give Puneet Arora a warm welcome for his third Writing Day and first virtual Atlantic Writing Day! Ekline is here to introduce their open core licenses for OSS projects. Puneet be available to help folks onboard to Ekline on their OSS project and show them how to use it to improve their documentation.
+Give Puneet Arora a warm welcome for his third Writing Day and first virtual Atlantic Writing Day! He's here to offer free EkLine open-core licenses for OSS projects. Puneet will be available to help folks onboard EkLine on their OSS projects and show them how to use it to improve their documentation.
 
 And more projects incoming!
 ---------------------------
 
 We have other projects incoming! We are currently working with their organizers to get them added to the Writing Day page. They'll be added to the Project List as soon as they are ready. 
 
-Remember! Writing Day traditionally has projects that opt to join and announce themself that day. These projects are exclusively posted in the event.
+Remember! Writing Day traditionally has projects that opt to join and announce themselves that day. These projects are posted exclusively inside the event space.

--- a/docs/conf/atlantic/2024/news/announcing-wd-projects.rst
+++ b/docs/conf/atlantic/2024/news/announcing-wd-projects.rst
@@ -29,9 +29,14 @@ Audinux - Plan and Publish a User Guide
 
 We are delighted to welcome Hank Lee and Audimux to their first Writing Day! Audinux is repository for FOSS music applications and pluginss. As a project, they want to empower creative people and help them use Audinux to its full potential! To do that, they need documentarians to help create a user guide.
 
+Improve Open Source Docs with Ekline
+------------------------------------
+
+Give Puneet Arora a warm welcome for his third Writing Day and first virtual Atlantic Writing Day! Ekline is here to introduce their open core licenses for OSS projects. Puneet be available to help folks onboard to Ekline on their OSS project and show them how to use it to improve their documentation.
+
 And more projects incoming!
 ---------------------------
 
-We have two other projects incoming! We are currently working with their organizers to get them added to the Writing Day page. They'll be added to the Project List as soon as they are ready. 
+We have other projects incoming! We are currently working with their organizers to get them added to the Writing Day page. They'll be added to the Project List as soon as they are ready. 
 
 Remember! Writing Day traditionally has projects that opt to join and announce themself that day. These projects are exclusively posted in the event.

--- a/docs/conf/atlantic/2024/news/announcing-wd-projects.rst
+++ b/docs/conf/atlantic/2024/news/announcing-wd-projects.rst
@@ -1,0 +1,35 @@
+:template: {{year}}/generic.html
+
+.. post:: Sept 11, 2024
+   :tags: atlantic-2024, speakers, tickets, shirts
+
+Let's meet the Writing Day projects!
+====================================
+
+Welcome to the pre-conference, Writing Day project sneak peak. Let's get pumped for Writing Day!
+
+Didn't get the chance to submit your project early? Fear not, you can submit it at any time between now and September 20 or you can bring it and submit it live during Writing Day. Day of project submissions are a time honored WTD tradition that we look forward to seeing continue.
+
+Get excited, get delighted, and get ready to meet our Writing Day projects for Write the Docs Atlantic 2024.
+
+Mutual Aid for Tech Writer/Documentarian Job Hunters
+-----------------------------------------------------
+
+We are delighted to once again welcome the Mutual Aid for Dcoumentarians projects, lead by the fantastic Kenzie Woodbridge (they/them). Kenzie has hosted this Writing Day session at multiple Write the Docs conferences and we are absolutely thrilled with their continued effort and support for the Write the Docs community.
+
+WTD Meetup resources for organizers
+------------------------------------
+
+Writing Day co-organizer, Rose Williams (she/her), is thankful to have a co-organizer for the Atlantic 2024 event. This inspired her to submit a half-day session focused on updating and consolidating resources for WTD Meetup organizers.
+
+Audinux - Plan and Publish a User Guide
+---------------------------------------
+
+We are delighted to welcome Hank Lee and Audimux to their first Writing Day! Audinux is repository for FOSS music applications and pluginss. As a project, they want to empower creative people and help them use Audinux to its full potential! To do that, they need documentarians to help create a user guide.
+
+And more projects incoming!
+---------------------------
+
+We have two other projects incoming! We are currently working with their organizers to get them added to the Writing Day page. They'll be added to the Project List as soon as they are ready. 
+
+Remember! Writing Day traditionally has projects that opt to join and announce themself that day. These projects are exclusively posted in the event.

--- a/docs/conf/atlantic/2024/news/announcing-wd-projects.rst
+++ b/docs/conf/atlantic/2024/news/announcing-wd-projects.rst
@@ -10,7 +10,9 @@ Welcome to the pre-conference, Writing Day project sneak peak. Let's get pumped 
 
 Didn't get the chance to submit your project early? Fear not, you can submit it at any time between now and September 20 or you can bring it and submit it live during Writing Day. Day of project submissions are a time honored WTD tradition that we look forward to seeing continue.
 
-Get excited, get delighted, and get ready to meet our Writing Day projects for Write the Docs Atlantic 2024.
+Get excited, get delighted, and get ready to meet our Writing Day projects for Write the Docs Atlantic 2024!
+
+Writing Day is included in our conference tickets. Sales close Thursday, September 19, at 23:59 UTC, so `get your tickets soon <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/>`_.
 
 Mutual Aid for Tech Writer/Documentarian Job Hunters
 -----------------------------------------------------


### PR DESCRIPTION
Hopefully we can get Jupyter and the other potential OSS project in there. 

I'd happily get this out on Friday, Sept 13, if possible. However, it would be great to get at least one of the other projects added - just to bulk out the day.

In an ideal world, this would go live no later than Monday, Sept 16.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2216.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->