### PR TITLE
Color-code schedule items by room location

### DIFF
--- a/docs/_templates/include/schedule2026.md
+++ b/docs/_templates/include/schedule2026.md
@@ -1,6 +1,30 @@
 <article class="schedule">
 {% for session in day_schedule %}
-  <div class="schedule-item">
+  <div class="schedule-item
+    {%- if day_type == 'talks' -%}
+      {%- if session.data or 'Lightning' in (session.title or '') or 'Q&A' in (session.title or '') -%}
+        {{ ' ' }}schedule-item--main
+      {%- elif 'Unconference' in (session.title or '') -%}
+        {{ ' ' }}schedule-item--unconf
+      {%- elif 'Welcome Wagon' in (session.title or '') -%}
+        {{ ' ' }}schedule-item--unconf
+      {%- elif 'Sponsor' in (session.title or '') -%}
+        {{ ' ' }}schedule-item--main
+      {%- elif 'Social event' in (session.title or '') or 'Reception' in (session.title or '') -%}
+        {{ ' ' }}schedule-item--social
+      {%- endif -%}
+    {%- elif day_type == 'writing' -%}
+      {%- if 'Welcome Wagon' in (session.title or '') -%}
+        {{ ' ' }}schedule-item--unconf
+      {%- elif 'Reception' in (session.title or '') -%}
+        {{ ' ' }}schedule-item--social
+      {%- elif 'Roundtable' in (session.title or '') or 'workshop' in (session.title or '') or 'writing' in (session.title or '') or 'Writing' in (session.title or '') or 'Projects' in (session.title or '') or 'Afternoon session' in (session.title or '') or 'Morning introduction' in (session.title or '') -%}
+        {{ ' ' }}schedule-item--writing
+      {%- endif -%}
+    {%- elif day_type == 'outing' -%}
+      {{ ' ' }}schedule-item--outdoor
+    {%- endif -%}
+  ">
     <div class="item-starting-time">{{ session.time }}</div>
     <div class="item-content">
       <div class="item-description">

--- a/docs/conf/portland/2026/schedule.md
+++ b/docs/conf/portland/2026/schedule.md
@@ -16,6 +16,37 @@ Write the Docs is more than a conference. Each year we organize a wide range of 
 
 All times are in [{{ tz }}](https://time.is/{{ tz | replace(' ', '_') }}).
 
+```{raw} html
+<style>
+.schedule-item--main { border-left: 4px solid #fdb913; }
+.schedule-item--unconf { border-left: 4px solid #7e4d00; }
+.schedule-item--writing { border-left: 4px solid #3a7ca5; }
+.schedule-item--social { border-left: 4px solid #c45b9a; }
+.schedule-item--outdoor { border-left: 4px solid #4a8c5c; }
+.schedule-item--main,
+.schedule-item--unconf,
+.schedule-item--writing,
+.schedule-item--social,
+.schedule-item--outdoor { padding-left: 12px; }
+.schedule-legend {
+  display: flex; flex-wrap: wrap; gap: 14px; margin-bottom: 16px;
+  font-size: 14px; color: #4a4a4a;
+}
+.schedule-legend-item {
+  display: flex; align-items: center; gap: 6px;
+}
+.schedule-legend-swatch {
+  display: inline-block; width: 14px; height: 14px;
+  border-radius: 2px; flex-shrink: 0;
+}
+.swatch-main { background: #fdb913; }
+.swatch-unconf { background: #7e4d00; }
+.swatch-writing { background: #3a7ca5; }
+.swatch-social { background: #c45b9a; }
+.swatch-outdoor { background: #4a8c5c; }
+</style>
+```
+
 ```{contents}
 :local:
 :depth: 1
@@ -29,7 +60,10 @@ All times are in [{{ tz }}](https://time.is/{{ tz | replace(' ', '_') }}).
 {% if flaghasschedule %}
 
 ```{raw} html
-{% with day_schedule=schedule.outing %}
+<div class="schedule-legend">
+  <span class="schedule-legend-item"><span class="schedule-legend-swatch swatch-outdoor"></span> Outdoor</span>
+</div>
+{% with day_schedule=schedule.outing, day_type="outing" %}
 {% include "include/schedule2026.md" %}
 {% endwith %}
 ```
@@ -45,12 +79,17 @@ All times are in [{{ tz }}](https://time.is/{{ tz | replace(' ', '_') }}).
 {% if flaghasschedule %}
 
 ```{raw} html
-{% with day_schedule=schedule.writing_day %}
+<div class="schedule-legend">
+  <span class="schedule-legend-item"><span class="schedule-legend-swatch swatch-writing"></span> {{about.unconfroom}}</span>
+  <span class="schedule-legend-item"><span class="schedule-legend-swatch swatch-unconf"></span> Welcome Wagon tours</span>
+  <span class="schedule-legend-item"><span class="schedule-legend-swatch swatch-social"></span> Social</span>
+</div>
+{% with day_schedule=schedule.writing_day, day_type="writing" %}
 {% include "include/schedule2026.md" %}
 {% endwith %}
 ```
 
-{% else %}  
+{% else %}
 A detailed schedule will be announced soon.
 
 {% endif %}
@@ -62,12 +101,17 @@ A detailed schedule will be announced soon.
 {% if flaghasschedule %}
 
 ```{raw} html
-{% with day_schedule=schedule.talks_day1 %}
+<div class="schedule-legend">
+  <span class="schedule-legend-item"><span class="schedule-legend-swatch swatch-main"></span> {{about.mainroom}}</span>
+  <span class="schedule-legend-item"><span class="schedule-legend-swatch swatch-unconf"></span> {{about.unconfroom}}</span>
+  <span class="schedule-legend-item"><span class="schedule-legend-swatch swatch-social"></span> Social</span>
+</div>
+{% with day_schedule=schedule.talks_day1, day_type="talks" %}
 {% include "include/schedule2026.md" %}
 {% endwith %}
 ```
 
-{% else %}  
+{% else %}
 A detailed schedule will be announced soon.
 
 {% endif %}
@@ -79,12 +123,16 @@ A detailed schedule will be announced soon.
 {% if flaghasschedule %}
 
 ```{raw} html
-{% with day_schedule=schedule.talks_day2 %}
+<div class="schedule-legend">
+  <span class="schedule-legend-item"><span class="schedule-legend-swatch swatch-main"></span> {{about.mainroom}}</span>
+  <span class="schedule-legend-item"><span class="schedule-legend-swatch swatch-unconf"></span> {{about.unconfroom}}</span>
+</div>
+{% with day_schedule=schedule.talks_day2, day_type="talks" %}
 {% include "include/schedule2026.md" %}
 {% endwith %}
 ```
 
-{% else %}  
+{% else %}
 A detailed schedule will be announced soon.
 
 {% endif %}


### PR DESCRIPTION
## Summary
- Keeps existing day-by-day scrolling layout (no tabs)
- Adds colored left borders to schedule items showing which room/location each event is in
- Per-day color legend at the top of each section

**Color key:**
- 🟡 Gold — Main stage (talks, Q&A, lightning talks, sponsor intros)
- 🟤 Brown — Library & Astoria room (unconference, Welcome Wagon tours)
- 🔵 Blue — Writing room (projects, workshops, roundtables)
- 🩷 Pink — Social events (reception, evening party)
- 🟢 Green — Outdoor (hike, urban walk)

Items without a color (breaks, lunch, doors) are venue-wide.

## Test plan
- [ ] Verify colored borders appear on correct items
- [ ] Check legend renders at top of each day section
- [ ] Confirm uncolored items (breaks, lunch) have no border
- [ ] Check mobile rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2584.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->