### PR TITLE
Add Keystone sponsorship tier for Berlin 2026

### DIFF
--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -84,7 +84,7 @@ sponsorship:
   patron:
     price: €6,000
   keystone:
-    price: "" # None to not render
+    price: €10,000
 
 grants:
   url: ""


### PR DESCRIPTION
## Summary
- Enable the Keystone sponsorship tier for Berlin 2026 at €10,000
- The prospectus template already has the Keystone section, gated by a price check — this just sets the price to make it render

## Test plan
- [ ] Verify Keystone section appears on Berlin 2026 prospectus page

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2603.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->