### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,9 @@ docs/conf/prague/ @mxsasha @plaindocs
 # Australia conference
 docs/conf/australia/ @swapnilogale @ericholscher
 
+# Newsletter
+docs/blog/newsletter-* @CollierCZ @ericholscher
+
 # Guide and learning resources
 docs/guide/ @ericholscher @CollierCZ
 docs/hiring-guide/ @ericholscher @CollierCZ

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,17 +2,7 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Default owners for everything in the repo
-* @ericholscher @plaindocs
-
-# Build system, configuration, and infrastructure
-docs/conf.py @ericholscher @mxsasha
-docs/Makefile @ericholscher
-pyproject.toml @ericholscher
-requirements.txt @ericholscher
-.readthedocs.yaml @ericholscher
-dockerfile @ericholscher
-docs/_ext/ @ericholscher
-docs/_scripts/ @ericholscher
+* @ericholscher @plaindocs @mxsasha
 
 # Portland conference
 docs/conf/portland/ @ericholscher @plaindocs @janine-c
@@ -28,10 +18,3 @@ docs/conf/australia/ @swapnilogale @ericholscher
 # Guide and learning resources
 docs/guide/ @ericholscher @CollierCZ
 docs/hiring-guide/ @ericholscher @CollierCZ
-
-# Sponsors
-docs/_data/*-sponsors* @ericholscher
-docs/_static/img/sponsors/ @ericholscher
-
-# CI/CD
-.github/workflows/ @ericholscher

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,49 @@
+# Write the Docs CODEOWNERS
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+* @ericholscher @plaindocs
+
+# Build system, configuration, and infrastructure
+docs/conf.py @ericholscher @mxsasha
+docs/Makefile @ericholscher
+pyproject.toml @ericholscher
+requirements.txt @ericholscher
+.readthedocs.yaml @ericholscher
+dockerfile @ericholscher
+
+# Extensions and scripts
+docs/_ext/ @ericholscher
+docs/_scripts/ @ericholscher
+
+# Templates and static assets
+docs/_templates/ @ericholscher @plaindocs
+docs/_data/ @ericholscher @plaindocs
+
+# Portland conference
+docs/conf/portland/ @ericholscher @plaindocs @katiejano @janine-c
+
+# Berlin conference (formerly Prague / Atlantic)
+docs/conf/berlin/ @mxsasha @plaindocs
+docs/conf/atlantic/ @mxsasha @plaindocs
+docs/conf/prague/ @mxsasha @plaindocs
+
+# Australia conference
+docs/conf/australia/ @swapnilogale @ericholscher
+
+# Kenya conference
+docs/conf/kenya/ @ericholscher
+
+# Guide and learning resources
+docs/guide/ @ericholscher @CollierCZ @thatdocslady
+docs/hiring-guide/ @ericholscher @CollierCZ
+
+# Blog
+docs/blog/ @ericholscher @thatdocslady
+
+# Sponsors
+docs/_data/*-sponsors* @ericholscher
+docs/_static/img/sponsors/ @ericholscher
+
+# CI/CD
+.github/workflows/ @ericholscher

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,17 +11,11 @@ pyproject.toml @ericholscher
 requirements.txt @ericholscher
 .readthedocs.yaml @ericholscher
 dockerfile @ericholscher
-
-# Extensions and scripts
 docs/_ext/ @ericholscher
 docs/_scripts/ @ericholscher
 
-# Templates and static assets
-docs/_templates/ @ericholscher @plaindocs
-docs/_data/ @ericholscher @plaindocs
-
 # Portland conference
-docs/conf/portland/ @ericholscher @plaindocs @katiejano @janine-c
+docs/conf/portland/ @ericholscher @plaindocs @janine-c
 
 # Berlin conference (formerly Prague / Atlantic)
 docs/conf/berlin/ @mxsasha @plaindocs
@@ -31,15 +25,9 @@ docs/conf/prague/ @mxsasha @plaindocs
 # Australia conference
 docs/conf/australia/ @swapnilogale @ericholscher
 
-# Kenya conference
-docs/conf/kenya/ @ericholscher
-
 # Guide and learning resources
-docs/guide/ @ericholscher @CollierCZ @thatdocslady
+docs/guide/ @ericholscher @CollierCZ
 docs/hiring-guide/ @ericholscher @CollierCZ
-
-# Blog
-docs/blog/ @ericholscher @thatdocslady
 
 # Sponsors
 docs/_data/*-sponsors* @ericholscher


### PR DESCRIPTION
## Summary
- Adds a GitHub CODEOWNERS file based on analysis of commit history (past year) and PR review patterns (last ~50 merged PRs)
- Default owners are @ericholscher, @plaindocs, and @mxsasha
- Conference and guide sections override with area-specific owners (minimum 2 per area)

## Key ownership areas

| Area | Owners |
|------|--------|
| Default (everything) | @ericholscher, @plaindocs, @mxsasha |
| Portland conference | @ericholscher, @plaindocs, @janine-c |
| Berlin/Atlantic/Prague conf | @mxsasha, @plaindocs |
| Australia conference | @swapnilogale, @ericholscher |
| Guide & hiring guide | @ericholscher, @CollierCZ |

## Test plan
- [ ] Verify listed GitHub usernames are all valid org members or collaborators
- [ ] Confirm ownership mappings match team expectations
- [ ] Check that CODEOWNERS syntax is valid (GitHub will flag errors in the repo settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)