### PR TITLE
Update London organisers list

### DIFF
--- a/docs/_data/meetups/gbr-london.yaml
+++ b/docs/_data/meetups/gbr-london.yaml
@@ -10,3 +10,7 @@ organizers:
     link: https://www.linkedin.com/in/eescapa/
   - name: Deborah Emeni
     link: https://www.linkedin.com/in/deborahemeni/
+  - name: Thomas Newton
+    link: https://www.linkedin.com/in/thomas-newton-43b52b27/
+  - name: Marta Malberti
+    link: https://www.linkedin.com/in/martamalberti/


### PR DESCRIPTION
A busy time for us - new joiners on board! Updating the WTD London organisers list.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2527.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->