### PR TITLE
Add button-link directive to replace inline HTML buttons

### DIFF
--- a/docs/_ext/button.py
+++ b/docs/_ext/button.py
@@ -1,0 +1,38 @@
+from docutils import nodes
+from docutils.parsers import rst
+
+
+class ButtonLink(rst.Directive):
+    """A simple button directive that renders a styled call-to-action button.
+
+    Usage in myst markdown::
+
+        ```{button-link} https://example.com
+        Button text
+        ```
+
+    Usage in RST::
+
+        .. button-link:: https://example.com
+
+           Button text
+    """
+
+    required_arguments = 1  # URL
+    has_content = True
+
+    def run(self):
+        url = self.arguments[0]
+        text = "\n".join(self.content).strip()
+        html = (
+            f'<div style="margin: 2em 0;">'
+            f'<table border="0" cellpadding="0" cellspacing="0" style="background-color:#fdb913; border-radius:5px; margin:auto;">'
+            f'<tr>'
+            f'<td align="center" valign="middle" style="color:#000000; font-family:Helvetica, Arial, sans-serif; font-size:16px; font-weight:bold; letter-spacing:-.5px; line-height:150%; padding-top:15px; padding-right:30px; padding-bottom:15px; padding-left:30px;">'
+            f'<a href="{url}" target="_blank" style="color:#000000; text-decoration:none; text-transform:uppercase; border-bottom: none;">{text}</a>'
+            f'</td>'
+            f'</tr>'
+            f'</table>'
+            f'</div>'
+        )
+        return [nodes.raw("", html, format="html")]

--- a/docs/_ext/button.py
+++ b/docs/_ext/button.py
@@ -24,15 +24,13 @@ class ButtonLink(rst.Directive):
     def run(self):
         url = self.arguments[0]
         text = "\n".join(self.content).strip()
-        html = (
-            f'<div style="margin: 2em 0;">'
-            f'<table border="0" cellpadding="0" cellspacing="0" style="background-color:#fdb913; border-radius:5px; margin:auto;">'
-            f'<tr>'
-            f'<td align="center" valign="middle" style="color:#000000; font-family:Helvetica, Arial, sans-serif; font-size:16px; font-weight:bold; letter-spacing:-.5px; line-height:150%; padding-top:15px; padding-right:30px; padding-bottom:15px; padding-left:30px;">'
-            f'<a href="{url}" target="_blank" style="color:#000000; text-decoration:none; text-transform:uppercase; border-bottom: none;">{text}</a>'
-            f'</td>'
-            f'</tr>'
-            f'</table>'
-            f'</div>'
-        )
+        html = f"""<div style="margin: 2em 0;">
+<table border="0" cellpadding="0" cellspacing="0" style="background-color:#fdb913; border-radius:5px; margin:auto;">
+<tr>
+<td align="center" valign="middle" style="color:#000000; font-family:Helvetica, Arial, sans-serif; font-size:16px; font-weight:bold; letter-spacing:-.5px; line-height:150%; padding-top:15px; padding-right:30px; padding-bottom:15px; padding-left:30px;">
+<a href="{url}" target="_blank" style="color:#000000; text-decoration:none; text-transform:uppercase; border-bottom: none;">{text}</a>
+</td>
+</tr>
+</table>
+</div>"""
         return [nodes.raw("", html, format="html")]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,6 +65,7 @@ from _ext.core import (
 from _ext.filters import add_jinja_filters_to_app
 from _ext.meetups import MeetupListing
 from _ext.atom_absolute import rewrite_atom_feed
+from _ext.button import ButtonLink
 
 exclude_patterns = [
     '_build',
@@ -259,6 +260,7 @@ def setup(app):
         app.connect('build-finished', rewrite_atom_feed)
 
     app.add_directive('meetup-listing', MeetupListing)
+    app.add_directive('button-link', ButtonLink)
     app.add_css_file('css/global-customizations.css')
     app.add_css_file('css/survey.css')
 

--- a/docs/conf/portland/2026/news/announcing-schedule.md
+++ b/docs/conf/portland/2026/news/announcing-schedule.md
@@ -13,15 +13,9 @@ The {{city}} conference is just over six weeks away, and we're busy getting read
 
 You've already seen our list of awesome speakers; now we're announcing our [full conference schedule](/conf/portland/{{year}}/schedule/) so you know when they will be presenting!
 
-<div style="margin: 2em 0;">
-<table border="0" cellpadding="0" cellspacing="0" style="background-color:#fdb913; border:1px solid #4a4a4a; border-radius:5px; margin:auto;">
-<tr>
-   <td align="center" valign="middle" style="color:#000000; font-family:Helvetica, Arial, sans-serif; font-size:16px; font-weight:bold; letter-spacing:-.5px; line-height:150%; padding-top:15px; padding-right:30px; padding-bottom:15px; padding-left:30px;">
-      <a href="https://ti.to/writethedocs/write-the-docs-portland-2026" target="_blank" style="color:#000000; text-decoration:none; text-transform:uppercase; border-bottom: none;">Buy your ticket</a>
-   </td>
-</tr>
-</table>
-</div>
+```{button-link} https://ti.to/writethedocs/write-the-docs-portland-2026
+Buy your ticket
+```
 
 ## Speaker Schedule
 

--- a/docs/conf/portland/2026/news/announcing-speakers.md
+++ b/docs/conf/portland/2026/news/announcing-speakers.md
@@ -13,15 +13,9 @@ Our {{year}} {{city}} conference is under three months away, and we can't wait t
 
 The big news today is that our speaker lineup is here! Check out the list of speakers and their talks below, and get ready for another year in Portland.
 
-<div style="margin: 2em 0;">
-<table border="0" cellpadding="0" cellspacing="0" style="background-color:#fdb913; border:1px solid #4a4a4a; border-radius:5px; margin:auto;">
-<tr>
-   <td align="center" valign="middle" style="color:#000000; font-family:Helvetica, Arial, sans-serif; font-size:16px; font-weight:bold; letter-spacing:-.5px; line-height:150%; padding-top:15px; padding-right:30px; padding-bottom:15px; padding-left:30px;">
-      <a href="https://ti.to/writethedocs/write-the-docs-portland-2026" target="_blank" style="color:#000000; text-decoration:none; text-transform:uppercase; border-bottom: none;">Buy your ticket</a>
-   </td>
-</tr>
-</table>
-</div>
+```{button-link} https://ti.to/writethedocs/write-the-docs-portland-2026
+Buy your ticket
+```
 
 ## {{city}} {{year}} speakers
 

--- a/docs/conf/portland/2026/news/one-month-out.md
+++ b/docs/conf/portland/2026/news/one-month-out.md
@@ -30,15 +30,9 @@ Still need a ticket? Now is a great time to purchase your ticket at one of our v
 | Corporate                              | $650                     | $175       |
    
 <br />
-<div style="margin: 2em 0;">
-<table border="0" cellpadding="0" cellspacing="0" style="background-color:#fdb913; border-radius:5px; margin:auto;">
-<tr>
-   <td align="center" valign="middle" style="color:#000000; font-family:Helvetica, Arial, sans-serif; font-size:16px; font-weight:bold; letter-spacing:-.5px; line-height:150%; padding-top:15px; padding-right:30px; padding-bottom:15px; padding-left:30px;">
-      <a href="https://ti.to/writethedocs/write-the-docs-portland-2026" target="_blank" style="color:#000000; text-decoration:none; text-transform:uppercase; border-bottom: none;">Buy your ticket</a>
-   </td>
-</tr>
-</table>
-</div>
+```{button-link} https://ti.to/writethedocs/write-the-docs-portland-2026
+Buy your ticket
+```
 
 ## Join our Slack Community
 
@@ -49,15 +43,9 @@ Our [#wtd-conferences](https://writethedocs.slack.com/archives/C1AKFQATH) channe
 
 There is a two-step process to join Slack. You need to complete a short signup form before you can create your account.
 
-<div style="margin: 2em 0;">
-<table border="0" cellpadding="0" cellspacing="0" style="background-color:#fdb913; border-radius:5px; margin:auto;">
-<tr>
-   <td align="center" valign="middle" style="color:#000000; font-family:Helvetica, Arial, sans-serif; font-size:16px; font-weight:bold; letter-spacing:-.5px; line-height:150%; padding-top:15px; padding-right:30px; padding-bottom:15px; padding-left:30px;">
-      <a href="https://docs.google.com/forms/d/e/1FAIpQLSdq4DWRphVt1qVqH8NsjNnS0Szu_NljjZRUvyYqR7mdc00zKQ/viewform" target="_blank" style="color:#000000; text-decoration:none; text-transform:uppercase; border-bottom: none;">Join Slack today</a>
-   </td>
-</tr>
-</table>
-</div>
+```{button-link} https://docs.google.com/forms/d/e/1FAIpQLSdq4DWRphVt1qVqH8NsjNnS0Szu_NljjZRUvyYqR7mdc00zKQ/viewform
+Join Slack today
+```
 
 
 ## Writing Day Projects
@@ -66,15 +54,9 @@ Call for Writing Day projects! Submit your project by **April 22, 2026** to be p
 
 Online project submission is optional, and we have several day-of project submissions. We adore all of our projects and volunteers, no matter when they sign up. And don't forget that this year we've added Git and GitHub workshops, resume and portfolio writing and review sessions, and roundtable discussions. All are welcome!
 
-<div style="margin: 2em 0;">
-<table border="0" cellpadding="0" cellspacing="0" style="background-color:#fdb913; border-radius:5px; margin:auto;">
-<tr>
-   <td align="center" valign="middle" style="color:#000000; font-family:Helvetica, Arial, sans-serif; font-size:16px; font-weight:bold; letter-spacing:-.5px; line-height:150%; padding-top:15px; padding-right:30px; padding-bottom:15px; padding-left:30px;">
-      <a href="https://docs.google.com/forms/d/e/1FAIpQLSfr5-2yJOFVjYLA2jaik8nP17nxm3fKDX6GA64SAyC14uKr1Q/viewform" target="_blank" style="color:#000000; text-decoration:none; text-transform:uppercase; border-bottom: none;">Submit your Writing Day project</a>
-   </td>
-</tr>
-</table>
-</div>
+```{button-link} https://docs.google.com/forms/d/e/1FAIpQLSfr5-2yJOFVjYLA2jaik8nP17nxm3fKDX6GA64SAyC14uKr1Q/viewform
+Submit your Writing Day project
+```
 
 ## How Do I Participate in the Conference? 
 


### PR DESCRIPTION
## Summary
- Adds a `button-link` Sphinx directive (`docs/_ext/button.py`) that replaces verbose inline HTML table buttons with a clean syntax:
  ````
  ```{button-link} https://example.com
  Button text
  ```
  ````
- Replaces all 5 inline HTML button instances across 3 Portland 2026 news posts
- Renders identical HTML output to the previous inline approach

## Test plan
- [ ] Verify RTD preview build renders buttons correctly on the 3 news pages
- [ ] Check button styling matches previous inline HTML buttons

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2606.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->