### PR TITLE
Remove sphinx-action from build step and build HTML directly

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -39,10 +39,10 @@ jobs:
         pip install -r requirements.txt
 
     - name: Build
-      uses: rickstaa/sphinx-action@master
-      with:
-        docs-folder: "./docs"
-        build-command: "sphinx-build -q -W -b dirhtml -d _build/doctrees . _build/html"
+      run: |
+        cd docs
+        sphinx-build -q -W -b dirhtml -d _build/doctrees . _build/html
+        cd ../
 
     # Upload performance is awful on the many small files our build generates,
     # so it's compressed locally before uploading

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,8 +75,6 @@ exclude_patterns = [
     'videos/prague/2018/tackling-technical-debt-in-the-docs-louise-fahey.rst',
 ]
 
-html4_writer = True
-
 # We use these *local* environment variables for private info like free ticket links
 
 cfp_variables = {}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,6 +75,8 @@ exclude_patterns = [
     'videos/prague/2018/tackling-technical-debt-in-the-docs-louise-fahey.rst',
 ]
 
+html4_writer = True
+
 # We use these *local* environment variables for private info like free ticket links
 
 cfp_variables = {}


### PR DESCRIPTION
### What
- When working on the python update I ran into a problem of python version mismatch. This PR fixes that.
- Others also ran into this problem and decided to build the HTML directly:
https://github.com/ammaraskar/sphinx-action/issues/43#issuecomment-1218439431

### How to test
- Pipeline should pass.
- HTML should build as normal.

### Notes
- This loses the [checks](https://github.com/marketplace/actions/sphinx-build-composite) function
- The [Github action](https://github.com/rickstaa/action-sphinx-composite) isn't updated in 4 years

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2274.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->