### PR TITLE
Remove duplicate Google and GitHub entries from config

### DIFF
--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -244,12 +244,6 @@ sponsors:
     - name: readthedocs
       link: https://about.readthedocs.com/?ref=writethedocs
       brand: Read the Docs
-    - name: google
-      link: https://opensource.google/?ref=writethedocs
-      brand: Google
-    - name: github
-      link: https://github.com/?ref=writethedocs
-      brand: GitHub
   first:
   in_kind:
 


### PR DESCRIPTION
Removed duplicate Google and GitHub links from the configuration.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2546.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->