### PR TITLE
Sphinx etc version upgrades

### DIFF
--- a/docs/_templates/2022/generic.html
+++ b/docs/_templates/2022/generic.html
@@ -86,7 +86,7 @@
                 {% block body %}
                 {{ body }}
                 {% endblock body %}
-                {# {% include "postcard.html" %} #}
+                {# {% include "ablog/postcard.html" %} #}
         </div>
     </div>
   {% endif %}

--- a/docs/_templates/2023/generic.html
+++ b/docs/_templates/2023/generic.html
@@ -86,7 +86,7 @@
                 {% block body %}
                 {{ body }}
                 {% endblock body %}
-                {# {% include "postcard.html" %} #}
+                {# {% include "ablog/postcard.html" %} #}
         </div>
     </div>
   {% endif %}

--- a/docs/_templates/2024/generic-iframe.html
+++ b/docs/_templates/2024/generic-iframe.html
@@ -15,7 +15,7 @@
                 {% block body %}
                 {{ body }}
                 {% endblock body %}
-                {# {% include "postcard.html" %} #}
+                {# {% include "ablog/postcard.html" %} #}
         </div>
     </div>
   {% endif %}

--- a/docs/_templates/2024/generic.html
+++ b/docs/_templates/2024/generic.html
@@ -86,7 +86,7 @@
                 {% block body %}
                 {{ body }}
                 {% endblock body %}
-                {# {% include "postcard.html" %} #}
+                {# {% include "ablog/postcard.html" %} #}
         </div>
     </div>
   {% endif %}

--- a/docs/_templates/2025/generic.html
+++ b/docs/_templates/2025/generic.html
@@ -86,7 +86,7 @@
                 {% block body %}
                 {{ body }}
                 {% endblock body %}
-                {# {% include "postcard.html" %} #}
+                {# {% include "ablog/postcard.html" %} #}
         </div>
     </div>
   {% endif %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,8 +75,6 @@ exclude_patterns = [
     'videos/prague/2018/tackling-technical-debt-in-the-docs-louise-fahey.rst',
 ]
 
-html4_writer = True
-
 # We use these *local* environment variables for private info like free ticket links
 
 cfp_variables = {}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -174,7 +174,7 @@ html_copy_source = False
 html_sidebars = {
     '**': [
         'about.html',
-        'postcard.html',
+        'ablog/postcard.html',
         'info.html',
         'searchbox.html',
         'navigation.html',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -141,7 +141,7 @@ blog_locations = {
 blog_default_location = None
 fontawesome_link_cdn = 'https://netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.min.css'
 
-templates_path = ['_templates', 'include', ablog.get_html_templates_path()]
+templates_path = ['_templates', 'include']
 html_extra_path = ['_static_html']
 source_suffix = ['.rst', '.md']
 

--- a/docs/surveys/salary-survey/2023.rst
+++ b/docs/surveys/salary-survey/2023.rst
@@ -26,8 +26,8 @@
 
 .. |%| replace:: :abbr:`% (Percentage of total respondents)`
 
-.. raw:: html   
-   
+.. raw:: html
+
   <nav>
 
 .. contents::
@@ -40,7 +40,7 @@
   </nav>
    <div class="breadcrumbs"><a href="/">Home</a> &raquo; <a href="/surveys/">Salary Surveys</a> &raquo;</div>
   <main>
-      
+
 
 .. _top:
 
@@ -49,9 +49,9 @@ Documentation Salary Survey 2023 Results
 ****************************************
 
 Introduction
-============ 
+============
 
-In this, the fifth annual Write the Docs documentation salary survey, we gathered data from a record-breaking 1017 individual respondents - 938 employees and 79 contractors - in 53 countries, working across dozens of industries, with experience ranging from less than one year to over 40 years. 
+In this, the fifth annual Write the Docs documentation salary survey, we gathered data from a record-breaking 1017 individual respondents - 938 employees and 79 contractors - in 53 countries, working across dozens of industries, with experience ranging from less than one year to over 40 years.
 
 In a hurry? Jump straight to `Median salary`_ or `Median hourly rate`_.
 
@@ -64,13 +64,13 @@ In a hurry? Jump straight to `Median salary`_ or `Median hourly rate`_.
 Feedback
 --------
 
-We're always keen to hear your thoughts on this survey, so that we can continue to develop and refine it - and if you have used the data to help negotiate a raise or evaluate an offer, we would love to know about it! Email us at support@writethedocs.org with your feedback, ideas and experiences. 
+We're always keen to hear your thoughts on this survey, so that we can continue to develop and refine it - and if you have used the data to help negotiate a raise or evaluate an offer, we would love to know about it! Email us at support@writethedocs.org with your feedback, ideas and experiences.
 
 Here are just some of the anonymous comments that respondents submitted in 2024:
 
 .. pull-quote::
 
-   I have a pretty good grasp on what salary I should be aiming for thanks to this survey! I hope other writers find this information as useful as I have. 
+   I have a pretty good grasp on what salary I should be aiming for thanks to this survey! I hope other writers find this information as useful as I have.
 
    WTD surveys (along with TechCommNZ surveys) are very useful in salary negotiations and my manager really appreciates that I bring facts and data to the table. In fact, we wait until info is available before sitting down each year.
 
@@ -87,7 +87,7 @@ Basis of employment
 -------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked (click to expand)</summary>
 
 .. container:: question
@@ -103,9 +103,9 @@ Basis of employment
 
    </details>
 
-In 2023, 92.2% of respondents (938) were employees and 7.8% (79 individuals) were contractors. 
+In 2023, 92.2% of respondents (938) were employees and 7.8% (79 individuals) were contractors.
 
-Of the employees, 3% stated they were currently unemployed, while this number was only 0.5% for contractors. Respondents not currently working were asked to fill out the survey as if they were still at their previous employer or contract. 
+Of the employees, 3% stated they were currently unemployed, while this number was only 0.5% for contractors. Respondents not currently working were asked to fill out the survey as if they were still at their previous employer or contract.
 
 .. table:: Basis of employment (2019-2023)
    :widths: 40 10 10 20 10 10
@@ -131,7 +131,7 @@ Hours worked
 ------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -149,18 +149,18 @@ Hours worked
 
    </details>
 
-As in previous years, the majority (96%) of respondents worked traditional "full-time" hours each week: 
+As in previous years, the majority (96%) of respondents worked traditional "full-time" hours each week:
 
 - 69.7% worked between 31 and 40 hours
 - 24.5% worked between 41 and 50 hours
-- 1.9% worked between 51 and 60 hours 
+- 1.9% worked between 51 and 60 hours
 
 Only one respondent worked more than 60 hours - this person indicated that they put in 95 hours per week.
 
-Of those that worked fewer hours: 
+Of those that worked fewer hours:
 
 - 2.2% worked 21 to 30 hours each week
-- 1.7% worked 1 to 20 hours 
+- 1.7% worked 1 to 20 hours
 
 .. table:: Weekly hours worked
    :widths: 70 15 15
@@ -187,7 +187,7 @@ Job title
 ---------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -198,9 +198,9 @@ Job title
 
    </details>
 
-With typos fixed, abbreviations expanded, stop words removed and keyword faceting applied, 275 unique job titles could be discerned. One respondent indicated that they did not have a job title.    
-      
-As in previous years, the most widely used exact title was "Technical Writer", reported by 32% of respondents - in fact this phrase appeared in the top 5 job titles and in 67.9% of all job titles.  
+With typos fixed, abbreviations expanded, stop words removed and keyword faceting applied, 275 unique job titles could be discerned. One respondent indicated that they did not have a job title.
+
+As in previous years, the most widely used exact title was "Technical Writer", reported by 32% of respondents - in fact this phrase appeared in the top 5 job titles and in 67.9% of all job titles.
 
 .. raw:: html
 
@@ -277,7 +277,7 @@ As in previous years, the most widely used exact title was "Technical Writer", r
    <figure>
       <object role="img" aria-label="Job title word cloud" aria-describedby="figure_job-title-word-cloud_desc" type="image/svg+xml" data="/_images/2023-job-title-word-cloud.svg">
          <p id="figure_job-title-word-cloud_desc">Word cloud showing relative weights of job title keywords</p>
-      </object> 
+      </object>
       <figcaption>Figure: Job title word cloud</figcaption>
    </figure>
 
@@ -289,7 +289,7 @@ Type of role
 ------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -321,7 +321,7 @@ Type of role
 Role category
 ~~~~~~~~~~~~~
 
-Most respondents identified their role as "writer, content creator, producer, editor" - 59.4% selected only this category, while 95.6% included it alongside other categories. The second most widely-selected was "management", with 15.5% of respondents selecting this along with other categories and 2.3% selecting it as their only role category, followed by "developer, engineer", included by 10.5% of all respondents. In total, respondents selected 63 different combinations of the 8 role categories. 
+Most respondents identified their role as "writer, content creator, producer, editor" - 59.4% selected only this category, while 95.6% included it alongside other categories. The second most widely-selected was "management", with 15.5% of respondents selecting this along with other categories and 2.3% selecting it as their only role category, followed by "developer, engineer", included by 10.5% of all respondents. In total, respondents selected 63 different combinations of the 8 role categories.
 
 .. table:: Top role category combinations
    :widths: 70 15 15
@@ -354,14 +354,14 @@ Most respondents identified their role as "writer, content creator, producer, ed
    | Writer/Creator/Editor + Developer/Engineer + Management | 10  | 1.0%  |
    +---------------------------------------------------------+-----+-------+
 
-Of those respondents who chose "Other" and provided more detail, the additional categories included project management, product management, process management, information architecture, instructional design, QA/testing, content strategy, mentoring, and translation - as well as some terms which can be bundled under the heading "DocOps": documentation tool and workflow administration, repository maintenance, and documentation infrastructure development and support. 
+Of those respondents who chose "Other" and provided more detail, the additional categories included project management, product management, process management, information architecture, instructional design, QA/testing, content strategy, mentoring, and translation - as well as some terms which can be bundled under the heading "DocOps": documentation tool and workflow administration, repository maintenance, and documentation infrastructure development and support.
 
 Team breakdown
 ~~~~~~~~~~~~~~
 
-The most widely-selected team configurations were single category: 25.2% of respondents worked only on a team made up of people with the same or similar roles, while 12.7% worked only on a team made up of people with differing roles. 8.5% worked only solo, and 7.1% selected only management. These four configurations covered just over half of all respondents - the other half chose a combination of categories. 
+The most widely-selected team configurations were single category: 25.2% of respondents worked only on a team made up of people with the same or similar roles, while 12.7% worked only on a team made up of people with differing roles. 8.5% worked only solo, and 7.1% selected only management. These four configurations covered just over half of all respondents - the other half chose a combination of categories.
 
-Of the 18.8% who indicated that they worked as a manager or team leader, 62.3% also fulfilled other team roles. 
+Of the 18.8% who indicated that they worked as a manager or team leader, 62.3% also fulfilled other team roles.
 
 .. table:: Team breakdown
    :widths: 70 15 15
@@ -400,15 +400,15 @@ Length of time in current role
 ------------------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
 
-   |icon-question| Employees: 
+   |icon-question| Employees:
 
    How long have you worked in your current role, at your current organization?
-   
+
    Note:
    Please select the length of time for your position at your current organization only – your total years of experience in documentation will be covered in the individual demographics section. If you have changed roles at the same organization, please select the length of time that you have been in your current role.
 
@@ -418,7 +418,7 @@ Length of time in current role
    - More than 5 years but less than 10 years
    - More than 10 years
 
-   Contractors: 
+   Contractors:
 
    How long have you worked as a contractor or freelancer, or been self-employed?
 
@@ -435,7 +435,7 @@ Length of time in current role
 
    </details>
 
-A spike in respondents with new jobs was first seen in 2021, with 31.7% of respondents reported being in their current position at their current organization for less than a year. In 2022, this number peaked at 36.8% - when respondents with new jobs outstripped the number who had held their current position for medium or long terms. In 2023, the number of respondents with new jobs has fallen again, to 20.3% - lower than in 2020 although still well above the 9% reported in 2019. 
+A spike in respondents with new jobs was first seen in 2021, with 31.7% of respondents reported being in their current position at their current organization for less than a year. In 2022, this number peaked at 36.8% - when respondents with new jobs outstripped the number who had held their current position for medium or long terms. In 2023, the number of respondents with new jobs has fallen again, to 20.3% - lower than in 2020 although still well above the 9% reported in 2019.
 
 .. table:: Length of time in current role
    :widths: 70 15 15
@@ -461,7 +461,7 @@ A spike in respondents with new jobs was first seen in 2021, with 31.7% of respo
    <figure>
       <object role="img" aria-label="Length of time in current role at current organization" aria-describedby="figure_length-of-time-in-current-role_desc" type="image/svg+xml" data="/_images/2023-length-of-time-in-current-role.svg">
          <p id="figure_length-of-time-in-current-role_desc">Length of time in current role (at current organization - employee respondents who have changed roles at the same organization were instructed to specify the length of time they had been in their current role only, not the total length of time at the organization)</p>
-      </object> 
+      </object>
       <figcaption>Figure: Length of time in current role</figcaption>
    </figure>
 
@@ -472,7 +472,7 @@ Proportion of role related to documentation
 -------------------------------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -495,7 +495,7 @@ Proportion of role related to documentation
 
    </details>
 
-The majority of respondents (73.5% in 2023, almost exactly the same proportion as in 2022) reported that documentation makes up both their whole official job description, and most or all of their day-to-day tasks (87.2% reporting more than 51% of their daily workload). The portion of respondents performing documentation-related tasks even though it's not part of their job description remained steady. 
+The majority of respondents (73.5% in 2023, almost exactly the same proportion as in 2022) reported that documentation makes up both their whole official job description, and most or all of their day-to-day tasks (87.2% reporting more than 51% of their daily workload). The portion of respondents performing documentation-related tasks even though it's not part of their job description remained steady.
 
 .. raw:: html
 
@@ -541,7 +541,7 @@ The majority of respondents (73.5% in 2023, almost exactly the same proportion a
    | 26-50%                               |  87 | 8.6%  |
    +--------------------------------------+-----+-------+
    | 0-25%                                | 43  | 4.2%  |
-   +--------------------------------------+-----+-------+   
+   +--------------------------------------+-----+-------+
 
 .. raw:: html
 
@@ -552,7 +552,7 @@ The majority of respondents (73.5% in 2023, almost exactly the same proportion a
    <figure>
       <object role="img" aria-label="Portion of role officially documentation-related" aria-describedby="figure_proportion-of-role-officially-docs-related_desc" type="image/svg+xml" data="/_images/2023-portion-of-role-officially-docs-related.svg">
          <p id="figure_proportion-of-role-officially-docs-related_desc">Donut chart showing what proportion of respondents official job description was documentation-related.</p>
-      </object> 
+      </object>
       <figcaption>Figure: Portion of role officially documentation-related</figcaption>
    </figure>
 
@@ -564,7 +564,7 @@ The majority of respondents (73.5% in 2023, almost exactly the same proportion a
    <figure>
       <object role="img" aria-label="Portion of role actually documentation-related" aria-describedby="figure_proportion-of-role-actually-docs-related_desc" type="image/svg+xml" data="/_images/2023-proportion-actual.svg">
          <p id="figure_proportion-of-role-actually-docs-related_desc">Donut chart showing what proportion of respondents actual day-to-day tasks are documentation-related.</p>
-      </object> 
+      </object>
       <figcaption>Figure: Portion of role actually documentation-related</figcaption>
    </figure>
 
@@ -582,15 +582,15 @@ Employment or contract status change
 ------------------------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
 
    |icon-question| Employees:
 
-   Has your employment status changed in the past year? 
-   
+   Has your employment status changed in the past year?
+
    - Yes
    - No
 
@@ -610,7 +610,7 @@ Employment or contract status change
 
    Contractors:
 
-   Has your contract/freelance status changed in the past year? 
+   Has your contract/freelance status changed in the past year?
 
    - Yes
    - No
@@ -712,7 +712,7 @@ Job or contract search status
 -----------------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -726,7 +726,7 @@ Job or contract search status
    - I'm not looking for a new position, but expect to be within the next year
    - I'm actively looking for a new position
 
-   Contractors: 
+   Contractors:
 
    What is your current contract/freelance search status?
 
@@ -735,11 +735,11 @@ Job or contract search status
    - I'm not looking for new contracts or freelance projects, but expect to be within the next year
    - I'm actively looking for new contracts or freelance projects
 
-.. raw:: html  
+.. raw:: html
 
    </details>
 
-The majority of respondents - 46.3% of employees and 38% of contractors - stated that while they were not actively looking for new positions or contracts, they were open to considering offers that might come their way. 14% of employees and 29.1% of contractors said they were actively looking for new work. 
+The majority of respondents - 46.3% of employees and 38% of contractors - stated that while they were not actively looking for new positions or contracts, they were open to considering offers that might come their way. 14% of employees and 29.1% of contractors said they were actively looking for new work.
 
 .. raw:: html
 
@@ -795,7 +795,7 @@ Job security and stability
 --------------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -810,7 +810,7 @@ Job security and stability
 
    </details>
 
-Note: Employees and contractors who had indicated that they were currently unemployed were not shown this question. 
+Note: Employees and contractors who had indicated that they were currently unemployed were not shown this question.
 
 Just over half of all respondents (54.1%) reported feeling the same level of job security and stability, compared to the previous year. 30.5% felt less secure, and only 15.4% felt more secure. The difference in responses between employees and contractors for this question was not significantly different.
 
@@ -833,13 +833,13 @@ Job offer considerations
 ------------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
 
-   |icon-question| When considering an offer of employment, how important do you consider the following 13 factors? 
-   
+   |icon-question| When considering an offer of employment, how important do you consider the following 13 factors?
+
    The options for each were: not relevant, not very important, somewhat important, very important.
 
    - Salary
@@ -860,9 +860,9 @@ Job offer considerations
 
    </details>
 
-Note: This question - new for 2023 - was only shown to employees. 
+Note: This question - new for 2023 - was only shown to employees.
 
-While some obvious factors were given high importance by most respondents - salary, work location, hours, and benefits - other factors resulted in more varied results. The only factor that the majority of respondents agreed was not very important was community involvement. Stability, diversity, professional development, career advancement and pay transparency were all found to be "somewhat important" by the majority of respondents, but for all of these factors there was a wide range of variations in the responses. 
+While some obvious factors were given high importance by most respondents - salary, work location, hours, and benefits - other factors resulted in more varied results. The only factor that the majority of respondents agreed was not very important was community involvement. Stability, diversity, professional development, career advancement and pay transparency were all found to be "somewhat important" by the majority of respondents, but for all of these factors there was a wide range of variations in the responses.
 
 .. table:: Employee job offer considerations
    :widths: 32 17 17 17 17
@@ -906,7 +906,7 @@ While some obvious factors were given high importance by most respondents - sala
    <figure>
       <object role="img" aria-label="Job offer considerations" aria-describedby="figure_job-offer-considerations_desc" type="image/svg+xml" data="/_images/2023-job-offer-considerations.svg">
          <p id="figure_job-offer-considerations_desc">Diverging stacked horizontal bar chart showing level of importance given to various factors by employee respondents when considering an offer of employment.</p>
-      </object> 
+      </object>
       <figcaption>Figure: Employee job offer considerations</figcaption>
    </figure>
 
@@ -916,7 +916,7 @@ While some obvious factors were given high importance by most respondents - sala
 Workplace
 =========
 
-The questions in this section relate to respondents' workplace: whether they work from home, from an office, or a combination, and how they feel about that. We were also interested in how the much-discussed "back to the office" mandates have affected our community. 
+The questions in this section relate to respondents' workplace: whether they work from home, from an office, or a combination, and how they feel about that. We were also interested in how the much-discussed "back to the office" mandates have affected our community.
 
 .. container:: note
 
@@ -928,7 +928,7 @@ Work location
 -------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -953,7 +953,7 @@ Work location
 
    </details>
 
-The majority of respondents reported working remotely, with the number doing so by choice (36.2%) higher than the number required to do so by their employer (29%). 
+The majority of respondents reported working remotely, with the number doing so by choice (36.2%) higher than the number required to do so by their employer (29%).
 
 .. table:: Work location
    :widths: 70 15 15
@@ -979,14 +979,14 @@ The majority of respondents reported working remotely, with the number doing so 
    <figure>
       <object role="img" aria-label="Work location" aria-describedby="figure_work-location_desc" type="image/svg+xml" data="/_images/2023-work-location.svg">
          <p id="figure_work-location_desc">Donut chart showing current work location - remote, hybrid, on-site - and whether the location is their choice or their employer's.</p>
-      </object> 
+      </object>
       <figcaption>Figure: Work location</figcaption>
    </figure>
 
 .. figure:: images/2023/2023-work-location.svg
    :class: hide
 
-The majority of respondents (80.8%) reported feeling "positive" about their work location, with 51.8% feeling "very positive". 
+The majority of respondents (80.8%) reported feeling "positive" about their work location, with 51.8% feeling "very positive".
 
 .. table:: Feelings about work location
    :widths: 70 15 15
@@ -1012,7 +1012,7 @@ The majority of respondents (80.8%) reported feeling "positive" about their work
    <figure>
       <object role="img" aria-label="Work location" aria-describedby="figure_feelings-about-work-location_desc" type="image/svg+xml" data="/_images/2023-feelings-about-work-location.svg">
          <p id="figure_feelings-about-work-location_desc">Donut chart showing respondents feelings about their work location.</p>
-      </object> 
+      </object>
       <figcaption>Figure: Feelings about work location</figcaption>
    </figure>
 
@@ -1026,10 +1026,10 @@ The majority of respondents (80.8%) reported feeling "positive" about their work
 
    .. rubric:: |icon-info| Note on use of the term "post-pandemic"
 
-   The survey questions originally included the term "post-pandemic" to describe "return to office" mandates. However, as was correctly pointed out by several community members, the COVID-19 pandemic is not over, and is still very much a concern for at-risk groups. Removing this term does not alter the meaning or intention of the question and so has been left out of this report. 
+   The survey questions originally included the term "post-pandemic" to describe "return to office" mandates. However, as was correctly pointed out by several community members, the COVID-19 pandemic is not over, and is still very much a concern for at-risk groups. Removing this term does not alter the meaning or intention of the question and so has been left out of this report.
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -1058,11 +1058,11 @@ The majority of respondents (80.8%) reported feeling "positive" about their work
 
    </details>
 
-55.1% of respondents reported that they have not been affected by "return to office" (RTO) policies. 42.8% have been affected, with only 2.2% unsure. 
+55.1% of respondents reported that they have not been affected by "return to office" (RTO) policies. 42.8% have been affected, with only 2.2% unsure.
 
-Of those that were not affected, 26.2% - the largest segment overall - reported that remote work was still allowed, encouraged or required, with another 23.4% stating that their position was always remote-only. 
+Of those that were not affected, 26.2% - the largest segment overall - reported that remote work was still allowed, encouraged or required, with another 23.4% stating that their position was always remote-only.
 
-For those that have been affected, most reported that a hybrid model was being mandated (24.2% overall).  
+For those that have been affected, most reported that a hybrid model was being mandated (24.2% overall).
 
 .. raw:: html
 
@@ -1110,19 +1110,19 @@ For those that have been affected, most reported that a hybrid model was being m
 
    </div></div>
 
-Those who reported being affected by an RTO policy were asked about their feelings on the situation. 
+Those who reported being affected by an RTO policy were asked about their feelings on the situation.
 
 Those who were required to return to the office on a part-time basis were quite evenly split between neutral (32.9%), negative (26%) and very negative (22%). Those who were positive (14.6%) or very positive (4.5%) were in the minority.
 
-Those who reported that a return was being encouraged by not required were less negative overall - 41% reported "neutral", with the remainder split evenly between positive and negative. 
+Those who reported that a return was being encouraged by not required were less negative overall - 41% reported "neutral", with the remainder split evenly between positive and negative.
 
-Those affected by a full time RTO mandate felt predominantly negative, with only 3 individuals reporting positive feelings. 
+Those affected by a full time RTO mandate felt predominantly negative, with only 3 individuals reporting positive feelings.
 
 Preferred work location
 -----------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -1138,7 +1138,7 @@ Preferred work location
 
    </details>
 
-Regardless of their current situation, 58% of all respondents said that their preferred work location is remote. Another 38.2% favored a hybrid model (some days in the office, some days working from home or another location). Only 2.6% said they preferred working on-site at their employer's office, and 1.3% stated no preference. 
+Regardless of their current situation, 58% of all respondents said that their preferred work location is remote. Another 38.2% favored a hybrid model (some days in the office, some days working from home or another location). Only 2.6% said they preferred working on-site at their employer's office, and 1.3% stated no preference.
 
 .. table:: Preferred work location
    :widths: 70 15 15
@@ -1160,7 +1160,7 @@ Regardless of their current situation, 58% of all respondents said that their pr
 Employee salary, benefits and satisfaction
 ==========================================
 
-To protect the privacy of our community, we do not publish median salary figures for any region or category with less than 10 respondents. In previous years, this has meant that median salaries could only be given for a few regions and countries, and a handful of US states.     
+To protect the privacy of our community, we do not publish median salary figures for any region or category with less than 10 respondents. In previous years, this has meant that median salaries could only be given for a few regions and countries, and a handful of US states.
 
 With this year's survey amassing the highest number of submissions yet, we can now provide a more extensive range of salary breakdowns. Alongside the baseline data for Africa, which encompasses respondents from South Africa, Kenya, and Nigeria, we have gathered enough data to publish median salaries (|50th| percentile) for 15 individual countries, 17 US states, 3 Canadian provinces (including separate figures for each province's largest city), and 3 Australian states.
 
@@ -1170,12 +1170,12 @@ Currency
 --------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
 
-   |icon-question| What currency are you paid in? 
+   |icon-question| What currency are you paid in?
 
 .. raw:: html
 
@@ -1184,7 +1184,7 @@ Currency
 Employee respondents reported being paid in 26 different currencies. To make comparisons possible, all currencies were converted to USD using mid-market exchange rates, averaged for the whole of 2023.
 
 .. table:: Currencies and exchange rates - employees
-   :widths: 55 10 10 10 15
+   :widths: 55 10 15
    :name: tbl-2023-currencies-employees
    :class: std3col
 
@@ -1248,7 +1248,7 @@ Pay interval
 ------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -1259,13 +1259,13 @@ Pay interval
 
    </details>
 
-In some locations, it is customary to discuss salary as a yearly figure, while in other it is more common to talk about monthly salaries. Respondents were asked to specify if they were entering a yearly or monthly figure, and all monthly salaries were multiplied by 12 to allow for comparison. In total, 81.1% of employee respondents chose to enter their salary as a yearly figure, with 18.9% choosing monthly. 
+In some locations, it is customary to discuss salary as a yearly figure, while in other it is more common to talk about monthly salaries. Respondents were asked to specify if they were entering a yearly or monthly figure, and all monthly salaries were multiplied by 12 to allow for comparison. In total, 81.1% of employee respondents chose to enter their salary as a yearly figure, with 18.9% choosing monthly.
 
 Median salary
 -------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -1276,14 +1276,14 @@ Median salary
 
    </details>
 
-As in previous years, salaries for those working part-time hours (less than 30 per week) have been omitted from the figures in this section. The median salaries are based on 922 full-time employee respondents.  
+As in previous years, salaries for those working part-time hours (less than 30 per week) have been omitted from the figures in this section. The median salaries are based on 922 full-time employee respondents.
 
 
 .. container:: note
 
    .. rubric:: |icon-info| Definition of percentile values
 
-   Previous survey results have only reported the median salary - the number in the middle of the range, sometimes referred to as the |50th| percentile. Due to the increase in numbers and finer-grained location data, we're able this year to also publish figures for the |25th| and |75th| percentile figures, for regions where there are more than 30 respondents. 
+   Previous survey results have only reported the median salary - the number in the middle of the range, sometimes referred to as the |50th| percentile. Due to the increase in numbers and finer-grained location data, we're able this year to also publish figures for the |25th| and |75th| percentile figures, for regions where there are more than 30 respondents.
 
    In the following tables, the following definitions apply:
 
@@ -1305,10 +1305,10 @@ Given the range of socio-economic differences in the countries in the survey res
    - North America: Puerto Rico, St Kitts & Nevis, Mexico
    - Europe: Spain, Czech Republic, Finland, Italy, Switzerland, Croatia, Sweden, Serbia, Austria, Slovenia, Estonia, Greece, Belgium, Lithuania, Bulgaria, Norway, Turkey, Cyprus, Montenegro, Denmark
    - Oceania: New Zealand
-   - Asia: Japan, Singapore, Thailand, Indonesia 
+   - Asia: Japan, Singapore, Thailand, Indonesia
    - Middle East: United Arab Emirates, Lebanon
-   - Africa: South Africa, Kenya, Nigeria 
-   - South America: Brazil, Argentina 
+   - Africa: South Africa, Kenya, Nigeria
+   - South America: Brazil, Argentina
 
 .. table:: Salary (USD) by respondent region
    :name: tbl-2023-salary-by-respondent-region
@@ -1365,7 +1365,7 @@ Given the range of socio-economic differences in the countries in the survey res
 Median salary by respondent region - further breakdowns
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Respondent numbers allow some additional breakdowns by US state, Candian province and Australian state, as well as a handful of North American cities. 
+Respondent numbers allow some additional breakdowns by US state, Candian province and Australian state, as well as a handful of North American cities.
 
 .. raw:: html
 
@@ -1470,9 +1470,9 @@ Respondent numbers allow some additional breakdowns by US state, Candian provinc
 Median salary by gender identity
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Due to numbers, we are only able to break down salary by gender identity for women (59.9% of all respondents) and men (34.7% of all respondents). In almost every region, men earned more than women, by as much as 76% in Asia - although with such a small sample size that is unlikely to be truly representative. 
+Due to numbers, we are only able to break down salary by gender identity for women (59.9% of all respondents) and men (34.7% of all respondents). In almost every region, men earned more than women, by as much as 76% in Asia - although with such a small sample size that is unlikely to be truly representative.
 
-The only region where the median for women was higher was North America overall - but even here, the 75th percentile salary was higher for men, and when looking at the two largest countries in that region (the United States and Canada) men were paid more overall. 
+The only region where the median for women was higher was North America overall - but even here, the 75th percentile salary was higher for men, and when looking at the two largest countries in that region (the United States and Canada) men were paid more overall.
 
 .. raw:: html
 
@@ -1884,7 +1884,7 @@ Employee benefits
 -----------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -1958,13 +1958,13 @@ Employee benefits
    | Transportation-related benefits (car, parking, fuel, public transport etc) | 184  | 19.6% |
    +----------------------------------------------------------------------------+------+-------+
 
-.. raw:: html 
-   
+.. raw:: html
+
    <div class="tbl-footnote">
 
 \* in excess of any government-mandated minimums
 
-.. raw:: html 
+.. raw:: html
 
    </div>
 
@@ -1972,7 +1972,7 @@ Employee satisfaction
 ---------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -2059,7 +2059,7 @@ Employee satisfaction
 
    </details>
 
-Looking at all regions, 68.7% of all employee respondents were satisfied with their salary and benefits package - 25.6% rated themselves "very satisfied". 
+Looking at all regions, 68.7% of all employee respondents were satisfied with their salary and benefits package - 25.6% rated themselves "very satisfied".
 
 .. raw:: html
 
@@ -2147,13 +2147,13 @@ As a result of 5 submissions in the "other" category, a new factor was added to 
    | No raises or adjustments for inflation *                              |   5 |  0.5% |
    +-----------------------------------------------------------------------+-----+-------+
 
-.. raw:: html 
-   
+.. raw:: html
+
    <div class="tbl-footnote">
 
 \* A new factor, added to the 2023 results as a result of multiple submissions in the "other" category
 
-.. raw:: html 
+.. raw:: html
 
    </div>
 
@@ -2162,7 +2162,7 @@ As a result of 5 submissions in the "other" category, a new factor was added to 
    <figure>
       <object role="img" aria-label="Factors affecting salary satisfaction" aria-describedby="figure_factors-affecting-salary-satisfaction_desc" type="image/svg+xml" data="/_images/2023-factors-affecting-salary-satisfaction.svg">
          <p id="figure_factors-affecting-salary-satisfaction_desc">Horizontal bar chart showing factors affecting salary satisfaction, as reported by employee respondents in 2023.</p>
-      </object> 
+      </object>
       <figcaption>Figure: Factors affecting salary satisfaction</figcaption>
    </figure>
 
@@ -2173,7 +2173,7 @@ As a result of 5 submissions in the "other" category, a new factor was added to 
 Factors affecting overall job satisfaction
 ------------------------------------------
 
-The most cited factor affecting overall job satisfaction among employees was "Role is undervalued or underfunded" - this option was selected by 34.7% of respondents. 
+The most cited factor affecting overall job satisfaction among employees was "Role is undervalued or underfunded" - this option was selected by 34.7% of respondents.
 
 Of the 19 respondents who selected "other" and provided more detail, those that did not fit into an existing category included:
 
@@ -2243,7 +2243,7 @@ Of the 19 respondents who selected "other" and provided more detail, those that 
 Factors enhancing job satisfaction
 ----------------------------------
 
-On the whole, respondents were very positive about the best aspects of their jobs. 85% said that they liked and/or respected their co-workers, and 72% highlighted flexibility in working hours or location. 
+On the whole, respondents were very positive about the best aspects of their jobs. 85% said that they liked and/or respected their co-workers, and 72% highlighted flexibility in working hours or location.
 
 Of those respondents who selected "other" and provided more detail, factors included:
 
@@ -2295,15 +2295,15 @@ Contract rates and satisfaction
 
    .. rubric:: |icon-info| Note on median rates for contractors
 
-   While the 2023 survey results include more contractors than in any previous year (79) this number is too low, and the respondents too geographically diverse, to determine median rates except for the very largest regions (the United States and Europe). Numbers are provided where possible, but it should be noted that the sample size is not large enough to provide meaningful insight. 
+   While the 2023 survey results include more contractors than in any previous year (79) this number is too low, and the respondents too geographically diverse, to determine median rates except for the very largest regions (the United States and Europe). Numbers are provided where possible, but it should be noted that the sample size is not large enough to provide meaningful insight.
 
-   For example, out of the 58 hourly rates entered, the highest value is 57 times higher than the lowest value. Even when only examining data for the United States, where 27 hourly rates were entered, the highest rate is 44 times higher than the lowest rate. Trying to segment these values further - by region, type of role, gender etc - results in numbers far too low to publish. 
+   For example, out of the 58 hourly rates entered, the highest value is 57 times higher than the lowest value. Even when only examining data for the United States, where 27 hourly rates were entered, the highest rate is 44 times higher than the lowest rate. Trying to segment these values further - by region, type of role, gender etc - results in numbers far too low to publish.
 
 Preferred term
 --------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -2321,7 +2321,7 @@ Preferred term
 
 For the first time this year, we asked those respondents who are not employees what term they use to describe the kind of work they do. 53.2% term themselves "contractors", while 27.8% prefer "self-employed" and 16.5% use "freelancer". Of those who chose "other", the two terms added were "agency" and "consultant".
 
-Several contractor respondents indicated that they were contractors by necessity rather than choice, taking contracts either because they were unable to find a suitable employment offer, or anticipating an employment offer after a period of contracting. 
+Several contractor respondents indicated that they were contractors by necessity rather than choice, taking contracts either because they were unable to find a suitable employment offer, or anticipating an employment offer after a period of contracting.
 
 .. table:: Preferred term - contractors
    :widths: 70 15 15
@@ -2344,12 +2344,12 @@ Type of contract work
 ---------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
 
-   |icon-question| What kind of contract, freelance or self-employed work do you typically engage in? Check all that apply. 
+   |icon-question| What kind of contract, freelance or self-employed work do you typically engage in? Check all that apply.
 
    - I work for multiple clients at the same time
    - I work for one client at a time
@@ -2367,7 +2367,7 @@ Type of contract work
 Contractor work type - clients
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-48% of contractor clients indicated that they worked exclusively for a single client at a time. Another 34% indicated that they worked exclusively for multiple clients at a time. 13% worked at times for either a single client or multiple clients, and 5% did not indicate whether they worked for a single client or multiple. 
+48% of contractor clients indicated that they worked exclusively for a single client at a time. Another 34% indicated that they worked exclusively for multiple clients at a time. 13% worked at times for either a single client or multiple clients, and 5% did not indicate whether they worked for a single client or multiple.
 
 .. table:: Contractor work type - clients
    :widths: 70 15 15
@@ -2438,7 +2438,7 @@ Currency and rates
 ------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -2448,7 +2448,7 @@ Currency and rates
    What is your hourly rate?
    What is you day rate?
    What is your monthly rate?
-   Note: Please don't include any VAT, GST or sales tax. 
+   Note: Please don't include any VAT, GST or sales tax.
 
 .. raw:: html
 
@@ -2460,7 +2460,7 @@ Currencies
 Contractor respondents were paid in 7 different currencies. To make comparisons possible, all currencies were converted to USD using mid-market exchange rates, averaged for the whole of 2023.
 
 .. table:: Currencies and exchange rates - contractors
-   :widths: 70 15 15 
+   :widths: 70 15 15
    :name: tbl-2023-currencies-exchange-rates-contractors
    :class: std3col
 
@@ -2538,7 +2538,7 @@ Location of contractors
    +------------------+-----+-------+
    | - Austria        |   1 |       |
    +------------------+-----+-------+
-   
+
 .. raw:: html
 
    </div><div class="tab__content">
@@ -2575,23 +2575,23 @@ Location of contractors
 Fee structures
 ~~~~~~~~~~~~~~
 
-Comparing payment rates for contractors is difficult due to the number of different ways that individuals in this group operate. To simplify this as much as possible while still allowing comparisons, contractors were asked to estimate their hourly rate, day rate or monthly rate - or one of each type of rate, if appropriate - even if they normally used a different fee structure. Contractors charging multiple rates or in multiple currencies were asked to enter their most common rate, or an average if they felt that was more representative.  
+Comparing payment rates for contractors is difficult due to the number of different ways that individuals in this group operate. To simplify this as much as possible while still allowing comparisons, contractors were asked to estimate their hourly rate, day rate or monthly rate - or one of each type of rate, if appropriate - even if they normally used a different fee structure. Contractors charging multiple rates or in multiple currencies were asked to enter their most common rate, or an average if they felt that was more representative.
 
 The hourly rate was the most popular option, utilized by 73.4% of respondents (and exclusively by 41.8%). Next was monthly rates, entered by 43% of respondents (exclusively by 20.3%). Day rates were entered by 38% of respondents, but only exclusively by 6.3%.
 
-41.8% of respondents entered a figure for all three fee structures. 8.9% entered both hourly and day rates, and there were no respondents entering only hourly and monthly, or only daily and monthly figures. 
+41.8% of respondents entered a figure for all three fee structures. 8.9% entered both hourly and day rates, and there were no respondents entering only hourly and monthly, or only daily and monthly figures.
 
 Median hourly rate
 ~~~~~~~~~~~~~~~~~~
 
-The median hourly rate across all regions (from 58 respondents) was USD $53. Drilling down to North America (34 respondents), that rises to USD $55, and this number stays the same when examining the United States only (27 respondents). 
+The median hourly rate across all regions (from 58 respondents) was USD $53. Drilling down to North America (34 respondents), that rises to USD $55, and this number stays the same when examining the United States only (27 respondents).
 
-Looking at Europe, the median hourly rate was USD $33 (19 respondents). No further splits are possible in this region. 
+Looking at Europe, the median hourly rate was USD $33 (19 respondents). No further splits are possible in this region.
 
 Median day rate
 ~~~~~~~~~~~~~~~
 
-The median day rate across all regions (30 respondents) was USD $447. Looking at North America only (12 respondents), this goes up to USD $465, and in the United States only (10 respondents) to USD $480.  
+The median day rate across all regions (30 respondents) was USD $447. Looking at North America only (12 respondents), this goes up to USD $465, and in the United States only (10 respondents) to USD $480.
 
 Looking only at Europe (13 respondents), the median day rate was USD $242.
 
@@ -2604,7 +2604,7 @@ Contractor satisfaction
 -----------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -2617,9 +2617,9 @@ Contractor satisfaction
    - Satisfied
    - Very satisfied
 
-   What reasons do you have for dissatisfaction with your contract or freelance rates, if any? Check all that apply, or check "none of the above". 
+   What reasons do you have for dissatisfaction with your contract or freelance rates, if any? Check all that apply, or check "none of the above".
    Note: Due to the many different types of contract and freelance work, some of these may not apply to your situation.
- 
+
    - Rate is too low
    - Discrepancy between rate and cost of living in my area
    - Unfair or inconsistent rates across similar roles in the organizations I work for
@@ -2882,7 +2882,7 @@ Factors affecting contractor satisfaction
 Pay transparency
 ================
 
-Organizations with pay transparency are open about salaries and benefits for existing and prospective employees and contractors. Due to feedback from contractors in 2022, pay transparency questions were only shown to employee respondents. 
+Organizations with pay transparency are open about salaries and benefits for existing and prospective employees and contractors. Due to feedback from contractors in 2022, pay transparency questions were only shown to employee respondents.
 
 .. container:: note
 
@@ -2897,7 +2897,7 @@ Official pay transparency policy
 --------------------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -2914,9 +2914,9 @@ Official pay transparency policy
 
    </details>
 
-52.2% of respondents reported that there was no official pay transparency policy at their organization, and 23.9% were unsure. These numbers are almost exactly the same as last year, which was the first time that this question was included. 
+52.2% of respondents reported that there was no official pay transparency policy at their organization, and 23.9% were unsure. These numbers are almost exactly the same as last year, which was the first time that this question was included.
 
-9.8% of organizations had a partial policy, and 6.8% had a full open pay transparency (slightly up from 5.3% last year). 7.2% had a policy forbidding any pay disclosure, which is slightly down from 9% last year. 
+9.8% of organizations had a partial policy, and 6.8% had a full open pay transparency (slightly up from 5.3% last year). 7.2% had a policy forbidding any pay disclosure, which is slightly down from 9% last year.
 
 .. table:: Pay transparency policy
    :widths: 70 15 15
@@ -2941,7 +2941,7 @@ Pay transparency culture
 ------------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -2980,7 +2980,7 @@ Feelings about pay transparency
 -------------------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -2997,7 +2997,7 @@ Feelings about pay transparency
 
    </details>
 
-74.9% of respondents were supportive of pay transparency, with 45.7% expressing strong support. Those in opposition were in the minority (3.6%).   
+74.9% of respondents were supportive of pay transparency, with 45.7% expressing strong support. Those in opposition were in the minority (3.6%).
 
 .. table:: Feelings about pay transparency
    :widths: 70 15 15
@@ -3027,7 +3027,7 @@ Organization size
 -----------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -3046,7 +3046,7 @@ Organization size
 
    </details>
 
-As in previous years, medium-sized organizations make up the largest proportion of the results. When separating the employee respondents from the contractor respondents, a different pattern emerges - contractors are generally spread much more evenly between small, medium and large organizations.  
+As in previous years, medium-sized organizations make up the largest proportion of the results. When separating the employee respondents from the contractor respondents, a different pattern emerges - contractors are generally spread much more evenly between small, medium and large organizations.
 
 .. raw:: html
 
@@ -3110,7 +3110,7 @@ Organization type and industry
 ------------------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -3160,13 +3160,13 @@ Organization type and industry
 
    </details>
 
-Respondents who selected software development or software development tools were asked to also select the industries that the software product or service created by the organization primarily caters to, if possible. For example, e-learning software would also be categorized as "Education, Training" and point of sale software for restaurants would also be "Food, Beverages". 
+Respondents who selected software development or software development tools were asked to also select the industries that the software product or service created by the organization primarily caters to, if possible. For example, e-learning software would also be categorized as "Education, Training" and point of sale software for restaurants would also be "Food, Beverages".
 
 The majority of organizations represented in the results - 94.8% - were for-profit businesses or corporations rather than non-profit, community, political, educational or government organizations, or NGOs.
 
 Based on feedback and "other" entries for industry, the final list of industries has been adjusted for the final results. One entirely new industry group has been added - Parks, Recreation, Nature, Wildnerness, Outdoors, Conservation, Ecotourism - and several others have had their definitions expanded.
 
-69.3% of respondents chose a single industry from the list, and 20% selected two, and 6% selected three different industries. 
+69.3% of respondents chose a single industry from the list, and 20% selected two, and 6% selected three different industries.
 
 .. table:: Organization industry
    :widths: 70 15 15
@@ -3248,7 +3248,7 @@ Organization origin and location
 --------------------------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -3259,11 +3259,11 @@ Organization origin and location
 
    Note: This is the primary location, headquarters or main location - or for multinational organizations, the location where the organization originated. This is not your location - that will be covered in the next section.
 
-   Country: 
+   Country:
 
-   State/Province/Region: 
-   
-   City/Town (optional): 
+   State/Province/Region:
+
+   City/Town (optional):
 
 .. raw:: html
 
@@ -3271,7 +3271,7 @@ Organization origin and location
 
 79.8% of respondents reported that their employer organization was a multinational organization - one with office locations and business operations in two or more countries. These respondents were asked to specify the location where the organization originated.
 
-A total of 63.3% of organizations originated in North America, with the bulk of those being US-based. 
+A total of 63.3% of organizations originated in North America, with the bulk of those being US-based.
 
 .. raw:: html
 
@@ -3295,7 +3295,7 @@ A total of 63.3% of organizations originated in North America, with the bulk of 
    +----------------------------------------+---------+-----------+
    | - Mexico                               |    2    |           |
    +----------------------------------------+---------+-----------+
- 
+
 .. raw:: html
 
 	</div><div class="tab__content">
@@ -3429,13 +3429,13 @@ A total of 63.3% of organizations originated in North America, with the bulk of 
 Respondent demographics
 =======================
 
-Who makes up the Write the Docs community? The questions in this section on respondent age, gender identity, education, experience, and location provide context for the salary/rate and satisfaction data. All questions in this section had an "I'd rather not say" option, with the exception of geographical location (country and state or province only), without which the core objective of the survey cannot be achieved.    
+Who makes up the Write the Docs community? The questions in this section on respondent age, gender identity, education, experience, and location provide context for the salary/rate and satisfaction data. All questions in this section had an "I'd rather not say" option, with the exception of geographical location (country and state or province only), without which the core objective of the survey cannot be achieved.
 
 Age group
 ---------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -3454,7 +3454,7 @@ Age group
 
    </details>
 
-The age group split was very neat this year - approximately one third of respondents were in the 26-35 year old age group, and another third were in the 36-45 year old age group. The remaining third were mostly in the older groups - 46-55, 56-65, and 66+ - although 3.2% fell into the 18-25 year old group and 1.2% chose not to supply an answer. 
+The age group split was very neat this year - approximately one third of respondents were in the 26-35 year old age group, and another third were in the 36-45 year old age group. The remaining third were mostly in the older groups - 46-55, 56-65, and 66+ - although 3.2% fell into the 18-25 year old group and 1.2% chose not to supply an answer.
 
 .. table:: Age group
    :widths: 70 15 15
@@ -3484,7 +3484,7 @@ The age group split was very neat this year - approximately one third of respond
    <figure>
       <object role="img" aria-label="Respondent age group" aria-describedby="figure_respondent-age-group_desc" type="image/svg+xml" data="/_images/2023-respondent-age-group.svg">
          <p id="figure_respondent-age-group_desc">Vertical bar chart showing age groupings of respondents. </p>
-      </object> 
+      </object>
       <figcaption>Figure: Respondent age group</figcaption>
    </figure>
 
@@ -3495,7 +3495,7 @@ Gender identity
 ---------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -3512,7 +3512,7 @@ Gender identity
 
    </details>
 
-The majority of respondents in 2023 were women - accounting for 59.9% of the total, slightly higher than in previous surveys. Men made up 34.7% - slightly lower than in previous surveys. 2.9% of respondents were non-binary, 0.3% chose "other", and 2.2% did not provide an answer. 
+The majority of respondents in 2023 were women - accounting for 59.9% of the total, slightly higher than in previous surveys. Men made up 34.7% - slightly lower than in previous surveys. 2.9% of respondents were non-binary, 0.3% chose "other", and 2.2% did not provide an answer.
 
 .. table:: Gender identity
    :widths: 70 15 15
@@ -3538,7 +3538,7 @@ The majority of respondents in 2023 were women - accounting for 59.9% of the tot
    <figure>
       <object role="img" aria-label="Respondent gender identity" aria-describedby="figure_respondent-gender-identity_desc" type="image/svg+xml" data="/_images/2023-respondent-gender-identity.svg">
          <p id="figure_respondent-gender-identity_desc">Donut chart showing gender identity of respodnents.</p>
-      </object> 
+      </object>
       <figcaption>Figure: Respondent gender identity</figcaption>
    </figure>
 
@@ -3549,7 +3549,7 @@ Experience
 ----------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -3571,7 +3571,7 @@ Experience
 
    </details>
 
-The experience level of respondents in 2023 was similar to previous years - around half fell into either the 5-10 years range (27.8%) or 2-5 years range (20%). 43.4% of respondents were spread out over the most experienced ranges - starting from 10 years of experience and going all the way up to 50 years in the documentation game. Only 8.3% were new documentarians (2.9% with less than one year and 5.4% with 1-2 years). 0.4% did not provide an answer. 
+The experience level of respondents in 2023 was similar to previous years - around half fell into either the 5-10 years range (27.8%) or 2-5 years range (20%). 43.4% of respondents were spread out over the most experienced ranges - starting from 10 years of experience and going all the way up to 50 years in the documentation game. Only 8.3% were new documentarians (2.9% with less than one year and 5.4% with 1-2 years). 0.4% did not provide an answer.
 
 .. table:: Experience in documentation
    :widths: 70 15 15
@@ -3607,7 +3607,7 @@ The experience level of respondents in 2023 was similar to previous years - arou
    <figure>
       <object role="img" aria-label="Respondent years of experience" aria-describedby="figure_respondent-years-experience_desc" type="image/svg+xml" data="/_images/2023-respondent-years-experience.svg">
          <p id="figure_respondent-years-experience_desc">Vertical bar chart showing respondents' years of experience in documentation. </p>
-      </object> 
+      </object>
       <figcaption>Figure: Years of experience in documentation</figcaption>
    </figure>
 
@@ -3618,7 +3618,7 @@ Education level
 ---------------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -3639,7 +3639,7 @@ Education level
 
    </details>
 
-Overall, most respondents are university- or college-educated: 93.9% held at least one undergraduate qualification, and 41.3% also held a postgraduate qualification. 3.5% held multiple undergraduate qualifications, and 3.7% held multiple post-graduate qualifications. 0.4% chose not to answer, and 2 individuals indicated that they had none of the listed qualifications.     
+Overall, most respondents are university- or college-educated: 93.9% held at least one undergraduate qualification, and 41.3% also held a postgraduate qualification. 3.5% held multiple undergraduate qualifications, and 3.7% held multiple post-graduate qualifications. 0.4% chose not to answer, and 2 individuals indicated that they had none of the listed qualifications.
 
 .. table:: Highest education level completed
    :widths: 70 15 15
@@ -3671,7 +3671,7 @@ Overall, most respondents are university- or college-educated: 93.9% held at lea
    <figure>
       <object role="img" aria-label="Respondent education level" aria-describedby="figure_respondent-education-level_desc" type="image/svg+xml" data="/_images/2023-respondent-education.svg">
          <p id="figure_respondent-education-level_desc">Vertical bar chart showing respondents' highest completed level of education. </p>
-      </object> 
+      </object>
       <figcaption>Figure: Education level</figcaption>
    </figure>
 
@@ -3682,7 +3682,7 @@ Location
 --------
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -3692,14 +3692,14 @@ Location
    - Rural area (low population density, ≤5000 people)
    - Town or suburban area (medium population density, ≤50,000 people)
    - City or urban area (high population density, >50,000 people)
-   
+
    Please refer to this World Bank article on Degree of Urbanization [https://blogs.worldbank.org/sustainablecities/how-do-we-define-cities-towns-and-rural-areas] for more clarification.
 
-   Country: 
-   
-   State/Province/Region: 
-   
-   City/Town (optional): 
+   Country:
+
+   State/Province/Region:
+
+   City/Town (optional):
 
 .. raw:: html
 
@@ -3707,10 +3707,10 @@ Location
 
 While most questions in this section were optional, general geographical location was not - this is because without country and state/province/region, we cannot calculate regional median salaries, which is one of the main objectives of the survey. For privacy reasons, finer-grained geographical location is optional.
 
-The majority of respondents - 70.3% - reported living in a city or urban area, with 23.7% in a town or suburban (semi-dense) location and only 6% living in a rural area. 
+The majority of respondents - 70.3% - reported living in a city or urban area, with 23.7% in a town or suburban (semi-dense) location and only 6% living in a rural area.
 
-.. table:: Degree of urbanization 
-   :widths: 70 15 15                
+.. table:: Degree of urbanization
+   :widths: 70 15 15
    :name: tbl-2023-degree-of-urbanization
    :class: std3col
 
@@ -3724,16 +3724,16 @@ The majority of respondents - 70.3% - reported living in a city or urban area, w
    | Rural area            | 61  | 6.0%  |
    +-----------------------+-----+-------+
 
-A little over half of respondents (55.7%) were based in North America, the bulk of those in the United States. 
+A little over half of respondents (55.7%) were based in North America, the bulk of those in the United States.
 
-New countries appearing in the results for 2023 include the Caribbean nation St Kitts & Nevis, Puerto Rico, United Arab Emirates, Lebanon, and Rwanda. 
+New countries appearing in the results for 2023 include the Caribbean nation St Kitts & Nevis, Puerto Rico, United Arab Emirates, Lebanon, and Rwanda.
 
 .. raw:: html
 
    <div class="tab-wrap"><input type="radio" id="tabH6-1" name="tabGroupH6" class="tab" checked><label for="tabH6-1">North America</label><input type="radio" id="tabH6-2" name="tabGroupH6" class="tab"><label for="tabH6-2">Europe</label><input type="radio" id="tabH6-3" name="tabGroupH6" class="tab"><label for="tabH6-3">Other Regions</label><div class="tab__content">
 
 .. table:: Respondent location - North America
-   :widths: 70 15 15                
+   :widths: 70 15 15
    :name: tbl-2023-respondent-location-north-america
    :class: std3col
 
@@ -4066,10 +4066,10 @@ Respondent location regional breakdowns
 Survey feedback
 ===============
 
-For the first time this year, we included a mini "meta-survey" - a handful of questions about the survey itself.  
+For the first time this year, we included a mini "meta-survey" - a handful of questions about the survey itself.
 
 .. raw:: html
-   
+
    <details><summary>What we asked</summary>
 
 .. container:: question
@@ -4086,25 +4086,25 @@ For the first time this year, we included a mini "meta-survey" - a handful of qu
 
    </details>
 
-More than half of the 2023 respondents - 58.2% - were first-time WTD Salary Survey participants. 
+More than half of the 2023 respondents - 58.2% - were first-time WTD Salary Survey participants.
 
 .. raw:: html
 
    <figure>
       <object role="img" aria-label="First-time vs repeat survey participants" aria-describedby="figure_first-time-vs-repeat-participants_desc" type="image/svg+xml" data="/_images/2023-first-time-vs-repeat-participants.svg">
          <p id="figure_first-time-vs-repeat-participants_desc">Donut chart showing proportion of first-time to repeat survey participants.</p>
-      </object> 
+      </object>
       <figcaption>Figure: First time vs repeat survey participants</figcaption>
    </figure>
 
 .. figure:: images/2023/2023-first-time-vs-repeat-participants.svg
    :class: hide
 
-Regarding the relevance of the questions, 52.2% rated them "excellent", and another 38.8% thought they were "good". 7.7% felt they were just "OK", and only 0.5% chose "not great". 0.8% chose not to share an opinion. 
+Regarding the relevance of the questions, 52.2% rated them "excellent", and another 38.8% thought they were "good". 7.7% felt they were just "OK", and only 0.5% chose "not great". 0.8% chose not to share an opinion.
 
-Concerning the usability of the survey form and website, over half rated it "excellent", with another 28.8% rating it "good". 6.1% chose "ok", 1.1% thought it was "no great" and 0.5% had no opinion. 
+Concerning the usability of the survey form and website, over half rated it "excellent", with another 28.8% rating it "good". 6.1% chose "ok", 1.1% thought it was "no great" and 0.5% had no opinion.
 
-The length of the survey has been an area of concern for the survey team, so we were quite relieved to find that 80.3% of respondents said that the length was "just right". However, a significant proportion - 13.6% - were of the opinion that the survey was too long (and another 1.2% chose "far too long") so this is something we will take into consideration in future surveys. 4% had no opinion and a very small percentage of survey fans (0.8%) said that it was "too short". 
+The length of the survey has been an area of concern for the survey team, so we were quite relieved to find that 80.3% of respondents said that the length was "just right". However, a significant proportion - 13.6% - were of the opinion that the survey was too long (and another 1.2% chose "far too long") so this is something we will take into consideration in future surveys. 4% had no opinion and a very small percentage of survey fans (0.8%) said that it was "too short".
 
 .. raw:: html
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,8 @@ sphinxemoji==0.2.0
 # For atom feed support
 Werkzeug==0.16.1 # pyup: <1.0
 # For fancy 404 pages
-sphinx-notfound-page==0.8
+sphinx-notfound-page==1.0.0
 # For fancy twitter previews
 sphinxext-opengraph==0.8.1
+
+pytz==2024.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
-Sphinx==4.5.0
+Sphinx==7.4.7
 
 # make livehtml support
 sphinx_autobuild==2021.3.14
 
 # Markdown support
-myst-parser==0.17.2
+myst-parser==4.0.0
 
 # Blogging
-ablog==0.10.6  # pyup: ignore
+ablog==0.11.11  # pyup: ignore
 
 # Sphinx (checked with 4.3) requires docutils=<0.18
-docutils==0.17.1   # pyup: <0.18
+docutils==0.21.2
 PyYAML>=4.2b1
 
 # Additional libraries

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,15 @@
-Sphinx==7.4.7
+Sphinx==7.1.2
 
 # make livehtml support
 sphinx_autobuild==2021.3.14
 
 # Markdown support
-myst-parser==4.0.0
+myst-parser==3.0.1
 
 # Blogging
-ablog==0.11.11  # pyup: ignore
+ablog==0.10.6
 
-# Sphinx (checked with 4.3) requires docutils=<0.18
-docutils==0.21.2
+docutils==0.20.1
 PyYAML>=4.2b1
 
 # Additional libraries


### PR DESCRIPTION
We don't have to merge this yet, and especially without testing, but I went down this rabbit hole because I wanted to upgrade ablog to 0.11.11 which removes the spurious parallelization error. 

That led to a few other changes and crashed into

```
Extension error (ablog):
Handler <function builder_inited at 0x7fd8867c5b40> for event 'builder-inited' threw an exception (exception: Found the path from `ablog.get_html_templates_path()` in the `templates_path` variable from `conf.py`. Doing so interferes with Ablog's ability to stay compatible with Sphinx themes that support it out of the box. Please remove `get_html_templates_path` from `templates_path` in your `conf.py` to resolve this.)
make: *** [Makefile:55: html] Error 2
```

Which probably looks like it'll take more significant work.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2246.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->