### PR TITLE
Close the CFP on the website

### DIFF
--- a/docs/_data/berlin-2025-config.yaml
+++ b/docs/_data/berlin-2025-config.yaml
@@ -219,7 +219,7 @@ sponsors:
 # Things that change over time, listed in order of change
 flaglanding: False
 flaghassponsors: True
-flagcfp: True
+flagcfp: False
 flagticketsonsale: True
 flagsoldout: False
 flagspeakersannounced: True


### PR DESCRIPTION
Seems like this never got removed after the CFP was closed?


<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2436.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->