### PR TITLE
Enable link checking for full writethedocs.org URLs

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -67,4 +67,4 @@ jobs:
     - name: Check links
       if: success()
       run:  |
-          bundle exec htmlproofer --ignore-files "/404/,/2013/,/2014/,/2015/,/2016/,/2017/,/search\/index.html/,/archive\/tag\/index/" --allow-hash-href=true --enforce-https=false --ignore-missing-alt=true --disable-external=true docs/_build/html
+          bundle exec htmlproofer --ignore-files "/404/,/2013/,/2014/,/2015/,/2016/,/2017/,/search\/index.html/,/archive\/tag\/index/" --allow-hash-href=true --enforce-https=false --ignore-missing-alt=true --disable-external=true --swap-urls "https\://www.writethedocs.org:,http\://www.writethedocs.org:" docs/_build/html

--- a/docs/blog/2022-community-update.rst
+++ b/docs/blog/2022-community-update.rst
@@ -51,7 +51,7 @@ allowing them to catch up on past conversations a bit more easily.
 We know some people wish we could pay for Slack,
 but we address `Slack history limitations <https://www.writethedocs.org/slack/#slack-history>`_ on our website.
 
-We also wanted to take the time to show appreciation to Janine Chan and all our `Slack moderation team <https://www.writethedocs.org/team/#slack-moderation>`_.
+We also wanted to take the time to show appreciation to Janine Chan and all our `Slack moderation team <https://www.writethedocs.org/team/#moderation-team>`_.
 We are overjoyed at the helpful community that we've been able to curate on our Slack network,
 and they play a huge role in that.
 If you aren't on our Slack,

--- a/docs/blog/introducing-weps.rst
+++ b/docs/blog/introducing-weps.rst
@@ -86,5 +86,5 @@ the better the community will be for everyone.
 
 .. [#] A great read if you haven't already: https://www.jofreeman.com/joreen/tyranny.htm
  
-.. _many other projects: https://www.writethedocs.org/#join-the-community
+.. _many other projects: https://www.writethedocs.org/#connect-with-the-community
 .. _WEP0: https://github.com/writethedocs/weps/pull/1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -244,7 +244,18 @@ def setup(app):
     def add_metadata(app, pagename, templatename, context, doctree):
         metadata = app.env.metadata.get(pagename, {})
         context.update(metadata)
+
+    # Fix canonical URLs for the dirhtml builder (Sphinx 5.x generates .html suffixed URLs)
+    def fix_canonical_url(app, pagename, templatename, context, doctree):
+        pageurl = context.get('pageurl')
+        if pageurl and pageurl.endswith('.html'):
+            if pageurl.endswith('/index.html'):
+                context['pageurl'] = pageurl[:-10]  # strip /index.html, keep trailing /
+            else:
+                context['pageurl'] = pageurl[:-5] + '/'  # strip .html, add /
+
     app.connect("html-page-context", add_metadata)
+    app.connect("html-page-context", fix_canonical_url)
 
     # Set up our custom jinja filters
     app.connect("builder-inited", add_jinja_filters_to_app)

--- a/docs/conf/atlantic/2023/news/announcing-schedule.rst
+++ b/docs/conf/atlantic/2023/news/announcing-schedule.rst
@@ -41,7 +41,7 @@ Our pre-conference `Writing Day <https://www.writethedocs.org/conf/{{shortcode}}
 
 If you have a project or are part of a community that you think would benefit from a writing sprint, start brainstorming now about what you might want to focus on.
 If you'd like us to include your project on the Writing Day page `submit your project <https://forms.gle/KPo1ZPuRHqf7UZy37>`_ and we'll
-add it to our `Writing Day project list <https://www.writethedocs.org/conf/atlantic/{{year}}/writing-day/#your-project-here>`__.
+add it to our `Writing Day project list <https://www.writethedocs.org/conf/atlantic/{{year}}/writing-day/#project-list>`__.
 You can also just show up on Sunday ready to introduce your project, but getting it on the website in advance can increase interest.
 
 

--- a/docs/conf/atlantic/2023/news/writing-day-cta.rst
+++ b/docs/conf/atlantic/2023/news/writing-day-cta.rst
@@ -27,7 +27,7 @@ Get involved with Writing Day!
 ------------------------------
 
 Ready to get involved?! `Submit your project <https://forms.gle/KPo1ZPuRHqf7UZy37>`_ and we'll 
-add it to our `Writing Day project list <https://www.writethedocs.org/conf/atlantic/{{year}}/writing-day/#your-project-here>`__.
+add it to our `Writing Day project list <https://www.writethedocs.org/conf/atlantic/{{year}}/writing-day/#project-list>`__.
 
 Need help convincing your OSS project community or corporate benefactors on the benefits of attending Writing Day? See `Make a case for Writing Day <https://www.writethedocs.org/conf/atlantic/{{year}}/writing-day-project-faq/#make-a-case-for-writing-day>`_.
 

--- a/docs/conf/atlantic/2024/cfp.rst
+++ b/docs/conf/atlantic/2024/cfp.rst
@@ -110,7 +110,7 @@ If you are making those assumptions about what your audience knows, it helps eve
 It can be  helpful to check out topics that might be related to your talk from previous years as well:
 
 * `Portland {{year-1}} <https://www.writethedocs.org/conf/portland/{{year-1}}/speakers/>`_
-* `Prague {{year-1}} <https://www.writethedocs.org/conf/prague/{{year-1}}/speakers/>`_
+* `Atlantic {{year-1}} <https://www.writethedocs.org/conf/atlantic/{{year-1}}/speakers/>`_
 * `Portland {{year-2}} <https://www.writethedocs.org/conf/portland/{{year-2}}/speakers/>`_
 * `Prague {{year-2}} <https://www.writethedocs.org/conf/prague/{{year-2}}/speakers/>`_
 

--- a/docs/conf/atlantic/2024/news/announcing-schedule.rst
+++ b/docs/conf/atlantic/2024/news/announcing-schedule.rst
@@ -43,7 +43,7 @@ Our pre-conference `Writing Day <https://www.writethedocs.org/conf/{{shortcode}}
 
 If you have a project or are part of a community that you think would benefit from a writing sprint, start brainstorming now about what you might want to focus on.
 If you'd like us to include your project on the Writing Day page, `submit your project <https://forms.gle/j44pUr31RNyzy5pL6>`_ and we'll
-add it to our `Writing Day project list <https://www.writethedocs.org/conf/atlantic/{{year}}/writing-day/#your-project-here>`__.
+add it to our `Writing Day project list <https://www.writethedocs.org/conf/atlantic/{{year}}/writing-day/#project-list>`__.
 You can also just show up on Sunday ready to introduce your project, but getting it on the website in advance can increase interest.
 
 

--- a/docs/conf/atlantic/2024/news/writing-day-call-for-projects.rst
+++ b/docs/conf/atlantic/2024/news/writing-day-call-for-projects.rst
@@ -43,4 +43,4 @@ welcome. Anyone with enthusiasm for their project and community is welcome to br
 If you’re excited about Writing Day and want to lead a project but not sure where to begin, we have `tips and tricks for project leaders <https://www.writethedocs.org/conf/atlantic/{{year}}/writing-day/#lead-a-project>`_ to help maximize your experience. 
 
 If you need additional information to advocate for Writing Day in your community, or help persuading 
-your corporate benefactors on the benefits of attending Writing Day, see the `Convince Your Community <https://www.writethedocs.org/conf/atlantic/{{year}}/convince-day-manager/#convince-your-community>`_ resource.
+your corporate benefactors on the benefits of attending Writing Day, see the `Convince Your Community <https://www.writethedocs.org/conf/atlantic/{{year}}/convince-your-manager/#convince-your-community>`_ resource.

--- a/docs/conf/atlantic/2024/writing-day.rst
+++ b/docs/conf/atlantic/2024/writing-day.rst
@@ -87,7 +87,7 @@ We strongly recommend that you `submit your Writing Day project in advance <http
 
 As usual, virtual walk-on projects are always welcome. All attendees always have the option to bring a project, sign up onsite, and announce it during Writing Day.
 
-If you need additional information to advocate for Writing Day in your community or organization, see the `Convince Your Community <https://www.writethedocs.org/conf/atlantic/{{year}}/convince-day-manager/#convince-your-community>`_ resource.
+If you need additional information to advocate for Writing Day in your community or organization, see the `Convince Your Community <https://www.writethedocs.org/conf/atlantic/{{year}}/convince-your-manager/#convince-your-community>`_ resource.
 
 Schedule
 --------

--- a/docs/conf/australia/2024/attendee-guide.md
+++ b/docs/conf/australia/2024/attendee-guide.md
@@ -43,11 +43,11 @@ The conference venue is located within a 5-minute walk of Melbourne Central Trai
 ## Hotels and Transportation
 
 - The conference is located in Melbourne Central Business District (CBD). There are many hotel options within a 5-10 minute drive, some of these are walking distance from the venue. View our [Visiting Melbourne](https://www.writethedocs.org/conf/australia/2024/visiting/#where-to-stay) page for recommended hotels.
-- Melbourne is an accessible city and there are many transportation options available including buses, trams, rideshare, and taxis. View our [Visiting Melbourne](https://www.writethedocs.org/conf/australia/2024/visiting/#getting-around) for information.
+- Melbourne is an accessible city and there are many transportation options available including buses, trams, rideshare, and taxis. View our [Visiting Melbourne](https://www.writethedocs.org/conf/australia/2024/visiting/#getting-around-melbourne) for information.
 
 ## Accessibility
 
-We are committed to hosting a conference that is accessible to everyone. Visit our [Accessibility section](https://www.writethedocs.org/conf/australia/2024/venue/#accessibility) on the Venue page for more information.
+We are committed to hosting a conference that is accessible to everyone. Visit our [Accessibility section](https://www.writethedocs.org/conf/australia/2024/venue/) on the Venue page for more information.
 
 ![Group of people talking](/_static/img/2024/attendee-guide.jpg)
 

--- a/docs/conf/australia/2024/cfp.rst
+++ b/docs/conf/australia/2024/cfp.rst
@@ -117,7 +117,7 @@ It can be  helpful to check out topics that might be related to your talk from p
 * `Australia {{year-1}} <https://www.writethedocs.org/conf/australia/{{year-1}}/speakers/>`_
 * `Australia {{year-3}} <https://www.writethedocs.org/conf/australia/{{year-3}}/speakers/>`_
 * `Portland {{year-1}} <https://www.writethedocs.org/conf/portland/{{year-1}}/speakers/>`_
-* `Prague {{year-1}} <https://www.writethedocs.org/conf/prague/{{year-1}}/speakers/>`_
+* `Atlantic {{year-1}} <https://www.writethedocs.org/conf/atlantic/{{year-1}}/speakers/>`_
 * `Portland {{year-2}} <https://www.writethedocs.org/conf/portland/{{year-2}}/speakers/>`_
 * `Prague {{year-2}} <https://www.writethedocs.org/conf/prague/{{year-2}}/speakers/>`_
 

--- a/docs/conf/australia/2025/attendee-guide.md
+++ b/docs/conf/australia/2025/attendee-guide.md
@@ -43,11 +43,11 @@ The conference venue is located within a 5-minute walk of Melbourne Central Trai
 ## Hotels and Transportation
 
 - The conference is located in Melbourne Central Business District (CBD). There are many hotel options within a 5-10 minute drive, some of these are walking distance from the venue. View our [Visiting Melbourne](https://www.writethedocs.org/conf/australia/2024/visiting/#where-to-stay) page for recommended hotels.
-- Melbourne is an accessible city and there are many transportation options available including buses, trams, rideshare, and taxis. View our [Visiting Melbourne](https://www.writethedocs.org/conf/australia/2024/visiting/#getting-around) for information.
+- Melbourne is an accessible city and there are many transportation options available including buses, trams, rideshare, and taxis. View our [Visiting Melbourne](https://www.writethedocs.org/conf/australia/2024/visiting/#getting-around-melbourne) for information.
 
 ## Accessibility
 
-We are committed to hosting a conference that is accessible to everyone. Visit our [Accessibility section](https://www.writethedocs.org/conf/australia/2024/venue/#accessibility) on the Venue page for more information.
+We are committed to hosting a conference that is accessible to everyone. Visit our [Accessibility section](https://www.writethedocs.org/conf/australia/2024/venue/) on the Venue page for more information.
 
 ![Group of people talking](/_static/img/2024/attendee-guide.jpg)
 

--- a/docs/conf/berlin/2026/cfp.md
+++ b/docs/conf/berlin/2026/cfp.md
@@ -99,7 +99,7 @@ Check out topics that might be related to your talk from previous years:
 
 - [Berlin {{year-1}}](https://www.writethedocs.org/conf/berlin/{{year-1}}/speakers/)
 - [Portland {{year-1}}](https://www.writethedocs.org/conf/portland/{{year-1}}/speakers/)
-- [Berlin {{year-2}}](https://www.writethedocs.org/conf/berlin/{{year-2}}/speakers/)
+- [Atlantic {{year-2}}](https://www.writethedocs.org/conf/atlantic/{{year-2}}/speakers/)
 - [Atlantic {{year-2}}](https://www.writethedocs.org/conf/atlantic/{{year-2}}/speakers/)
 
 ## Writing your proposal

--- a/docs/conf/berlin/2026/convince-your-manager.md
+++ b/docs/conf/berlin/2026/convince-your-manager.md
@@ -94,7 +94,7 @@ Peer review new and existing documentation*
 
 When discussing how to pitch Writing Day, a few helpful tips emerged:
 
-- Highlight specific projects from a previous [Writing Day project list.](https://www.writethedocs.org/conf/berlin/2025/writing-day/#project-listing)
+- Highlight specific projects from a previous [Writing Day project list.](https://www.writethedocs.org/conf/portland/2025/writing-day/#project-list)
 - If your community is looking for regular documentation contributions, this is a great place to onboard potential contributors and editors.
 - Attending raises the visibility of your company in the community. 
 - Establishes your team's reputation for caring about their docs.

--- a/docs/conf/berlin/2026/writing-day.md
+++ b/docs/conf/berlin/2026/writing-day.md
@@ -136,7 +136,7 @@ If you are planning to contribute, review the project list before the conference
 - Love letters
 - The Documentarian Manifesto
 
-Find specific examples on the [Berlin Writing Day 2025 project list](https://www.writethedocs.org/conf/berlin/2025/writing-day/#project-list).
+Find specific examples on the [Portland Writing Day 2025 project list](https://www.writethedocs.org/conf/portland/2025/writing-day/#project-list).
 
 ## Project list
 

--- a/docs/conf/portland/2022/news/thanks-recap.rst
+++ b/docs/conf/portland/2022/news/thanks-recap.rst
@@ -102,7 +102,7 @@ the US or in a similar timezone.
 
 .. _build the meetup community: http://www.writethedocs.org/meetups/
 .. _starting: http://www.writethedocs.org/organizer-guide/meetups/starting/
-.. _Quorum Meetups: https://www.writethedocs.org/meetups/#current-meetups-quorum
+.. _Quorum Meetups: https://www.writethedocs.org/meetups/#current-meetups
 
 Code of Conduct transparency report
 -----------------------------------

--- a/docs/conf/portland/2023/welcome-wagon.rst
+++ b/docs/conf/portland/2023/welcome-wagon.rst
@@ -87,8 +87,8 @@ How do I take part in the Writing Day?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  `Writing Day <https://www.writethedocs.org/conf/portland/2023/writing-day/>`_ takes place in the conference venue on Sunday, the day before the conference starts. You can show up any time between 9am and 5pm. There are lots of ways to contribute, and here are the most common:
--  `Sign up to host a project <https://www.writethedocs.org/conf/portland/2023/writing-day/#your-project-here>`_ before or during Writing Day. Be sure to include how to reach out to you. Here's the `2022 Writing Day Project list that you can use as a guide <http://www.writethedocs.org/conf/portland/2022/writing-day/>`_.
--  Help someone else with their writing project. `Check out the list <https://www.writethedocs.org/conf/portland/2023/writing-day/#your-project-here>`_ and connect with the project organizer, before or during Writing Day.
+-  `Sign up to host a project <https://www.writethedocs.org/conf/portland/2023/writing-day/#project-listing>`_ before or during Writing Day. Be sure to include how to reach out to you. Here's the `2022 Writing Day Project list that you can use as a guide <http://www.writethedocs.org/conf/portland/2022/writing-day/>`_.
+-  Help someone else with their writing project. `Check out the list <https://www.writethedocs.org/conf/portland/2023/writing-day/#project-listing>`_ and connect with the project organizer, before or during Writing Day.
 
 
 How do I take part in the unconference?

--- a/docs/conf/portland/2024/attendee-guide.md
+++ b/docs/conf/portland/2024/attendee-guide.md
@@ -38,7 +38,7 @@ Review our [Venue](https://www.writethedocs.org/conf/portland/2024/venue/) page 
     -   Ingredients will be listed
     -   Please email katie@writethedocs.org for other dietary requirements
 -   Bring a water bottle to make it easier for you to stay hydrated.
--   There are many food and beverage options within .5 mile around the conference venue. Explore Portland's amazing food scene on the [Portland](https://www.writethedocs.org/conf/portland/2024/visiting/#eating) page.
+-   There are many food and beverage options within .5 mile around the conference venue. Explore Portland's amazing food scene on the [Portland](https://www.writethedocs.org/conf/portland/2024/visiting/#food-and-beverages) page.
 -   The Welcome Wagon team will organize lunch and dinner meetups for folks interested in eating with others. Visit the WW table during conference days to sign up.
 
 ## Dress Code

--- a/docs/conf/portland/2024/convince-your-manager.rst
+++ b/docs/conf/portland/2024/convince-your-manager.rst
@@ -114,7 +114,7 @@ methods, such as Slack, Discord, etc.
   * Building professional connections with other documentarians
 
 Bringing our project to Writing Day benefits us as a community. It gives us the opportunity to 
-improve our documentation and create a more inclusive project. Check out the `Call for Projects <https://www.writethedocs.org/conf/portland/2024/call-for-projects-writing-day>`_ for more information.
+improve our documentation and create a more inclusive project. Check out the `Call for Projects <https://www.writethedocs.org/conf/portland/2024/news/call-for-projects-writing-day>`_ for more information.
 
   Thanks in advance,
   [your name]

--- a/docs/conf/portland/2024/news/call-for-projects-writing-day.rst
+++ b/docs/conf/portland/2024/news/call-for-projects-writing-day.rst
@@ -45,4 +45,4 @@ welcome. Anyone with enthusiasm for their project and community is welcome to br
 If you’re excited about Writing Day and want to lead a project but not sure where to begin, we have `tips and tricks for project leaders <https://www.writethedocs.org/conf/portland/{{year}}/writing-day/#lead-a-project>`_ to help maximize your experience. 
 
 If you need additional information to advocate for Writing Day in your community, or help persuading 
-your corporate benefactors on the benefits of attending Writing Day, see the `Convince Your Community <https://www.writethedocs.org/conf/portland/{{year}}/convince-day-manager/#convince-your-community>`_ resource.
+your corporate benefactors on the benefits of attending Writing Day, see the `Convince Your Community <https://www.writethedocs.org/conf/portland/{{year}}/convince-your-manager/#convince-your-community>`_ resource.

--- a/docs/conf/portland/2024/writing-day.rst
+++ b/docs/conf/portland/2024/writing-day.rst
@@ -101,7 +101,7 @@ Learn more in our `Call for Project Announcement <https://www.writethedocs.org/c
 
 As usual, walk-on projects are always welcome. All attendees always have the option to bring a project, sign up on site, and announce it during Writing Day.
 
-If you need additional information to advocate for Writing Day in your community or organization, see the `Convince Your Community <https://www.writethedocs.org/conf/portland/{{year}}/convince-day-manager/#convince-your-community>`_ resource.
+If you need additional information to advocate for Writing Day in your community or organization, see the `Convince Your Community <https://www.writethedocs.org/conf/portland/{{year}}/convince-your-manager/#convince-your-community>`_ resource.
 
 Project List
 ------------

--- a/docs/conf/portland/2025/news/announcing-schedule.rst
+++ b/docs/conf/portland/2025/news/announcing-schedule.rst
@@ -63,7 +63,7 @@ The campaign will run in batches until May 31st. Shipping is available from the 
 Website Resources
 -----------------
 
-View our `Attendee Guide <https://www.writethedocs.org/conf/{{city}}/{{year}}/attendee-guide/>`_ for a comprehensive overview of how to participate in the conference.
+View our `Attendee Guide <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/attendee-guide/>`_ for a comprehensive overview of how to participate in the conference.
 
 Thanks To Our Sponsors
 ----------------------

--- a/docs/conf/portland/2025/news/announcing-speakers.rst
+++ b/docs/conf/portland/2025/news/announcing-speakers.rst
@@ -42,7 +42,7 @@ Please ensure to arrange your travel only after buying a conference ticket.
 If you need additional information, we have a few resources to help you:
 
 * Visit our `Convince Your Manager page <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/convince-your-manager/>`_ for assistance in making the case for attendance.
-* Purchase your tickets on our `Tickets page <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/>`_.
+* Purchase your tickets on our `Tickets page <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/tickets/>`_.
 * Plan your journey with our `Visiting {{city}} page <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/visiting/>`_.
 
 

--- a/docs/conf/portland/2026/convince-your-manager.md
+++ b/docs/conf/portland/2026/convince-your-manager.md
@@ -94,7 +94,7 @@ Peer review new and existing documentation*
 
 When discussing how to pitch Writing Day, a few helpful tips emerged:
 
-- Highlight specific projects from a previous [Writing Day project list.](https://www.writethedocs.org/conf/portland/2025/writing-day/#project-listing)
+- Highlight specific projects from a previous [Writing Day project list.](https://www.writethedocs.org/conf/portland/2025/writing-day/#project-list)
 - If your community is looking for regular documentation contributions, this is a great place to onboard potential contributors and editors.
 - Attending raises the visibility of your company in the community. 
 - Establishes your team's reputation for caring about their docs.

--- a/docs/conf/portland/2026/news/announcing-schedule.md
+++ b/docs/conf/portland/2026/news/announcing-schedule.md
@@ -67,7 +67,7 @@ The campaign will run in batches until May 31st. Shipping is available from the 
 
 ## Website Resources
 
-View our [Attendee Guide](https://www.writethedocs.org/conf/{{city}}/{{year}}/attendee-guide/) for a comprehensive overview of how to participate in the conference.
+View our [Attendee Guide](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/attendee-guide/) for a comprehensive overview of how to participate in the conference.
 
 ## Thanks To Our Sponsors
 

--- a/docs/conf/prague/2022/news/thank-you-recap.rst
+++ b/docs/conf/prague/2022/news/thank-you-recap.rst
@@ -87,7 +87,7 @@ New this year are our `Quorum Meetups`_ which are virtual and targeting large ge
 
 .. _build your local or online communities: http://www.writethedocs.org/meetups/
 .. _starting: http://www.writethedocs.org/organizer-guide/meetups/starting/
-.. _Quorum Meetups: https://www.writethedocs.org/meetups/#current-meetups-quorum
+.. _Quorum Meetups: https://www.writethedocs.org/meetups/#current-meetups
 
 Code of Conduct transparency report
 -----------------------------------

--- a/docs/organizer-guide/meetups/quorum.md
+++ b/docs/organizer-guide/meetups/quorum.md
@@ -127,7 +127,6 @@ Participating U.S. East Coast and Central meetups:
 - [Detroit, MI/Windsor, CAN](https://www.meetup.com/write-the-docs-detroit-windsor/)
 - [Florida](https://www.meetup.com/write-the-docs-florida/)
 - [New England](https://www.meetup.com/ne-write-the-docs/)
-- [Philadelphia, PA](https://www.writethedocs.org/meetups/)
 - [Toronto, ON, CAN](https://www.meetup.com/Write-The-Docs-Toronto/)
 - [Washington, D.C.](https://www.meetup.com/Write-the-Docs-DC/)
 

--- a/docs/organizer-guide/meetups/quorum.md
+++ b/docs/organizer-guide/meetups/quorum.md
@@ -127,7 +127,7 @@ Participating U.S. East Coast and Central meetups:
 - [Detroit, MI/Windsor, CAN](https://www.meetup.com/write-the-docs-detroit-windsor/)
 - [Florida](https://www.meetup.com/write-the-docs-florida/)
 - [New England](https://www.meetup.com/ne-write-the-docs/)
-- [Philadelphia, PA](https://www.writethedocs.org/meetups/philly/)
+- [Philadelphia, PA](https://www.writethedocs.org/meetups/)
 - [Toronto, ON, CAN](https://www.meetup.com/Write-The-Docs-Toronto/)
 - [Washington, D.C.](https://www.meetup.com/Write-the-Docs-DC/)
 


### PR DESCRIPTION
## Summary
- Adds `--swap-urls` to the htmlproofer step so that absolute `https://www.writethedocs.org` and `http://www.writethedocs.org` URLs are rewritten to relative paths and checked as internal links
- External link checking for third-party sites remains disabled to avoid slow/flaky CI

## Test plan
- [ ] Verify the Ubuntu Build workflow passes on this PR
- [ ] Confirm any broken full-URL internal links are now caught

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2588.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->