### PR TITLE
Rename sponsor-text CSS class to avoid ad blockers

### DIFF
--- a/docs/_templates/2020/sponsors.html
+++ b/docs/_templates/2020/sponsors.html
@@ -12,7 +12,7 @@
     </div>
       {% if include_text and sponsor.text %}
       <div >
-      <p class="sponsor-text">
+      <p class="supporter-info">
         {{ sponsor.text }}
       </p>
       </div>
@@ -30,7 +30,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text">
+      <span class="supporter-info">
         {{ sponsor.text }}
       </span>
       {% endif %}
@@ -47,7 +47,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text">
+      <span class="supporter-info">
         {{ sponsor.text }}
       </span>
       {% endif %}

--- a/docs/_templates/2021/sponsors.html
+++ b/docs/_templates/2021/sponsors.html
@@ -12,7 +12,7 @@
     </div>
       {% if include_text and sponsor.text %}
       <div >
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
         {{ sponsor.text }}
       </p>
       </div>
@@ -30,7 +30,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
 
         {{ sponsor.text }}
       </span>
@@ -52,7 +52,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
 
         {{ sponsor.text }}
       </span>
@@ -74,7 +74,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
         {{ sponsor.text }}
       </span>
       {% endif %}

--- a/docs/_templates/2022/sponsors.html
+++ b/docs/_templates/2022/sponsors.html
@@ -12,7 +12,7 @@
     </div>
       {% if include_text and sponsor.text %}
       <div >
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
         {{ sponsor.text }}
       </p>
       </div>
@@ -30,7 +30,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
 
         {{ sponsor.text }}
       </span>
@@ -52,7 +52,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
 
         {{ sponsor.text }}
       </span>
@@ -74,7 +74,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
         {{ sponsor.text }}
       </span>
       {% endif %}

--- a/docs/_templates/2023/sponsors.html
+++ b/docs/_templates/2023/sponsors.html
@@ -12,7 +12,7 @@
     </div>
       {% if include_text and sponsor.text %}
       <div >
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
         {{ sponsor.text }}
       </p>
       </div>
@@ -30,7 +30,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
 
         {{ sponsor.text }}
       </span>
@@ -52,7 +52,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
 
         {{ sponsor.text }}
       </span>
@@ -74,7 +74,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
         {{ sponsor.text }}
       </span>
       {% endif %}

--- a/docs/_templates/2024/sponsors.html
+++ b/docs/_templates/2024/sponsors.html
@@ -12,7 +12,7 @@
     </div>
       {% if include_text and sponsor.text %}
       <div >
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
       <p>
         {{ sponsor.text }}
       </p>
@@ -31,7 +31,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
 
         {{ sponsor.text }}
       </span>
@@ -53,7 +53,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
 
         {{ sponsor.text }}
       </span>
@@ -75,7 +75,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
         {{ sponsor.text }}
       </span>
       {% endif %}

--- a/docs/_templates/2025/sponsors.html
+++ b/docs/_templates/2025/sponsors.html
@@ -12,7 +12,7 @@
     </div>
       {% if include_text and sponsor.text %}
       <div >
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
       <p>
         {{ sponsor.text }}
       </p>
@@ -31,7 +31,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
 
         {{ sponsor.text }}
       </span>
@@ -53,7 +53,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
 
         {{ sponsor.text }}
       </span>
@@ -75,7 +75,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
         {{ sponsor.text }}
       </span>
       {% endif %}

--- a/docs/_templates/2026/sponsors.html
+++ b/docs/_templates/2026/sponsors.html
@@ -12,7 +12,7 @@
     </div>
       {% if include_text and sponsor.text %}
       <div >
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
       <p>
         {{ sponsor.text }}
       </p>
@@ -31,7 +31,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
 
         {{ sponsor.text }}
       </span>
@@ -53,7 +53,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
 
         {{ sponsor.text }}
       </span>
@@ -75,7 +75,7 @@
       </a>
     </div>
       {% if include_text and sponsor.text %}
-      <span class="sponsor-text" style="display: block;">
+      <span class="supporter-info" style="display: block;">
         {{ sponsor.text }}
       </span>
       {% endif %}


### PR DESCRIPTION
## Summary
- Renamed `sponsor-text` CSS class to `supporter-info` across all sponsor templates (2020–2026)
- Ad blockers (e.g. uBlock Origin) match class names containing "sponsor" and hide those elements, preventing users from seeing sponsor descriptions
- The class has no associated CSS rules, so this is a purely cosmetic rename with no style impact

## Test plan
- [ ] Verify sponsor descriptions render correctly on conference pages
- [ ] Confirm sponsor text is no longer hidden by common ad blockers (uBlock Origin, AdBlock Plus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2594.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->