### PR TITLE
fixes encoding issue when reading YAML files.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,6 +91,7 @@ else:
 
 extensions = [
     'ablog',
+    'sphinx.ext.intersphinx',
     'sphinxcontrib.datatemplates',
     'notfound.extension',
     'sphinxemoji.sphinxemoji',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,8 +9,38 @@ import ablog
 
 # Only for windows compatibility - Forces default encoding to UTF8, which it may not be on windows
 if os.name == 'nt':
-    reload(sys)
-    sys.setdefaultencoding('UTF8')
+    # monkeypatches sphinxcontrib.datatemplates so it uses utf-8 as the encoding
+    # instead of cp1252 when opening a file. using sys.setdefaultencoding does
+    # not alter the encoding when opening a file for reading.
+
+    from sphinxcontrib.datatemplates import directive
+    from xml.etree import ElementTree as ET
+    import mimetypes
+
+    old_load_data = directive.DataTemplateLegacy._load_data
+
+    def _load_data(self, env, data_source, encoding):
+        rel_filename, filename = env.relfn2path(data_source)
+        if data_source.endswith('.yaml'):
+            return self._load_yaml(filename, 'utf-8')
+        elif data_source.endswith('.json'):
+            return self._load_json(filename, 'utf-8')
+        elif data_source.endswith('.csv'):
+            return self._load_csv(filename, 'utf-8')
+        elif "xml" in mimetypes.guess_type(data_source)[0]:
+            # there are many XML based formats
+            return ET.parse(filename).getroot()
+        else:
+            raise NotImplementedError('cannot load file type of %s' %
+                                      data_source)
+
+
+    directive.DataTemplateLegacy._load_data = _load_data
+    setattr(
+        sys.modules['sphinxcontrib.datatemplates.directive'].DataTemplateLegacy,
+        '_load_data',
+        _load_data
+    )
 
 
 sys.path.append(os.getcwd())  # noqa

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,10 +1,36 @@
-@ECHO OFF
+@echo off
 
 REM Command file for Sphinx documentation
+SETLOCAL ENABLEDELAYEDEXPANSION
+
+set _found_python_path=""
+
+
+for /f "tokens=1" %%a in ('REG QUERY HKEY_LOCAL_MACHINE\SOFTWARE\Python\PythonCore /s /f InstallPath ^| findstr "HKEY_LOCAL_MACHINE"') do (
+  set _python_reg=%%a
+
+  for /f "tokens=3" %%b in ('REG QUERY !_python_reg! /v ExecutablePath') do (
+    set _python_path=%%b
+  )
+
+  for /f "tokens=5 delims=\" %%v in ("%%a") Do (
+    set _version=%%v
+
+    IF !_version! == 3.8 (
+        set _found_python_path=!_python_path!
+    )
+  )
+)
+
+IF "%_found_python_path%" == "" (
+    echo.Python 3.8 installation not found.
+    goto end
+)
 
 if "%SPHINXBUILD%" == "" (
-	set SPHINXBUILD=sphinx-build
+	set SPHINXBUILD=!_found_python_path! -m sphinx-build
 )
+
 set BUILDDIR=_build
 set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% .
 if NOT "%PAPER%" == "" (
@@ -49,7 +75,7 @@ if "%1" == "html" (
 )
 
 if "%1" == "livehtml" (
-	sphinx-autobuild -p 8888  -z _data -b dirhtml %ALLSPHINXOPTS% %BUILDDIR%/html
+	!_found_python_path! -m sphinx-autobuild -p 8888  -z _data -b dirhtml %ALLSPHINXOPTS% %BUILDDIR%/html
 )
 
 if "%1" == "dirhtml" (
@@ -158,3 +184,5 @@ results in %BUILDDIR%/doctest/output.txt.
 )
 
 :end
+
+ENDLOCAL

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ sphinx_autobuild==2021.3.14
 myst-parser==0.17.2
 
 # Blogging
-ablog==0.11.11  # pyup: ignore
+ablog==0.10.33.post1  # pyup: ignore
 
 # Sphinx (checked with 4.3) requires docutils=<0.18
 docutils==0.17.1   # pyup: <0.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ sphinx_autobuild==2021.3.14
 myst-parser==0.17.2
 
 # Blogging
-ablog==0.10.6  # pyup: ignore
+ablog==0.11.11  # pyup: ignore
 
 # Sphinx (checked with 4.3) requires docutils=<0.18
 docutils==0.17.1   # pyup: <0.18


### PR DESCRIPTION
This problem only occurs when compiling under windows. This is due to the default encoding for loading files being set to cp1252. To change this behavior we need to supply the proper encoding of utf-8

@vwheeler63 

Give this a try and see if it corrects the build problem under Windows. It might need some tweaking to make it work correctly bit it should do the trick after any needed tweaks. 



<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2221.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->