### PR TITLE
Show other websites for meetups

### DIFF
--- a/docs/_data/meetups/aus.yaml
+++ b/docs/_data/meetups/aus.yaml
@@ -1,6 +1,5 @@
 region: Oceania
 country: Australia
-website: https://www.meetup.com/write-the-docs-australia/events/
 meetup: Write-the-Docs-Australia
 organizers:
   - name: Swapnil Ogale

--- a/docs/_data/meetups/can-calgary.yaml
+++ b/docs/_data/meetups/can-calgary.yaml
@@ -2,7 +2,6 @@ region: North America
 country: Canada
 state: Alberta
 city: Calgary
-website: https://www.meetup.com/wtd-calgary/events/
 meetup: WTD-Calgary
 organizers:
   - name: Ken Schatzke

--- a/docs/_data/meetups/can-ottawa.yaml
+++ b/docs/_data/meetups/can-ottawa.yaml
@@ -2,7 +2,6 @@ region: North America
 country: Canada
 state: Ontario
 city: Ottawa
-website: https://www.meetup.com/write-the-docs-yow-ottawa/events/
 meetup: Write-The-Docs-YOW-Ottawa
 organizers:
   - name: Andrew Johnston

--- a/docs/_data/meetups/can-toronto.yaml
+++ b/docs/_data/meetups/can-toronto.yaml
@@ -2,7 +2,6 @@ region: North America
 country: Canada
 state: Ontario
 city: Toronto
-website: https://www.meetup.com/write-the-docs-toronto/events/
 meetup: Write-The-Docs-Toronto
 organizers:
   - name: Dan Kellett

--- a/docs/_data/meetups/esp-barcelona.yaml
+++ b/docs/_data/meetups/esp-barcelona.yaml
@@ -1,7 +1,6 @@
 region: Europe
 country: Spain
 city: Barcelona
-website: https://www.meetup.com/write-the-docs-barcelona/events/
 meetup: Write-the-Docs-Barcelona
 organizers:
   - name: Fabrizio Ferri-Benedetti

--- a/docs/_data/meetups/fra-paris.yaml
+++ b/docs/_data/meetups/fra-paris.yaml
@@ -1,7 +1,6 @@
 region: Europe
 country: France
 city: Paris
-website: https://www.meetup.com/write-the-docs-paris/events/
 meetup: Write-the-Docs-Paris
 organizers:
   - name: François Violette

--- a/docs/_data/meetups/gbr-london.yaml
+++ b/docs/_data/meetups/gbr-london.yaml
@@ -1,7 +1,6 @@
 region: Europe
 country: United Kingdom
 city: London
-website: https://www.meetup.com/write-the-docs-london/events/
 meetup: Write-The-Docs-London
 organizers:
   - name: Kristof Van Tomme

--- a/docs/_data/meetups/ger-berlin.yaml
+++ b/docs/_data/meetups/ger-berlin.yaml
@@ -1,7 +1,6 @@
 region: Europe
 country: Germany
 city: Berlin
-website: https://www.meetup.com/write-the-docs-berlin/events/
 meetup: Write-The-Docs-Berlin
 organizers:
   - name: Sam Wright

--- a/docs/_data/meetups/ger-hamburg.yaml
+++ b/docs/_data/meetups/ger-hamburg.yaml
@@ -1,7 +1,6 @@
 region: Europe
 country: Germany
 city: Hamburg
-website: https://www.meetup.com/write-the-docs-hamburg/events/
 meetup: Write-the-Docs-Hamburg
 organizer:
   - name: Frank Ralf

--- a/docs/_data/meetups/ind-bangalore.yaml
+++ b/docs/_data/meetups/ind-bangalore.yaml
@@ -1,7 +1,6 @@
 region: Asia
 country: India
 city: Bangalore
-website: https://www.meetup.com/write-the-docs-india/events/
 meetup: Write-the-Docs-India
 organizers:
    - name: Rajakavitha Kodhandapani

--- a/docs/_data/meetups/irl-dublin.yaml
+++ b/docs/_data/meetups/irl-dublin.yaml
@@ -1,7 +1,6 @@
 region: Europe
 country: Ireland
 city: Dublin
-website: https://www.meetup.com/write-the-docs-ireland/events/
 meetup: Write-The-Docs-Ireland
 organizers:
   - name: Artem Konev

--- a/docs/_data/meetups/isr-herzliya.yaml
+++ b/docs/_data/meetups/isr-herzliya.yaml
@@ -1,7 +1,6 @@
 region: Asia
 country: Israel
 city: Tel Aviv+
-website: https://www.meetup.com/write-the-docs-taplus/events/
 meetup: Write-The-Docs-TAplus
 organizers:
   - name: Laura Novich

--- a/docs/_data/meetups/kenya-nairobi.yaml
+++ b/docs/_data/meetups/kenya-nairobi.yaml
@@ -1,7 +1,6 @@
 region: Africa
 country: Kenya
 city: Nairobi
-website: https://www.meetup.com/wtd-kenya/events/
 meetup: Write-the-Docs-Kenya
 organizers:
   - name: Hillary Nyakundi

--- a/docs/_data/meetups/ned-amsterdam.yaml
+++ b/docs/_data/meetups/ned-amsterdam.yaml
@@ -1,7 +1,6 @@
 region: Europe
 country: Netherlands
 city: Amsterdam
-website: https://www.meetup.com/write-the-docs-amsterdam/events/
 meetup: Write-The-Docs-Amsterdam
 organizers:
   - name: Laura Vass

--- a/docs/_data/meetups/ng-portharcourt.yaml
+++ b/docs/_data/meetups/ng-portharcourt.yaml
@@ -1,7 +1,6 @@
 region: Africa
 country: Nigeria
 city: Port Harcourt & Lagos
-website: https://www.meetup.com/write-the-docs-nigeria/events/
 meetup: Write-the-Docs-Nigeria
 organizers:
   - name: Tabah Baridule Martins

--- a/docs/_data/meetups/qrm-usEast.yaml
+++ b/docs/_data/meetups/qrm-usEast.yaml
@@ -2,7 +2,6 @@ region: Quorum-US-East
 country: USA
 state: East Coast
 city:
-website: https://www.meetup.com/virtual-write-the-docs-east-coast-quorum/events/
 meetup: Virtual-Write-The-Docs-East-Coast-Quorum
 twitter:
 organizers:

--- a/docs/_data/meetups/swe-stockholm.yaml
+++ b/docs/_data/meetups/swe-stockholm.yaml
@@ -1,7 +1,6 @@
 region: Europe
 country: Sweden
 city: Stockholm
-website: https://www.meetup.com/write-the-docs-stockholm/events/
 meetup: write-the-docs-stockholm
 organizers:
   - name: Gunilla Svanfeldt

--- a/docs/_data/meetups/tn-tunis.yaml
+++ b/docs/_data/meetups/tn-tunis.yaml
@@ -1,7 +1,6 @@
 region: Africa
 country: Tunisia
 city: Tunis
-website: https://www.meetup.com/tunis-write-the-docs/
 meetup: tunis-write-the-docs
 organizers:
   - name: AbdelKarim BenAbdallah

--- a/docs/_data/meetups/usa-austin.yaml
+++ b/docs/_data/meetups/usa-austin.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: Texas
 city: Austin
-website: https://www.meetup.com/writethedocs-atx-meetup/events/
 meetup: WriteTheDocs-ATX-Meetup
 organizers:
   - name: Caley Burton

--- a/docs/_data/meetups/usa-boise.yaml
+++ b/docs/_data/meetups/usa-boise.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: Idaho
 city: Boise
-website: https://www.meetup.com/write-the-docs-boise/events/
 meetup: Write-the-Docs-Boise
 organizers:
   - name: Mike Taylor

--- a/docs/_data/meetups/usa-boulder.yaml
+++ b/docs/_data/meetups/usa-boulder.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: Colorado
 city: Boulder/Denver
-website: https://www.meetup.com/write-the-docs-boulder-denver/events/
 meetup: Write-the-Docs-Boulder-Denver
 organizers:
   - name: Kaylyn Sigler

--- a/docs/_data/meetups/usa-florida.yaml
+++ b/docs/_data/meetups/usa-florida.yaml
@@ -1,7 +1,6 @@
 region: North America
 country: USA
 state: Florida
-website: https://www.meetup.com/write-the-docs-florida/events/
 meetup: Write-the-Docs-Florida
 organizers:
   - name: Barrie Byron

--- a/docs/_data/meetups/usa-losAngeles.yaml
+++ b/docs/_data/meetups/usa-losAngeles.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: California
 city: Los Angeles
-website: https://www.meetup.com/write-the-docs-la/events/
 meetup: Write-the-Docs-Los-Angeles
 organizers:
   - name: Andrea Kao

--- a/docs/_data/meetups/usa-michigan.yaml
+++ b/docs/_data/meetups/usa-michigan.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: Michigan
 city: Detroit-Windsor
-website: https://www.meetup.com/write-the-docs-detroit-windsor/events/
 meetup: write-the-docs-detroit-windsor
 organizers:
   - name: Ryan Macklin

--- a/docs/_data/meetups/usa-nashville.yaml
+++ b/docs/_data/meetups/usa-nashville.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: Tennessee
 city: Nashville
-website: https://www.meetup.com/write-the-docs-nashville/events/
 meetup: Write-the-Docs-Nashville
 organizers:
   - name: Pratishtha Singh

--- a/docs/_data/meetups/usa-new-england.yaml
+++ b/docs/_data/meetups/usa-new-england.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: New England (formerly Boston)
 city: Boston, MA
-website: https://www.meetup.com/ne-write-the-docs/events/
 meetup: Boston-Write-the-Docs
 organizers:
   - name: Lisa Gay

--- a/docs/_data/meetups/usa-nyc.yaml
+++ b/docs/_data/meetups/usa-nyc.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: New York
 city: New York City
-website: https://www.meetup.com/writethedocsnyc/events/
 meetup: WriteTheDocsNYC
 twitter: WriteTheDocsNYC
 organizers:

--- a/docs/_data/meetups/usa-pittsburgh.yaml
+++ b/docs/_data/meetups/usa-pittsburgh.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: Pennsylvania
 city: Pittsburgh
-website: https://www.meetup.com/write-the-docs-pittsburgh/events/
 meetup: write-the-docs-pittsburgh
 organizers:
   - name: Rachael Stavchansky

--- a/docs/_data/meetups/usa-portland.yaml
+++ b/docs/_data/meetups/usa-portland.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: Oregon
 city: Portland
-website: https://www.meetup.com/write-the-docs-pdx/events/
 meetup: Write-The-Docs-PDX
 twitter: WriteTheDocsPDX
 organizers:

--- a/docs/_data/meetups/usa-sanfrancisco.yaml
+++ b/docs/_data/meetups/usa-sanfrancisco.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: California
 city: San Francisco
-website: https://www.meetup.com/write-the-docs-bay-area/events/
 meetup: Write-the-Docs
 organizer:
    - name: Ilona Koren-Deutsch

--- a/docs/_data/meetups/usa-seattle.yaml
+++ b/docs/_data/meetups/usa-seattle.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: Washington
 city: Seattle
-website: https://www.meetup.com/write-the-docs-seattle/events/
 meetup: Write-The-Docs-Seattle
 organizers:
   - name: Jerome Villegas

--- a/docs/_data/meetups/usa-washingtondc.yaml
+++ b/docs/_data/meetups/usa-washingtondc.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: DC
 city: Washington
-website: https://www.meetup.com/write-the-docs-dc/events/
 meetup: Write-the-Docs-DC
 organizers:
   - name: Allison Gisinger

--- a/docs/_templates/include/meetups/listing.jinja
+++ b/docs/_templates/include/meetups/listing.jinja
@@ -35,6 +35,13 @@
               </div>
             {% endif %}
 
+            {# Other internet presence  #}
+            {% if meetup['website'] %}
+              <div>
+                Elsewhere: <a href="{{ meetup['website']}}">{{ meetup['website'] }}</a>
+              </div>
+            {% endif %}
+
             {# On twitter #}
             {% if meetup['twitter'] %}
               <div>

--- a/docs/_templates/include/meetups/listing.jinja
+++ b/docs/_templates/include/meetups/listing.jinja
@@ -36,10 +36,12 @@
             {% endif %}
 
             {# Other internet presence  #}
-            {% if meetup['website'] %}
-              <div>
-                Elsewhere: <a href="{{ meetup['website']}}">{{ meetup['website'] }}</a>
-              </div>
+            {% if meetup['links'] %}
+              <ul aria-label="External links">
+                {% for text, link in meetup['links'].items() %}
+                  <li><a href="{{ link }}">{{ text }}</a></li>
+                {% endfor %}
+              </ul>
             {% endif %}
 
             {# On twitter #}


### PR DESCRIPTION
@rosewms this replaces the single `website` field with a `links` dict, allowing multiple links with custom labels:

```yaml
links:
  Meetup: https://www.meetup.com/write-the-docs-pdx/events/
  LinkedIn: https://linkedin.com/groups/...
```

Each entry is rendered as a list item with the key as the visible link text.

Previously:

- ~~can only have one website~~
- ~~cannot customize the link title~~

Now:

- can have multiple links
- can customize each link's label text
- still need a meetup ID


----
📚 Documentation preview 📚: https://writethedocs-www--2242.org.readthedocs.build/