### PR TITLE
Update North Carolina meetup details and organizers

### DIFF
--- a/docs/_data/meetups/usa-northcarolina.yaml
+++ b/docs/_data/meetups/usa-northcarolina.yaml
@@ -1,14 +1,13 @@
 region: North America
 country: USA
-state: North Carolina
-website: https://www.meetup.com/write-the-docs-north-carolina/
-meetup: Write-the-Docs-North-Carolina
+state: North & South Carolina
+website: https://www.meetup.com/write-the-docs-carolinas/
+meetup: Write-the-Docs-Carolinas
 organizers:
-  - name: August Lindgren-Ruby
-    link: https://www.linkedin.com/in/august-lr/
   - name: Kane Martin
     link: https://www.linkedin.com/in/kanemartin/
-  - name: Christina Prosnak
-    link: https://www.linkedin.com/in/christina-prosnak-073845241/
+  - name: August Lindgren-Ruby
+    link: https://www.linkedin.com/in/august-lr/
+  - name: Mitchell Knell
+    link: https://www.linkedin.com/in/mitchellknell/
   - name: CT Smith
-  - name: Lyn M


### PR DESCRIPTION
Renamed meetup to also include South Carolina, updated Meetup.com URL and list of organizers

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2469.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->