### PR TITLE
Update US East Coast Virtual meetup details

### DIFF
--- a/docs/_data/meetups/us-east-coast-virtual.yaml
+++ b/docs/_data/meetups/us-east-coast-virtual.yaml
@@ -1,5 +1,5 @@
 region: North America
-country: US East Coast Virtual (Formerly Boston/New England)
+country: US East Coast Virtual
 website: https://www.meetup.com/write-the-docs-east-coast/events/
 meetup: Write-The-Docs-East-Coast
 organizers:
@@ -13,7 +13,5 @@ organizers:
     link: https://www.linkedin.com/in/kanemartin/
   - name: Randi Stebbins
     link: https://www.linkedin.com/in/randiwstebbins/
-  - name: Aimee Ukasick
-  - name: Cynthia Peter
   - name: Rose Williams (founder, former organizer)
     link: https://www.linkedin.com/in/williamsrose/


### PR DESCRIPTION
Removed 'Formerly Boston/New England' from meetup name and deleted two organizers.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2542.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->