### PR TITLE
Add Google and GitHub as Portland 2026 Second Draft sponsors

### DIFF
--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -235,6 +235,12 @@ sponsors:
     - name: helpdocs
       link: https://www.helpdocs.io/?utm_source=writethedocs&utm_medium=sponsor&utm_campaign=wtdp26
       brand: HelpDocs
+    - name: google
+      link: https://opensource.google/?ref=writethedocs
+      brand: Google
+    - name: github
+      link: https://github.com/?ref=writethedocs
+      brand: GitHub
     - name: readthedocs
       link: https://about.readthedocs.com/?ref=writethedocs
       brand: Read the Docs


### PR DESCRIPTION
## Summary
- add `google` to `sponsors.second` in Portland 2026 config
- add `github` to `sponsors.second` in Portland 2026 config

## Testing
- YAML parses successfully