### PR TITLE
Update Berlin 2026 sponsorship prospectus

### DIFF
--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -28,8 +28,8 @@ buttons:
   top:
     - text: Conference announcement
       link: /news/welcome
-#    - text: Sponsor us
-#      link: /sponsors/prospectus
+    - text: Sponsor us
+      link: /sponsors/prospectus
     # - text: Submit a Talk
     #   link: /cfp
     # - text: See the Schedule
@@ -45,8 +45,8 @@ buttons:
   bottom:
     - text: Conference announcement
       link: /news/welcome
-#    - text: Sponsor us
-#      link: /sponsors/prospectus
+    - text: Sponsor us
+      link: /sponsors/prospectus
     # - text: Submit a Talk
     #   link: /cfp
     # - text: Buy a Ticket
@@ -78,11 +78,11 @@ tickets:
 
 sponsorship:
   second_draft:
-    price: €2,000
+    price: €2,250
   publisher:
-    price: €3,500
+    price: €4,000
   patron:
-    price: €5,500
+    price: €6,000
   keystone:
     price: "" # None to not render
 

--- a/docs/conf/berlin/2026/sponsors/prospectus.md
+++ b/docs/conf/berlin/2026/sponsors/prospectus.md
@@ -8,7 +8,7 @@ banner: _static/conf/images/headers/2026/prospectus.jpg
 
 ## Introduction
 
-Welcome to the Write the Docs {{ city }} {{ year }} sponsorship prospectus. We're excited to work with the organizations in our community to build the best documentation event in {{ year }}. Created in 2013 in Berlin, Germany, WTD has hosted conferences around the world in Prague, Berlin, Sydney, London, and Melbourne. We’re excited to celebrate this year with your support!
+Welcome to the Write the Docs {{ city }} {{ year }} sponsorship prospectus. We’re excited to work with the organizations in our community to build the best documentation event in {{ year }}. Created in 2013 in Portland, Oregon, WTD has hosted conferences around the world in Prague, Berlin, Sydney, London, and Melbourne. We’re excited to celebrate this year with your support!
 
 {% if flagrunofshow %}
 
@@ -68,7 +68,7 @@ The **Keystone** sponsorship highlights you as the primary sponsor of the confer
 
 #### Benefits
 
-- Eight (8) tickets, with additional available to purchase at a discounted rate of \$500/ticket.
+- Eight (8) tickets, with additional available to purchase at a discounted rate of €300/ticket.
 - Most visible **sponsorship booth** for the entire conference (Monday & Tuesday). Monitor included in booth. Booths placed in order of purchase.
 - Sponsorship of a primary Write the Docs conference event (Unconference, Writing Day, or Social Event).
 - **60 second introduction** on the main stage introducing your company.
@@ -90,8 +90,8 @@ The **Patron** package is great for a larger company to get in front of our atte
 
 #### Benefits
 
-- Six (6) tickets, with additional available to purchase at a discounted rate of \$500/ticket.
-- A **sponsorship booth** for the entire conference (Monday & Tuesday). Monitor rental available for \$500.
+- Six (6) tickets, with additional available to purchase at a discounted rate of €300/ticket.
+- A **sponsorship booth** for the entire conference (Monday & Tuesday). Monitor rental available for €300.
 - **30 second introduction** on the main stage introducing your company.
 - Dedicated social media post.
 - Logo included in intermission slides and on talk videos.
@@ -107,7 +107,7 @@ The **Publisher** package is great for a company looking to send some employees 
 
 #### Benefits
 
-- Four (4) tickets, with additional available to purchase at a discounted rate of \$500/ticket.
+- Four (4) tickets, with additional available to purchase at a discounted rate of €300/ticket.
 - Logo included in intermission slides and on talk videos.
 - Dedicated social media post.
 - Logo and description (100 words) on the conference website.
@@ -122,7 +122,7 @@ The **Second Draft** package gives you visibility on the conference website and 
 
 #### Benefits
 
-- Two (2) tickets, with additional available to purchase at a discounted rate of \$500/ticket.
+- Two (2) tickets, with additional available to purchase at a discounted rate of €300/ticket.
 - Logo on the conference website.
 - Name included in all conference emails to attendees.
 - Display promotional (“Swag”) items on the conference swag table (provided by sponsor).
@@ -133,7 +133,7 @@ The following a la carte offerings are available either independently or combine
 
 ### Lightning Talks
 
-**\$3,500** - **Limit 2**
+**€4,000** - **Limit 2**
 
 Sponsor one day of Lightning Talks, where attendees have 5 minutes to share something they are excited about working on. You will have 60 seconds at the start to introduce your company.
 
@@ -146,7 +146,7 @@ Sponsor one day of Lightning Talks, where attendees have 5 minutes to share some
 
 ### Opportunity Grants
 
-**\$2,000** - **Limit 2**
+**€2,250** - **Limit 2**
 
 Provide additional funding for our Opportunity Grant program, which supports equity and accessibility and provides funding for low-income, marginalized people to attend the conference. These individuals would otherwise not be able to attend.
 

--- a/docs/conf/berlin/2026/sponsors/prospectus.md
+++ b/docs/conf/berlin/2026/sponsors/prospectus.md
@@ -146,7 +146,7 @@ Sponsor one day of Lightning Talks, where attendees have 5 minutes to share some
 
 ### Opportunity Grants
 
-**€2,250** - **Limit 2**
+**€2,000** - **Limit 2**
 
 Provide additional funding for our Opportunity Grant program, which supports equity and accessibility and provides funding for low-income, marginalized people to attend the conference. These individuals would otherwise not be able to attend.
 


### PR DESCRIPTION
## Summary

- Bump sponsorship prices ~10% for Berlin 2026 (Patron €5,500→€6,000, Publisher €3,500→€4,000, Second Draft €2,000→€2,250)
- Bump a la carte prices similarly (Lightning Talks €4,000, Opportunity Grants €2,250)
- Fix currency from USD ($) to EUR (€) throughout the prospectus — a la carte prices, discounted ticket rates, and monitor rental were all incorrectly in dollars
- Fix intro text that said WTD was created in Berlin (it was Portland)
- Enable "Sponsor us" button on the Berlin 2026 conference page

## Test plan

- [ ] Review updated prices with Sasha
- [x] Verify prospectus page renders correctly with `cd docs && make html`

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2597.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->