### PR TITLE
Add role="main" to conference page templates

### DIFF
--- a/docs/_templates/2018/generic.html
+++ b/docs/_templates/2018/generic.html
@@ -80,7 +80,7 @@
     <!-- end page-banner -->
 
   {% if body %}
-    <div class="page-content">
+    <div class="page-content" role="main">
         <div class="uk-container">
                 {% block body %}
                 {{ body }}

--- a/docs/_templates/2019/generic.html
+++ b/docs/_templates/2019/generic.html
@@ -82,7 +82,7 @@
     <!-- end page-banner -->
 
   {% if body %}
-    <div class="page-content">
+    <div class="page-content" role="main">
         <div class="uk-container">
                 {% block body %}
                 {{ body }}

--- a/docs/_templates/2020/generic.html
+++ b/docs/_templates/2020/generic.html
@@ -81,7 +81,7 @@
     <!-- end page-banner -->
 
   {% if body %}
-    <div class="page-content">
+    <div class="page-content" role="main">
         <div class="uk-container">
                 {% block body %}
                 {{ body }}

--- a/docs/_templates/2021/generic.html
+++ b/docs/_templates/2021/generic.html
@@ -81,7 +81,7 @@
     <!-- end page-banner -->
 
   {% if body %}
-    <div class="page-content">
+    <div class="page-content" role="main">
         <div class="uk-container">
                 {% block body %}
                 {{ body }}

--- a/docs/_templates/2022/generic.html
+++ b/docs/_templates/2022/generic.html
@@ -81,7 +81,7 @@
     <!-- end page-banner -->
 
   {% if body %}
-    <div class="page-content">
+    <div class="page-content" role="main">
         <div class="uk-container">
                 {% block body %}
                 {{ body }}

--- a/docs/_templates/2023/generic.html
+++ b/docs/_templates/2023/generic.html
@@ -81,7 +81,7 @@
     <!-- end page-banner -->
 
   {% if body %}
-    <div class="page-content">
+    <div class="page-content" role="main">
         <div class="uk-container">
                 {% block body %}
                 {{ body }}

--- a/docs/_templates/2024/generic-iframe.html
+++ b/docs/_templates/2024/generic-iframe.html
@@ -10,7 +10,7 @@
 
 {% block container %}
   {% if body %}
-    <div class="page-content">
+    <div class="page-content" role="main">
         <div class="uk-container">
                 {% block body %}
                 {{ body }}

--- a/docs/_templates/2024/generic.html
+++ b/docs/_templates/2024/generic.html
@@ -81,7 +81,7 @@
     <!-- end page-banner -->
 
   {% if body %}
-    <div class="page-content">
+    <div class="page-content" role="main">
         <div class="uk-container">
                 {% block body %}
                 {{ body }}

--- a/docs/_templates/2025/generic-iframe.html
+++ b/docs/_templates/2025/generic-iframe.html
@@ -10,7 +10,7 @@
 
 {% block container %}
   {% if body %}
-    <div class="page-content">
+    <div class="page-content" role="main">
         <div class="uk-container">
                 {% block body %}
                 {{ body }}

--- a/docs/_templates/2025/generic.html
+++ b/docs/_templates/2025/generic.html
@@ -81,7 +81,7 @@
     <!-- end page-banner -->
 
   {% if body %}
-    <div class="page-content">
+    <div class="page-content" role="main">
         <div class="uk-container">
                 {% block body %}
                 {{ body }}

--- a/docs/_templates/2026/generic-iframe.html
+++ b/docs/_templates/2026/generic-iframe.html
@@ -10,7 +10,7 @@
 
 {% block container %}
   {% if body %}
-    <div class="page-content">
+    <div class="page-content" role="main">
         <div class="uk-container">
                 {% block body %}
                 {{ body }}

--- a/docs/_templates/2026/generic.html
+++ b/docs/_templates/2026/generic.html
@@ -57,7 +57,7 @@
     <!-- end page-banner -->
 
   {% if body %}
-    <div class="page-content">
+    <div class="page-content" role="main">
         <div class="uk-container">
                 {% block body %}
                 {{ body }}


### PR DESCRIPTION
## Summary

- Adds `role="main"` to the `div.page-content` element in all conference `generic.html` and `generic-iframe.html` templates (2018–2026)
- This allows using `[role="main"]` as a unified CSS selector for Read the Docs addons configuration, since Alabaster pages already have `role="main"` on their content div
- Also improves accessibility by adding the ARIA landmark role for screen readers

## Test plan

- [ ] Verify conference pages render correctly (no layout changes expected — attribute-only addition)
- [ ] Update Read the Docs addons content selector from `.page-content` to `[role="main"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2602.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->