### PR TITLE
Make example match CFP

### DIFF
--- a/docs/conf/portland/2026/example-proposal.rst
+++ b/docs/conf/portland/2026/example-proposal.rst
@@ -6,7 +6,8 @@ Example talk proposal title
 Abstract
 --------
 
-The abstract is published in the conference schedule.
+**The abstract is published in the conference schedule**.
+
 It should be publication ready, although it might be edited for brevity and consistency by the conference staff.
 
 Include a brief story, typically two to four paragraphs, describing your personal work experience with the topic. Write to appeal to our audience of documentarians.
@@ -19,20 +20,6 @@ Include a list of takeaways that our audience can learn from your talk, such as:
 
 Avoid walls of text. The ideal length for an abstract is between 100 and 300 words.
 
-Detailed Spoilers
------------------
-
-Use this section to share specifics about the content of your talk that will give us a better sense of its depth. These spoilers are for the *selection committee* only and won’t be shared publicly, but will help us ensure your session is a good fit.
-
-In this section, please include:
-
-- Specific examples, case studies, or methodologies that will be covered in your talk.
-- In-depth explanations of technical processes or workflows.
-- Key takeaways that will be explored in detail, including any particular challenges or outcomes you’ll be addressing.
-- Anything else that will give us a better understanding of the content you’ll be presenting.
-
-We’d love to see how your talk will deliver real value to our audience. The more specific you can be about your content here, the better we’ll be able to assess whether it will resonate with our attendees.
-
 Who and Why
 -----------
 
@@ -41,8 +28,13 @@ Help them think: "Oh yes, this talk could help me when I do X in my work!"
 
 Answer the questions:
 
-- Who is this talk for?
-- Why is this helpful, applicable, important, etc.?
+- :ref:`who_portland_2026`
+- :ref:`why_portland_2026`
+
+.. _who_portland_2026:
+
+Who is this talk for?
+~~~~~~~~~~~~~~~~~~~~~
 
 Our audience creates documentation primarily for software. Given the variety of tools used for software documentation, we rarely accept talks that focus on a specific software tool or set of tools. If a talk does include tools, you should also discuss the wider context, applications, and implications of implementing the tools.
 
@@ -53,6 +45,22 @@ Our audience goes beyond the technical writing community. Here’s a typical dem
 - Support Staff (10%)
 - Managers (10%)
 - Community Contributors, Enthusiasts & Other Folks (10%)
+
+.. _why_portland_2026:
+
+Why?
+~~~~
+
+Share specifics about the content of your talk that will give us a better sense of its depth. These spoilers are for the *selection committee* only and won’t be shared publicly, but will help us ensure your session is a good fit.
+
+Please include:
+
+- Specific examples, case studies, or methodologies that will be covered in your talk.
+- In-depth explanations of technical processes or workflows.
+- Key takeaways that will be explored in detail, including any particular challenges or outcomes you’ll be addressing.
+- Anything else that will give us a better understanding of the content you’ll be presenting.
+
+We’d love to see how your talk will deliver real value to our audience. The more specific you can be about your content here, the better we’ll be able to assess whether it will resonate with our attendees.
 
 Other Information
 -----------------

--- a/docs/conf/portland/2026/example-proposal.rst
+++ b/docs/conf/portland/2026/example-proposal.rst
@@ -48,8 +48,8 @@ Our audience goes beyond the technical writing community. Here’s a typical dem
 
 .. _why_portland_2026:
 
-Why?
-~~~~
+Why is this helpful, applicable, important?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Share specifics about the content of your talk that will give us a better sense of its depth. These spoilers are for the *selection committee* only and won’t be shared publicly, but will help us ensure your session is a good fit.
 


### PR DESCRIPTION
Someone rightfully pointed out that the example didn't match the format in Pretalx, this pull request fixes that.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2495.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->