### PR TITLE
Remove Waldium as a patron sponsor

### DIFF
--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -212,9 +212,6 @@ sponsors:
       brand: GitBook
       text: "GitBook combines powerful docs with AI-powered search and insights to give technical teams a single source of truth for their knowledge.
              Effortlessly create, surface and improve public and internal documentation that your users and teams will love. "
-    - name: waldium
-      link: https://www.waldium.com/?ref=writethedocs
-      brand: Waldium
     - name: fern
       link: https://buildwithfern.com/?ref=writethedocs
       brand: Fern


### PR DESCRIPTION
## Summary
- Remove Waldium from the patron sponsor list in the Portland 2026 config

## Test plan
- [ ] Verify sponsor page renders without Waldium
- [ ] Confirm no broken references to Waldium elsewhere

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2585.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->