### PR TITLE
Add dependabot config to keep the Gemfile up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
### What
- Adds dependabot config to enable Pull Requests for gems.
- This will keep the gems in the [Gemfile](https://github.com/writethedocs/www/blob/main/Gemfile) up to date.
- For now this is only to keep ([htmlproofer](https://github.com/gjtorikian/html-proofer)) up to date.

### Docs
- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2296.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->