### PR TITLE
Point video archive to YouTube channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ WIP (Work In Progress) Docs on how to do this:
 
 2. Make sure the directory `videos/<city>/<year>` is included in the Video Archive `toctree` in `docs/videos/index.rst`.
 
-3. In the [virtual environment](#prerequisites-for-generating-the-docs-locally), switch to the `docs` directory and run `BUILD_VIDEOS=True make html`.
+3. In the [virtual environment](#prerequisites-for-generating-the-docs-locally), switch to the `docs` directory and run `make html`.
 
 4. Commit the *relevant* changed files:
 
@@ -34,7 +34,7 @@ WIP (Work In Progress) Docs on how to do this:
 
 5. If you want to preview locally:
 
-    1. Run `BUILD_VIDEOS=True make livehtml` and browse the new video pages at `http://127.0.0.1:8888`.
+    1. Run `make livehtml` and browse the new video pages at `http://127.0.0.1:8888`.
 
 ### Prerequisites for generating the docs locally
 

--- a/docs/_static_html/conf/na/2015/news/videos-forum-eu-cfp/index.html
+++ b/docs/_static_html/conf/na/2015/news/videos-forum-eu-cfp/index.html
@@ -180,7 +180,7 @@ so don’t wait to submit a talk or buy tickets.</p>
 <div class="section" id="videos">
 <h2>Videos<a class="headerlink" href="#videos" title="Permalink to this headline">¶</a></h2>
 <p>We have <a class="reference external" href="https://www.youtube.com/playlist?list=PLmV2D6sIiX3UW1kPWlhzyo4lr6e3US6re">videos</a> of every talk from our conference this year. If you missed something, you can always catch it on video.</p>
-<p>Check out previous talks, too. We’ve also recorded <a class="reference external" href="https://www.writethedocs.org/videos/">every talk</a> at Write the Docs from every year.</p>
+<p>Check out previous talks, too. All of our recordings are on the <a class="reference external" href="https://www.youtube.com/c/WritetheDocs">Write the Docs YouTube channel</a>.</p>
 </div>
 <div class="section" id="id1">
 <h2>2016<a class="headerlink" href="#id1" title="Permalink to this headline">¶</a></h2>

--- a/docs/about/learning-resources.rst
+++ b/docs/about/learning-resources.rst
@@ -29,7 +29,7 @@ Our monthly :doc:`/newsletter` aggregates the latest discussions about topics th
 Videos
 ~~~~~~
 
-All the presentation `videos </videos/>`_ are available on YouTube so that you can catch up on the content even if you can't attend the conferences.
+All the presentation videos are available on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`_ so that you can catch up on the content even if you can't attend the conferences.
 
 Podcast
 ~~~~~~~

--- a/docs/blog/2020-community-update.rst
+++ b/docs/blog/2020-community-update.rst
@@ -17,7 +17,7 @@ The talks were just announced for the Prague conference, we'll be publishing mor
 
 We also just recently wrapped up our first online Portland conference.
 We had around 600 people join us to make this another memorable event.
-The `videos <https://www.writethedocs.org/videos/portland/2020/>`_ from the conference are now available online.
+The videos from the conference are now available on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`_.
 
 Salary Survey
 -------------

--- a/docs/blog/2021-community-update.rst
+++ b/docs/blog/2021-community-update.rst
@@ -18,7 +18,7 @@ The talks were just announced for the Prague conference, and the `Australia & In
 
 We also had our second virtual Portland conference in April this year.
 It was another success with almost 700 people attending from all over the world.
-The `videos <https://www.writethedocs.org/videos/portland/2021/>`_ from the conference are now available online.
+The videos from the conference are now available on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`_.
 
 Write the Docs Enhancement Proposals (WEPs)
 -------------------------------------------

--- a/docs/blog/newsletter-april-2018.rst
+++ b/docs/blog/newsletter-april-2018.rst
@@ -14,7 +14,7 @@ First, we're coming up on the Portland conference here in just four weeks (!?), 
 Tickets are fully sold out, but if you're itching for a conference fix, now's a great time to look ahead to Prague in September... especially if you'd like to speak!
 The Prague call for proposals is open until **midnight, Tuesday May 15th**, and you can read more and submit your talk idea `here on our CFP page <https://www.writethedocs.org/conf/prague/2018/cfp/>`_.
 
-We also have a new virtual resource to announce – the `Write the Docs Video Archive <https://www.writethedocs.org/videos/>`_!
+We also have a new virtual resource to announce – the `Write the Docs YouTube channel <https://www.youtube.com/c/WritetheDocs>`_!
 You can now easily browse all of the videos from every North American and European conference, going back over the last three years.
 There are hours of excellent talks in there, on almost any docs-topic you can think of.
 Dive in!

--- a/docs/blog/newsletter-december-2024.rst
+++ b/docs/blog/newsletter-december-2024.rst
@@ -61,14 +61,14 @@ Searching and browsing are complementary actions. The method used by any one per
 **Search-related resources**
 
 * `Search platform tips for documentation websites <https://www.writethedocs.org/blog/newsletter-june-2024/#search-platform-tips-for-documentation-websites>`_  (WTD Newsleter)
-* `Making documentation discoverable in search engines <https://www.writethedocs.org/videos/prague/2020/making-documentation-discoverable-in-search-engines-myriam-jessier/>`_ (WTD video)
+* *Making documentation discoverable in search engines* (available on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`_)
 * `Search engine optimization (SEO) for documentation <https://www.writethedocs.org/guide/seo/>`_ (WTD page)
 * `Information Foraging <https://www.nngroup.com/articles/information-foraging/>`_ (Nielsen Norman Group)
 
 **Navigation- and IA-related resources**
 
 * Many articles available from `Nielsen Norman Group <https://www.nngroup.com/search/?q=information+architecture&searchSubmit=Search>`__
-* `Building navigation for your doc site: 5 best practices <https://www.writethedocs.org/videos/na/2017/building-navigation-for-your-doc-site-5-best-practices-tom-johnson/>`__ (WTD video)
+* *Building navigation for your doc site: 5 best practices* (available on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`_)
 * `Complete Beginner’s Guide to Information Architecture <https://uxbooth.com/articles/complete-beginners-guide-to-information-architecture/>`__ (UX Booth)
 * `How To Make Sense of Any Mess <https://abbycovert.com/make-sense/>`_ (book by Abby Covert)
 

--- a/docs/blog/newsletter-february-2021.rst
+++ b/docs/blog/newsletter-february-2021.rst
@@ -24,7 +24,7 @@ A middle-ground approach is using text descriptions of UI elements, like "Click 
 
 What about a video walkthrough or GIFs? Again, documentarians were split: it's helpful to watch a process through before trying it yourself, but videos and GIFs are inaccessible for people with visual impairments, distracting for people with attention issues, and unusable for people who don't have dependable broadband service. And following video instructions can be frustrating if you have to repeatedly press pause, or feel like the pace of spoken instructions is too slow.
 
-For more on screenshots in documentation, check out Steve Stegelin's `Graphic Content Warning: The Pros, Cons, and Alternatives to Screenshots <https://www.writethedocs.org/videos/portland/2018/graphic-content-warning-the-pros-cons-and-alternatives-to-screenshots-steve-stegelin/>`_ from Write the Docs Portland 2018 and Swapnil Ogale's `When bad screenshots happen to good writers <https://www.writethedocs.org/videos/eu/2016/when-bad-screenshots-happen-to-good-writers-swapnil-ogale/>`_ from WTD EU 2016.
+For more on screenshots in documentation, check out Steve Stegelin's *Graphic Content Warning: The Pros, Cons, and Alternatives to Screenshots* and Swapnil Ogale's *When bad screenshots happen to good writers* on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`_.
 
 --------------------------------------
 Report from the book club: managing up

--- a/docs/blog/newsletter-june-2018.rst
+++ b/docs/blog/newsletter-june-2018.rst
@@ -67,7 +67,7 @@ Short advice for writing error messages
 ---------------------------------------
 This month, the hivemind fielded a request for advice about writing good error messages. Attached to the request, though, was a familiar (and vital) caveat: They needed short, easy-to-digest pointers, rather than longer, meatier reads, in an effort to boost the odds that their developer teams would actually find the time to read what they shared.
 
-One of the top suggestions was Kate Voss's `Error Messages talk at WTD Portland 2017 <https://www.writethedocs.org/videos/na/2017/error-messages-being-humble-human-and-helpful-will-make-users-happy-kate-voss/>`_ We'll admit that a 15-minute video doesn't fit the "short" parameter...but Kate's own distillation of her talk brings it down to three concise rules: Humble, Helpful, and Human.
+One of the top suggestions was Kate Voss's *Error Messages* talk from WTD Portland 2017 (available on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`_). We'll admit that a 15-minute video doesn't fit the "short" parameter...but Kate's own distillation of her talk brings it down to three concise rules: Humble, Helpful, and Human.
 
 * **Humble**: apologize and acknowledge the error
 * **Helpful**: make sure the error message tells users what to do next

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -91,16 +91,8 @@ if all(cfp_variables.values()):
 else:
     print('Private CFP environment variables not set, not building CFP email templates.')
 
-# Only build the videos on production, to speed up dev
 on_rtd = str(os.environ.get('READTHEDOCS')).lower() == 'true'
-build_videos = str(os.environ.get('BUILD_VIDEOS')).lower() == 'true'
-if not on_rtd and not build_videos:
-    print('EXCLUDING VIDEO PATHS. Video links will not work.')
-    exclude_patterns.append('videos')
-    REWRITE_FEED = False
-else:
-    print('BUILDING VIDEOS. All video links should work.')
-    REWRITE_FEED = True
+REWRITE_FEED = on_rtd
 
 extensions = [
     'ablog',
@@ -233,10 +225,6 @@ html_context = {
     'announcement_message': announcement_message,
 }
 
-if build_videos:
-
-    html_context.update(videos.main())
-
 notfound_no_urls_prefix = True
 
 
@@ -261,7 +249,7 @@ def setup(app):
     # Render HTML templates with proper HTML context
     app.connect('html-page-context', override_template_load_context)
 
-    if on_rtd or build_videos or REWRITE_FEED:
+    if on_rtd or REWRITE_FEED:
         app.connect('build-finished', rewrite_atom_feed)
 
     app.add_directive('meetup-listing', MeetupListing)

--- a/docs/conf/australia/2021/welcome-wagon.rst
+++ b/docs/conf/australia/2021/welcome-wagon.rst
@@ -76,7 +76,7 @@ To attend the moderated Q&A after each talk, go to **Sessions** and select the *
 Watching talks after the conference
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Don't worry if you miss something in a talk! Stage talks and Q&A sessions are recorded. Videos will be published in the `Write the Docs Video Archive <https://www.writethedocs.org/videos/>`__ shortly after the conference (typically about a week after the conference ends). To be notified when videos are published, `sign up for our newsletter <https://www.writethedocs.org/newsletter/>`__ or `subscribe to our YouTube channel <https://www.youtube.com/c/WritetheDocs/?sub_confirmation=1>`__.
+Don't worry if you miss something in a talk! Stage talks and Q&A sessions are recorded. Videos will be published on the `Write the Docs YouTube channel <https://www.youtube.com/c/WritetheDocs>`__ shortly after the conference (typically about a week after the conference ends). To be notified when videos are published, `sign up for our newsletter <https://www.writethedocs.org/newsletter/>`__ or `subscribe to our YouTube channel <https://www.youtube.com/c/WritetheDocs/?sub_confirmation=1>`__.
 
 Other sessions (such as Unconference, Hallway, and Writing Day sessions) are not recorded.
 

--- a/docs/conf/australia/2022/welcome-wagon.rst
+++ b/docs/conf/australia/2022/welcome-wagon.rst
@@ -76,7 +76,7 @@ To attend the moderated Q&A after each talk, go to **Sessions** and select the *
 Watching talks after the conference
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Don't worry if you miss something in a talk! Stage talks and Q&A sessions are recorded. Videos will be published in the `Write the Docs Video Archive <https://www.writethedocs.org/videos/>`__ shortly after the conference (typically about a week after the conference ends). To be notified when videos are published, `sign up for our newsletter <https://www.writethedocs.org/newsletter/>`__ or `subscribe to our YouTube channel <https://www.youtube.com/c/WritetheDocs/?sub_confirmation=1>`__.
+Don't worry if you miss something in a talk! Stage talks and Q&A sessions are recorded. Videos will be published on the `Write the Docs YouTube channel <https://www.youtube.com/c/WritetheDocs>`__ shortly after the conference (typically about a week after the conference ends). To be notified when videos are published, `sign up for our newsletter <https://www.writethedocs.org/newsletter/>`__ or `subscribe to our YouTube channel <https://www.youtube.com/c/WritetheDocs/?sub_confirmation=1>`__.
 
 Other sessions (such as Unconference, Hallway, and Writing Day sessions) are not recorded.
 

--- a/docs/conf/portland/2018/news/thanks-recap.rst
+++ b/docs/conf/portland/2018/news/thanks-recap.rst
@@ -40,9 +40,8 @@ see our awesome community gather out in the physical world.
 Videos and photos and write-ups
 ===============================
 
-Videos of all the talks are now available `in our video
-archive <https://www.writethedocs.org/videos/portland/2018/>`__. Thanks 
-to `Backpedal <https://backpedal.tv/>`__ for doing such a great job with these. 
+Videos of all the talks are now available on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`__. Thanks
+to `Backpedal <https://backpedal.tv/>`__ for doing such a great job with these.
 If you gave a lightning talk, we're working to get
 them on our site, but you can see them on 
 `YouTube <https://www.youtube.com/playlist?list=PLZAeFn6dfHplUgfLOLEuHHAm1HdrIyaZ7>`__ 

--- a/docs/conf/portland/2019/news/thanks-recap.rst
+++ b/docs/conf/portland/2019/news/thanks-recap.rst
@@ -33,9 +33,8 @@ and we had a great time.
 Videos and photos
 =================
 
-Videos of all the talks are now available `in our video
-archive <https://www.writethedocs.org/videos/portland/2019/>`__. Thanks 
-to `Backpedal <https://backpedal.tv/>`__ for doing such a great job with these. 
+Videos of all the talks are now available on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`__. Thanks
+to `Backpedal <https://backpedal.tv/>`__ for doing such a great job with these.
 If you gave a lightning talk, we're working to get
 them on our site, but you can see them on 
 `YouTube <https://www.youtube.com/playlist?list=PLZAeFn6dfHpmuHCu5qsIkmp9H5jFD-xq->`__ 

--- a/docs/conf/prague/2018/news/thanks-recap.rst
+++ b/docs/conf/prague/2018/news/thanks-recap.rst
@@ -28,7 +28,7 @@ Overall, we were so excited to see another conference come together and see our 
 Videos and photos
 =================
 
-Videos of all the talks are now available `in our video archive <https://www.writethedocs.org/videos/prague/2018/>`__.
+Videos of all the talks are now available on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`__.
 Thanks to `Here to Record <https://heretorecord.com/>`__ for doing such a great job with these.
 If you gave a lightning talk, we're working to get them on our site, but in the meantime you can see them on `YouTube <https://www.youtube.com/watch?v=oXmrFoEEf3A&list=PLZAeFn6dfHplRZcYDQjST22bAVeeWML4d>`__ for now.
 (You can also subscribe to our `YouTube channel <https://www.youtube.com/channel/UCr019846MitZUEhc6apDdcQ>`_

--- a/docs/conf/prague/2020/welcome-wagon.rst
+++ b/docs/conf/prague/2020/welcome-wagon.rst
@@ -76,7 +76,7 @@ To attend the moderated Q&A after each talk, go to **Sessions** and select the *
 Watching talks after the conference
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Don't worry if you miss something in a talk! Stage talks and Q&A sessions are recorded. Videos will be published in the `Write the Docs Video Archive <https://www.writethedocs.org/videos/>`__ shortly after the conference (typically about a week after the conference ends). To be notified when videos are published, `sign up for our newsletter <https://www.writethedocs.org/newsletter/>`__ or `subscribe to our YouTube channel <https://www.youtube.com/c/WritetheDocs/?sub_confirmation=1>`__.
+Don't worry if you miss something in a talk! Stage talks and Q&A sessions are recorded. Videos will be published on the `Write the Docs YouTube channel <https://www.youtube.com/c/WritetheDocs>`__ shortly after the conference (typically about a week after the conference ends). To be notified when videos are published, `sign up for our newsletter <https://www.writethedocs.org/newsletter/>`__ or `subscribe to our YouTube channel <https://www.youtube.com/c/WritetheDocs/?sub_confirmation=1>`__.
 
 Other sessions (such as Unconference, Hallway, and Writing Day sessions) are not recorded.
 

--- a/docs/guide/writing/accessibility.md
+++ b/docs/guide/writing/accessibility.md
@@ -37,6 +37,6 @@ And for general writing style, see [style guides](https://www.writethedocs.org/g
 
 ## Relevant talks from Write the Docs:
 
-- [Moving beyond empathy: a11y in documentation](https://www.writethedocs.org/videos/portland/2020/moving-beyond-empathy-a11y-in-documentation-alexandra-white/)
-- [A11y-Friendly Documentation](https://www.writethedocs.org/videos/prague/2018/a11y-friendly-documentation-carolyn-stransky/) at Write the Docs Prague 2018
-- [Inclusive Tech Docs - TechComm Meets Accessibility](http://www.writethedocs.org/videos/eu/2015/inclusive-tech-docs-techcomm-meets-accessibility-rmatic/) at Write the Docs EU 2015
+- *Moving beyond empathy: a11y in documentation* (available on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`_)
+- *A11y-Friendly Documentation* from Write the Docs Prague 2018 (available on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`_)
+- *Inclusive Tech Docs - TechComm Meets Accessibility* from Write the Docs EU 2015 (available on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`_)

--- a/docs/guide/writing/reducing-bias.md
+++ b/docs/guide/writing/reducing-bias.md
@@ -31,7 +31,7 @@ Paid resources:
 
 Relevant talks from Write the Docs:
 
-- [What They Don’t Tell You About Creating New Style Guides](https://www.writethedocs.org/videos/portland/2018/what-they-don-t-tell-you-about-creating-new-style-guides-thursday-bram/)
+- *What They Don’t Tell You About Creating New Style Guides* (available on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`_)
 
 ## Providing inclusive example names
 

--- a/docs/guide/writing/style-guides.md
+++ b/docs/guide/writing/style-guides.md
@@ -97,7 +97,7 @@ A command-line interface (CLI) processes commands to a computer program in the f
 
 Relevant talk from Write the Docs:
 
-- [How I learned to stop worrying and love the CLI](https://www.writethedocs.org/videos/portland/2019/how-i-learned-to-stop-worrying-and-love-the-command-line-mike-jang/) at WTD Portland 2019
+- *How I learned to stop worrying and love the CLI* from WTD Portland 2019 (available on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`_)
 
 ### API documentation
 
@@ -211,7 +211,7 @@ What to avoid:
 
 - [App Release Notes Are Getting Stupid -- TechCrunch](https://techcrunch.com/2015/09/04/app-release-notes-are-getting-stupid/)
 - [Release Notes: 13 Mistakes to Avoid When Writing Bugs and Enhancements -- klariti.com](https://www.klariti.com/technical-writing/2015/05/08/release-notes-mistakes-to-avoid/) Related talks:
-- [Learning to love release notes](http://www.writethedocs.org/videos/prague/2018/learning-to-love-release-notes-anne-edwards/) at Write the Docs Prague 2018
+- *Learning to love release notes* from Write the Docs Prague 2018 (available on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`_)
 - [Rethinking Release Notes](https://www.youtube.com/watch?v=SWduFnDPjYg) at Write the Docs Australia 2019
 
 <!-- vale on -->

--- a/docs/include/conf/virtual/welcome-wagon.rst
+++ b/docs/include/conf/virtual/welcome-wagon.rst
@@ -98,7 +98,7 @@ Watching talks after the conference
 
 Don't worry if you miss something in a talk!
 Stage talks, Q&A sessions, and lightning talks are recorded.
-Videos will be published in the `Write the Docs Video Archive <https://www.writethedocs.org/videos/>`__ shortly after the conference
+Videos will be published on the `Write the Docs YouTube channel <https://www.youtube.com/c/WritetheDocs>`__ shortly after the conference
 (typically about a week after the conference ends).
 To be notified when videos are published, `sign up for our newsletter <https://www.writethedocs.org/newsletter/>`__
 or `subscribe to our YouTube channel <https://www.youtube.com/c/WritetheDocs/?sub_confirmation=1>`__.
@@ -350,7 +350,7 @@ Are the talks recorded?
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 - Stage talks and Q&A sessions are recorded.
-  Videos will be published in the `Write the Docs Video Archive <https://www.writethedocs.org/videos/>`__ shortly after the conference
+  Videos will be published on the `Write the Docs YouTube channel <https://www.youtube.com/c/WritetheDocs>`__ shortly after the conference
   (typically about a week after the conference ends).
 - Other sessions (such as Unconference, Hallway, and Writing Day sessions) are not recorded.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,8 +52,9 @@ Work with other documentarians.
 Learn from our resources
 ------------------------
 
-We have an ever-increasing set of talk videos, articles, links, and resources:
+We have an ever-increasing set of articles, links, and resources. Watch our talks on YouTube:
 
+* Watch past conference talks on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`_
 * Subscribe to our :doc:`newsletter and conference </newsletter>` mailing lists
 * Browse our :doc:`topic index </topics>`
 * Read the latest in our :doc:`blog </blog/index>`

--- a/docs/organizer-guide/meetups/starting.rst
+++ b/docs/organizer-guide/meetups/starting.rst
@@ -197,8 +197,8 @@ The following are examples of topics that have worked well for other meetups:
 If You Can't Find a Local Speaker
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you can't find a local speaker, consider screening a popular talk from one of the
-`Write the Docs conferences <https://www.writethedocs.org/videos/>`_ and inviting the conference presenter to call in for
+If you can't find a local speaker, consider screening a popular talk from the
+`Write the Docs YouTube channel <https://www.youtube.com/c/WritetheDocs>`_ and inviting the conference presenter to call in for
 a live Q & A session. Both the Boulder and Austin meetups have done well with this format.
 
  * `So you need to document an API <https://www.meetup.com/Boulder-Denver-WriteTheDocs-Meetup/events/232962552/>`_

--- a/docs/organizer-guide/meetups/sustainable-meetups.rst
+++ b/docs/organizer-guide/meetups/sustainable-meetups.rst
@@ -11,7 +11,7 @@ Minimal Viable Meetup checklist
 * Host a maximum of ten meetups per year. You can skip August and December, since most people are on vacation at that time, or taking a break from their usual activities. 
 * Regular meetups help people plan their commitments. Host your meetup at the same time every month – eg the first Wednesday, or another specific date.
 * Try to host your meetup in a regular event space to minimize the need to spend time finding new spaces. 
-* If you can’t find a local speaker for each meetup, consider screening a popular talk from one of our past `Write the Docs conferences <https://www.writethedocs.org/videos/>`_ and inviting the conference presenter to call in for a live Q & A session.
+* If you can’t find a local speaker for each meetup, consider screening a popular talk from our `Write the Docs YouTube channel <https://www.youtube.com/c/WritetheDocs>`_ and inviting the conference presenter to call in for a live Q & A session.
 * Alternatively, consider hosting a regular informal ‘docs and drinks’ to keep the momentum going with your attendees – these can involve either alcohol or coffee. 
 * Bring in at least two main organizers for your meetup (including yourself). This helps shoulder the burden of organizing and stops you burning out. 
 * Check your scheduling won’t clash with an overlapping meetup that might attract away your attendees. 

--- a/docs/videos/index.rst
+++ b/docs/videos/index.rst
@@ -1,13 +1,6 @@
 Video Archive
 =============
 
-.. toctree::
-   :glob:
-   :maxdepth: 1
+We no longer host the video archive on this site.
 
-   au/*/index
-   australia/*/index
-   eu/*/index
-   na/*/index
-   portland/*/index
-   prague/*/index
+Watch all Write the Docs talks on our `YouTube channel <https://www.youtube.com/c/WritetheDocs>`_.


### PR DESCRIPTION
## Summary
- replace the video archive page with a pointer to the Write the Docs YouTube channel
- update site copy, conference info, and resource listings to send users to YouTube instead of on-site video URLs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692600aec54883209dbdb7504fa400f7)

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2481.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->