### PR TITLE
Ship Berlin Sponsorship Info

### DIFF
--- a/docs/_data/berlin-2025-config.yaml
+++ b/docs/_data/berlin-2025-config.yaml
@@ -159,21 +159,19 @@ date: # how do we handle these? human readable would be nice.
     summary: And the conference goes on! More talks and unconference today!
     dotw: Tuesday
     talk_time: 10:00-17:00
-    job_fair_time: 10:00-12:00
     unconference_time: 13:00-17:00
     icon: conversation
   total_talk_days: 2
 
 about:
   attendees: 200
-#  social_venue: Jupiter NEXT, 900 E Burnside St (2nd floor)
-#  venue: Revolution Hall
-#  venue_address: Revolution Hall, 1300 SE Stark St, Portland, Oregon 97214
+#  social_venue: 
+#  venue: 
+#  venue_address: 
 #  photos: TBD
   mainroom: Main stage
   unconfroom: TBC
   projector_ratio: "16:9"
-  job_fair_room: Sponsor area
 
 cfp: # Conf dates 27-28 October
   url: "https://pretalx.com/wtd-berlin-2025/cfp"   # Open June 2 (Mon), -> 8 weeks to submit
@@ -240,5 +238,5 @@ flaghashike: False
 flaghasfood: True
 flaghaswritingday: False
 flaghaslightningtalks: True
-flaghasjobfair: True
+flaghasjobfair: False
 flaghasboat: False

--- a/docs/conf/berlin/2025/sponsors/information.md
+++ b/docs/conf/berlin/2025/sponsors/information.md
@@ -21,12 +21,12 @@ The address is: Paul-Lincke-Ufer 21, 10999 Berlin
 * 07:00: Arrival and booth setup for Patron sponsors
 * 08:00: Doors to venue/sponsor booths open
 * 09:30–17:00: Speaker Talks and Unconference
-* 10:55: Booth sponsor introductions on main stage
+* 11:35: Booth sponsor introductions on main stage
 
 **TUESDAY**:
 
-* 07:45: Patron sponsor arrival
-* 08:00: Doors to venue/sponsor booths open
+* 08:00: Patron sponsor arrival
+* 08:30: Doors to venue/sponsor booths open
 * 09:00–16:00: Speaker Talks and Unconference
 * 16:00: Conference ends/load out
 * 17:30: Out of the venue 
@@ -34,9 +34,9 @@ The address is: Paul-Lincke-Ufer 21, 10999 Berlin
 ## Conference Overview
 
 
-* **MONDAY**: Day 1 of Speaker Talks and Unconference. Booth setup begins for Patron sponsors at 07:00. Attendees begin to arrive at 08:00. Sponsor introductions will happen after the first coffee break on the main stage for booth sponsors. Two thirds of attendees check in early this morning. There are seven speakers, with a short break after each talk. The Unconference track runs parallel to Speaker Talks. 
+* **MONDAY**: Day 1 of Speaker Talks and Unconference. Booth setup begins for Patron sponsors at 08:00. Attendees begin to arrive at 08:30. Sponsor introductions will happen after the first coffee break on the main stage for booth sponsors. Two thirds of attendees check in early this morning. There are seven speakers, with a short break after each talk. The Unconference track runs parallel to Speaker Talks. 
 
-* **TUESDAY**: Day 2 of Speaker Talks and Unconference. Patron sponsor arrival is at 07:45. Doors open at 08:00. Schedule is similar to Monday. There are six speakers this day. Tear down for sponsors starts at 16:00, and all things must be removed from the venue the last day of the conference.
+* **TUESDAY**: Day 2 of Speaker Talks and Unconference. Patron sponsor arrival is at 08:00. Doors open at 08:30. Schedule is similar to Monday. There are six speakers this day. Tear down for sponsors starts at 16:00, and all things must be removed from the venue the last day of the conference.
 
 The [full schedule](/conf/{{ shortcode }}/{{ year }}/schedule/) will be available around a month before the conference.
 
@@ -66,7 +66,7 @@ Sponsor booths are set up in the main hallway on Monday and Tuesday outside of t
 
 **Logistics**:
 
-* **We provides**: Each sponsor receives a 2.4 m (8 ft) table, 2 chairs, and access to power and Wi‑Fi. You must provide your own linen.
+* **We provides**: Each sponsor receives a 200x80cm (6.5') table, 2 chairs, and access to power and Wi‑Fi. You must provide your own linen.
 * You are responsible for loading in and loading out your entire booth setup.
 * **Recommendations**: We encourage you to bring a table linen with your company logo and laptop or tablet to show off your product. Some sponsors bring a banner frame to place behind their table. Check in with the Sponsorship Coordinator for specific setup questions.
 * **Arrive early for setup**: Sponsor arrival is 07:00 on Monday; the conference venue opens at 08:00. We recommend arriving on time to be set up for attendee arrival.
@@ -74,21 +74,6 @@ Sponsor booths are set up in the main hallway on Monday and Tuesday outside of t
 * **Bring swag (especially stickers)**: We recommend bringing a variety of swag to give away. Stickers are by far the most popular item for our attendees.
 * **Engage with folks as both a sponsor and attendee**: This is a great opportunity to meet folks in the community, so we recommend engaging with folks in an official capacity, but also as a regular attendee.
 * **Use QR codes**: QR codes are a great way to get people to a website quickly. We recommend using a service like <https://www.qr-code-generator.com/> to create these.
-
-### Lightning Talks
-
-If your sponsorship includes a Lightning Talk, you will be given 60 seconds to present on the main stage. This is a great way to introduce your company to the entire audience.
-
-**Logistics**:
-
-* Your 60-second introduction will occur on Monday or Tuesday, after lunch and before Lightning Talks begin.
-* If you want to use a slide for your introduction, let us know. Otherwise, we will create a slide with your logo.
-
-**Logistics**:
-
-* Sessions are on Sunday in the morning, afternoon, or all day.
-* View our [Lead a Project](https://www.writethedocs.org/conf/{{ shortcode }}/{{ year }}/writing-day/#lead-a-project) for more information.
-
 
 ### Unconference
 
@@ -118,8 +103,8 @@ You should have received a unique URL with a discount code for your sponsorship 
 
 ### How should I send my booth materials?
 
-* Patron sponsors are allowed to send 3 boxes at 61 × 46 × 46 cm (24 × 18 × 18 in) in size. Please contact us for the shipping address for an organizer, as the venue doesn't accept packages.
-* Packages must arrive between 1 and 2 weeks before the conference.
+* Patron sponsors are allowed to send 3 boxes at 61 × 46 × 46 cm (24 × 18 × 18 in) in size. Please contact us for the shipping address.
+* Packages must arrive between 1 week before the conference at most.
 * Sponsors are responsible for all sponsorship materials after they arrive at the venue. 
 * Sponsors are responsible for mailing all materials after the conference. 
 * Please print your return shipping labels prior to coming to the venue to send your materials back.

--- a/docs/conf/berlin/2025/sponsors/information.md
+++ b/docs/conf/berlin/2025/sponsors/information.md
@@ -66,7 +66,7 @@ Sponsor booths are set up in the main hallway on Monday and Tuesday outside of t
 
 **Logistics**:
 
-* **We provides**: Each sponsor receives a 200x80cm (6.5') table, 2 chairs, and access to power and Wi‑Fi. You must provide your own linen.
+* **We provide**: Each sponsor receives a 200x80cm (6.5') table, 2 chairs, and access to power and Wi‑Fi. You must provide your own linen.
 * You are responsible for loading in and loading out your entire booth setup.
 * **Recommendations**: We encourage you to bring a table linen with your company logo and laptop or tablet to show off your product. Some sponsors bring a banner frame to place behind their table. Check in with the Sponsorship Coordinator for specific setup questions.
 * **Arrive early for setup**: Sponsor arrival is 07:00 on Monday; the conference venue opens at 08:00. We recommend arriving on time to be set up for attendee arrival.
@@ -104,7 +104,7 @@ You should have received a unique URL with a discount code for your sponsorship 
 ### How should I send my booth materials?
 
 * Patron sponsors are allowed to send 3 boxes at 61 × 46 × 46 cm (24 × 18 × 18 in) in size. Please contact us for the shipping address.
-* Packages must arrive between 1 week before the conference at most.
+* Packages must arrive 1 week before the conference at most.
 * Sponsors are responsible for all sponsorship materials after they arrive at the venue. 
 * Sponsors are responsible for mailing all materials after the conference. 
 * Please print your return shipping labels prior to coming to the venue to send your materials back.

--- a/docs/conf/berlin/2025/sponsors/information.md
+++ b/docs/conf/berlin/2025/sponsors/information.md
@@ -10,39 +10,42 @@ Hi sponsors! We're excited to have you join us for our {{ year }} {{ city }} con
 
 ## Location
 
+The conference will be held at [bUm Berlin](https://bum.berlin/en/). 
+
+The address is: Paul-Lincke-Ufer 21, 10999 Berlin
+
 ## Schedule
 
 **MONDAY**:
 
-* 7:00am: Arrival and booth setup for Patron sponsors
-* 8:00am: Doors to venue/sponsor booths open
-* 9:00am-5:00pm: Speaker Talks and Unconference
-* 10:55am: Booth sponsor introductions on main stage
-* 5:00-7:00pm: Evening break
-* 7:00-9:00pm: Evening party at Jupiter NEXT (800 E Burnside St, 2nd floor)
+* 07:00: Arrival and booth setup for Patron sponsors
+* 08:00: Doors to venue/sponsor booths open
+* 09:30–17:00: Speaker Talks and Unconference
+* 10:55: Booth sponsor introductions on main stage
 
 **TUESDAY**:
 
-* 7:45am: Patron sponsor arrival
-* 8:00am: Doors to venue/sponsor booths open
-* 9:00am-4:00pm: Speaker Talks and Unconference
-* 4:00pm: Conference ends/load out
-* 5:30pm: Out of venue 
+* 07:45: Patron sponsor arrival
+* 08:00: Doors to venue/sponsor booths open
+* 09:00–16:00: Speaker Talks and Unconference
+* 16:00: Conference ends/load out
+* 17:30: Out of the venue 
 
 ## Conference Overview
 
 
-* **MONDAY**: Day 1 of Speaker Talks and Unconference. Booth setup begins for Patron sponsors at 7am. Attendees begin to arrive at 8am. Sponsor introductions will happen at 10:55am on the main stage for booth sponsors. Two thirds of attendees check in early this morning. There are seven speakers, with a short break after each talk. The Unconference track runs parallel to Speaker Talks. There is a Monday social gathering in the evening offsite.
+* **MONDAY**: Day 1 of Speaker Talks and Unconference. Booth setup begins for Patron sponsors at 07:00. Attendees begin to arrive at 08:00. Sponsor introductions will happen after the first coffee break on the main stage for booth sponsors. Two thirds of attendees check in early this morning. There are seven speakers, with a short break after each talk. The Unconference track runs parallel to Speaker Talks. 
 
-* **TUESDAY**: Day 2 of Speaker Talks and Unconference. Patron sponsor arrival is at 7:45am. Doors open at 8am. Schedule is similar to Monday. There are six speakers this day.
+* **TUESDAY**: Day 2 of Speaker Talks and Unconference. Patron sponsor arrival is at 07:45. Doors open at 08:00. Schedule is similar to Monday. There are six speakers this day. Tear down for sponsors starts at 16:00, and all things must be removed from the venue the last day of the conference.
 
-The [full schedule](/conf/{{ shortcode }}/{{ year }}/schedule/) is available.
+The [full schedule](/conf/{{ shortcode }}/{{ year }}/schedule/) will be available around a month before the conference.
 
 ### Venue Layout
 
 Our [Venue page](/conf/{{ shortcode }}/{{ year }}/venue/) has more information about the venue, including the location of the sponsor booths, speaker talks, and other conference spaces.
 
-## Media Kit
+<!-- Remove Media Kit for Berlin -->
+<!-- ## Media Kit
 
 Download copy and graphics from our [Media Kit](https://drive.google.com/drive/folders/1GMr65VQ9d0cXQXAmqfZfEuyZENTS3i8R?usp=drive_link).
 
@@ -51,23 +54,23 @@ This includes:
 * Social media copy
 * Email copy
 * "I am a sponsor" graphic
-* Event graphic 
+* Event graphic  -->
 
 ## Sponsorship Benefits During the Conference
 
-Each sponsorship includes different opportunities to engage with our attendees. View further information below on specifics to sponsor booths, Writing Day, Unconference, and Lightning Talks. 
+Each sponsorship includes different opportunities to engage with our attendees. View further information below on specifics to sponsor booths, Unconference, and Lightning Talks. 
 
 ### Sponsor Booths
 
-Sponsor booths are setup in the main hallway on Monday and Tuesday outside of the auditorium. Attendees are always looking for great products to use in their day to day workflows, and are curious to learn more about your company.
+Sponsor booths are set up in the main hallway on Monday and Tuesday outside of the auditorium. Attendees are always looking for great products to use in their day to day workflows, and are curious to learn more about your company.
 
 **Logistics**:
 
-* **WTD provides**: Each sponsor receives an 8 foot table, 2 chairs, and access to power and wifi. You must provide your own linen.
+* **We provides**: Each sponsor receives a 2.4 m (8 ft) table, 2 chairs, and access to power and Wi‑Fi. You must provide your own linen.
 * You are responsible for loading in and loading out your entire booth setup.
 * **Recommendations**: We encourage you to bring a table linen with your company logo and laptop or tablet to show off your product. Some sponsors bring a banner frame to place behind their table. Check in with the Sponsorship Coordinator for specific setup questions.
-* **Arrive early for setup**: Sponsor arrival is 7am on Monday; the conference venue opens at 8am. We recommend arriving on time to be set up for attendee arrival.
-* **The most important times to be present at your booth are during the breaks and at the start of lunch break.**
+* **Arrive early for setup**: Sponsor arrival is 07:00 on Monday; the conference venue opens at 08:00. We recommend arriving on time to be set up for attendee arrival.
+* **The most important times to be present at your booth are during the breaks and at the start of lunch break.** This is when attendees will be most engaged with your booth, and you can easily chat with them without other events happening.
 * **Bring swag (especially stickers)**: We recommend bringing a variety of swag to give away. Stickers are by far the most popular item for our attendees.
 * **Engage with folks as both a sponsor and attendee**: This is a great opportunity to meet folks in the community, so we recommend engaging with folks in an official capacity, but also as a regular attendee.
 * **Use QR codes**: QR codes are a great way to get people to a website quickly. We recommend using a service like <https://www.qr-code-generator.com/> to create these.
@@ -78,20 +81,14 @@ If your sponsorship includes a Lightning Talk, you will be given 60 seconds to p
 
 **Logistics**:
 
-* Your 60 second introduction will occur on Monday or Tuesday, after lunch and before Lightning Talks begin.
+* Your 60-second introduction will occur on Monday or Tuesday, after lunch and before Lightning Talks begin.
 * If you want to use a slide for your introduction, let us know. Otherwise, we will create a slide with your logo.
-
-### Writing Day
-
-Writing Day is on Sunday and modeled after the concept of “sprints”. This is a place where the community gathers to get actual work done. This is a great opportunity to get small group and extended interaction with attendees.
 
 **Logistics**:
 
 * Sessions are on Sunday in the morning, afternoon, or all day.
 * View our [Lead a Project](https://www.writethedocs.org/conf/{{ shortcode }}/{{ year }}/writing-day/#lead-a-project) for more information.
-* [Submit your Writing Day project here.](https://docs.google.com/forms/d/e/1FAIpQLSeHMZ1uXTfnT0HMm-KfsgxYV1w3tmS7bMPtBx4H9cktJpSrdg/viewform?usp=dialog) All projects submitted by April 23 will be published to our website, which encourages attendees to attend, engage with your product, and contribute to your documentation.
 
-You are always welcome to introduce your project to attendees during the Writing Day introduction on Sunday morning.
 
 ### Unconference
 
@@ -121,11 +118,11 @@ You should have received a unique URL with a discount code for your sponsorship 
 
 ### How should I send my booth materials?
 
-* Patron sponsors are allowed to send 3 boxes at 24"x18"x18" in size. Please contact us for the shipping address for an organizer, as the venue doesn't accept packages.
+* Patron sponsors are allowed to send 3 boxes at 61 × 46 × 46 cm (24 × 18 × 18 in) in size. Please contact us for the shipping address for an organizer, as the venue doesn't accept packages.
 * Packages must arrive between 1 and 2 weeks before the conference.
 * Sponsors are responsible for all sponsorship materials after they arrive at the venue. 
 * Sponsors are responsible for mailing all materials after the conference. 
 * Please print your return shipping labels prior to coming to the venue to send your materials back.
-* **All materials must be out of the venue by 6pm on Tuesday**
+* **All materials must be out of the venue by 18:00 on Tuesday**
 
 If you have any further questions, reach out to Eric Holscher or <sponsorship@writethedocs.org>.

--- a/docs/conf/berlin/2025/sponsors/information.md
+++ b/docs/conf/berlin/2025/sponsors/information.md
@@ -75,6 +75,16 @@ Sponsor booths are set up in the main hallway on Monday and Tuesday outside of t
 * **Engage with folks as both a sponsor and attendee**: This is a great opportunity to meet folks in the community, so we recommend engaging with folks in an official capacity, but also as a regular attendee.
 * **Use QR codes**: QR codes are a great way to get people to a website quickly. We recommend using a service like <https://www.qr-code-generator.com/> to create these.
 
+### Sponsor Introduction
+
+If you have a sponsorship booth, you will have 30 seconds on stage to introduce yourself to the attendees. This is a great opportunity to share what your company does and what you are showcasing at the conference, especially why they should come talk with you at the booth.
+
+**Logistics**:
+
+* Sponsor introductions happen at the end of the first snack break on Monday.
+* Please keep your introduction to 30 seconds to ensure all sponsors have equal time.
+* You will have a slide on the stage with your company logo displayed on it. Let us know if you'd like a custom slide with additional information (eg. a QR code and additional info).
+
 ### Unconference
 
 The Unconference provides the opportunity for sponsors and attendees to lead, contribute, share ideas, and discuss problems in an organized setting away from main stage talks.  

--- a/docs/conf/berlin/2025/venue.md
+++ b/docs/conf/berlin/2025/venue.md
@@ -5,3 +5,10 @@ template: {{year}}/generic.html
 # Venue
 
 The conference will be held at [bUm Berlin](https://bum.berlin/en/). More information about the venue will be available closer to the event.
+
+## Address
+
+Paul-Lincke-Ufer 21
+10999 Berlin
+
+


### PR DESCRIPTION
This is just a quick update to update timing and remove Writing Day.
We need to confirm/update:

* Venue layout
* Table sizes
* Dates and times

I added:

* Venue address

I removed:

* Writing Day mentions
* Sponsor media kit


<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2427.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->

Direct link: https://writethedocs-www--2427.org.readthedocs.build/conf/berlin/2025/sponsors/information/