### PR TITLE
Add devcontainer section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,20 @@ virtual Python environment with the following command on Linux:
 If you have verified this command on Windows, we invite you to submit a PR to include that information here.
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/writethedocs/www.svg)](https://greenkeeper.io/)
+
+### Using devcontainer
+
+In addition to local development with Python `venv`, it is also possible to use the devcontainer found in the root of the project.
+
+### Requirements
+
+Make sure all of the following is installed.
+
+- [Docker](https://docs.docker.com/get-started/get-docker/)
+- [Supported IDE](https://containers.dev/supporting#editors)
+
+Follow the steps below to open the development environment.
+
+1. Open a [supported IDE](https://containers.dev/supporting#editors)
+2. Click the "Open in devcontainer" popup
+3. The development environment starts in an containerized environment


### PR DESCRIPTION
### What

In addition to the added [devcontainer setup](https://github.com/writethedocs/www/pull/2272): A readme section is added to the readme.

### How to test
- Read the readme and make sure the explanation is correct.

### Notes
- Let me know if you have any feedback on the writing style, for example.


<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2275.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->