### PR TITLE
Replace single website field with links dict for meetup listings

### DIFF
--- a/docs/_data/meetups/aus.yaml
+++ b/docs/_data/meetups/aus.yaml
@@ -1,6 +1,5 @@
 region: Oceania
 country: Australia
-website: https://www.meetup.com/write-the-docs-australia/events/
 meetup: Write-the-Docs-Australia
 organizers:
   - name: Swapnil Ogale

--- a/docs/_data/meetups/can-calgary.yaml
+++ b/docs/_data/meetups/can-calgary.yaml
@@ -2,7 +2,6 @@ region: North America
 country: Canada
 state: Alberta
 city: Calgary
-website: https://www.meetup.com/wtd-calgary/events/
 meetup: WTD-Calgary
 organizers:
   - name: Ken Schatzke

--- a/docs/_data/meetups/can-ottawa.yaml
+++ b/docs/_data/meetups/can-ottawa.yaml
@@ -2,7 +2,6 @@ region: North America
 country: Canada
 state: Ontario
 city: Ottawa
-website: https://www.meetup.com/write-the-docs-yow-ottawa/events/
 meetup: Write-The-Docs-YOW-Ottawa
 organizers:
   - name: Andrew Johnston

--- a/docs/_data/meetups/esp-barcelona.yaml
+++ b/docs/_data/meetups/esp-barcelona.yaml
@@ -1,7 +1,6 @@
 region: Europe
 country: Spain
 city: Barcelona
-website: https://www.meetup.com/write-the-docs-barcelona/events/
 meetup: Write-the-Docs-Barcelona
 organizers:
   - name: Fabrizio Ferri-Benedetti

--- a/docs/_data/meetups/fra-paris.yaml
+++ b/docs/_data/meetups/fra-paris.yaml
@@ -1,7 +1,6 @@
 region: Europe
 country: France
 city: Paris
-website: https://www.meetup.com/write-the-docs-paris/events/
 meetup: Write-the-Docs-Paris
 organizers:
   - name: François Violette

--- a/docs/_data/meetups/gbr-london.yaml
+++ b/docs/_data/meetups/gbr-london.yaml
@@ -1,7 +1,6 @@
 region: Europe
 country: United Kingdom
 city: London
-website: https://www.meetup.com/write-the-docs-london/events/
 meetup: Write-The-Docs-London
 organizers:
   - name: Polina Zaichkina

--- a/docs/_data/meetups/ger-berlin.yaml
+++ b/docs/_data/meetups/ger-berlin.yaml
@@ -1,7 +1,6 @@
 region: Europe
 country: Germany
 city: Berlin
-website: https://www.meetup.com/write-the-docs-berlin/events/
 meetup: Write-The-Docs-Berlin
 organizers:
   - name: Sam Wright

--- a/docs/_data/meetups/ind-bangalore.yaml
+++ b/docs/_data/meetups/ind-bangalore.yaml
@@ -1,7 +1,6 @@
 region: Asia
 country: India
 city: Bangalore
-website: https://www.meetup.com/write-the-docs-india/events/
 meetup: Write-the-Docs-India
 organizers:
    - name: Rajakavitha Kodhandapani

--- a/docs/_data/meetups/irl-dublin.yaml
+++ b/docs/_data/meetups/irl-dublin.yaml
@@ -1,7 +1,6 @@
 region: Europe
 country: Ireland
 city: Dublin
-website: https://www.meetup.com/write-the-docs-ireland/events/
 meetup: Write-The-Docs-Ireland
 organizers:
   - name: Artem Konev

--- a/docs/_data/meetups/isr-herzliya.yaml
+++ b/docs/_data/meetups/isr-herzliya.yaml
@@ -1,7 +1,6 @@
 region: Asia
 country: Israel
 city: Tel Aviv+
-website: https://www.meetup.com/write-the-docs-taplus/events/
 meetup: Write-The-Docs-TAplus
 organizers:
   - name: Laura Novich

--- a/docs/_data/meetups/kenya-nairobi.yaml
+++ b/docs/_data/meetups/kenya-nairobi.yaml
@@ -1,7 +1,6 @@
 region: Africa
 country: Kenya
 city: Nairobi
-website: https://www.meetup.com/wtd-kenya/events/
 meetup: Write-the-Docs-Kenya
 organizers:
   - name: Hillary Nyakundi

--- a/docs/_data/meetups/ned-amsterdam.yaml
+++ b/docs/_data/meetups/ned-amsterdam.yaml
@@ -1,7 +1,6 @@
 region: Europe
 country: Netherlands
 city: Amsterdam
-website: https://www.meetup.com/write-the-docs-amsterdam/events/
 meetup: Write-The-Docs-Amsterdam
 organizers:
   - name: Laura Vass

--- a/docs/_data/meetups/ng-portharcourt.yaml
+++ b/docs/_data/meetups/ng-portharcourt.yaml
@@ -1,7 +1,6 @@
 region: Africa
 country: Nigeria
 city: Port Harcourt & Lagos
-website: https://www.meetup.com/write-the-docs-nigeria/events/
 meetup: Write-the-Docs-Nigeria
 organizers:
   - name: Tabah Baridule Martins

--- a/docs/_data/meetups/swe-stockholm.yaml
+++ b/docs/_data/meetups/swe-stockholm.yaml
@@ -1,6 +1,5 @@
 region: Europe
 country: Sweden
-website: https://www.meetup.com/write-the-docs-sweden/events/
 meetup: write-the-docs-sweden
 organizers:
   - name: Julia Fischer

--- a/docs/_data/meetups/us-east-coast-virtual.yaml
+++ b/docs/_data/meetups/us-east-coast-virtual.yaml
@@ -1,6 +1,5 @@
 region: North America
 country: US East Coast Virtual
-website: https://www.meetup.com/write-the-docs-east-coast/events/
 meetup: Write-The-Docs-East-Coast
 organizers:
   - name: Lisa Gay

--- a/docs/_data/meetups/usa-austin.yaml
+++ b/docs/_data/meetups/usa-austin.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: Texas
 city: Austin
-website: https://www.meetup.com/writethedocs-atx-meetup/events/
 meetup: WriteTheDocs-ATX-Meetup
 organizers:
   - name: Caley Burton

--- a/docs/_data/meetups/usa-boulder.yaml
+++ b/docs/_data/meetups/usa-boulder.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: Colorado
 city: Boulder/Denver
-website: https://www.meetup.com/write-the-docs-boulder-denver/events/
 meetup: Write-the-Docs-Boulder-Denver
 organizers:
   - name: Kaylyn Sigler

--- a/docs/_data/meetups/usa-huntsville.yaml
+++ b/docs/_data/meetups/usa-huntsville.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: Alabama
 city: Huntsville
-website: https://www.meetup.com/write-the-docs-huntsville/events
 meetup: Write-the-Docs-Huntsville
 organizers:
   - name: Morgan Etheredge

--- a/docs/_data/meetups/usa-losAngeles.yaml
+++ b/docs/_data/meetups/usa-losAngeles.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: California
 city: Los Angeles
-website: https://www.meetup.com/write-the-docs-la/events/
 meetup: Write-the-Docs-Los-Angeles
 organizers:
   - name: Andrea Kao

--- a/docs/_data/meetups/usa-nashville.yaml
+++ b/docs/_data/meetups/usa-nashville.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: Tennessee
 city: Nashville
-website: https://www.meetup.com/write-the-docs-nashville/events/
 meetup: Write-the-Docs-Nashville
 organizers:
   - name: Pratishtha Singh

--- a/docs/_data/meetups/usa-northcarolina.yaml
+++ b/docs/_data/meetups/usa-northcarolina.yaml
@@ -1,7 +1,6 @@
 region: North America
 country: USA
 state: North & South Carolina
-website: https://www.meetup.com/write-the-docs-carolinas/
 meetup: Write-the-Docs-Carolinas
 organizers:
   - name: Kane Martin

--- a/docs/_data/meetups/usa-nyc.yaml
+++ b/docs/_data/meetups/usa-nyc.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: New York
 city: New York City
-website: https://www.meetup.com/writethedocsnyc
 meetup: NYC Write the Docs
 organizers:
   - name: Lois Patterson

--- a/docs/_data/meetups/usa-pittsburgh.yaml
+++ b/docs/_data/meetups/usa-pittsburgh.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: Pennsylvania
 city: Pittsburgh
-website: https://www.meetup.com/write-the-docs-pittsburgh/events/
 meetup: write-the-docs-pittsburgh
 organizers:
   - name: Rachael Stavchansky

--- a/docs/_data/meetups/usa-portland.yaml
+++ b/docs/_data/meetups/usa-portland.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: Oregon
 city: Portland
-website: https://www.meetup.com/write-the-docs-pdx/events/
 meetup: Write-The-Docs-PDX
 twitter: WriteTheDocsPDX
 organizers:

--- a/docs/_data/meetups/usa-sanfrancisco.yaml
+++ b/docs/_data/meetups/usa-sanfrancisco.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: California
 city: San Francisco
-website: https://www.meetup.com/write-the-docs-bay-area/events/
 meetup: Write-the-Docs
 organizer:
    - name: Ilona Koren-Deutsch

--- a/docs/_data/meetups/usa-seattle.yaml
+++ b/docs/_data/meetups/usa-seattle.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: Washington
 city: Seattle
-website: https://www.meetup.com/write-the-docs-seattle/events/
 meetup: Write-The-Docs-Seattle
 organizers:
   - name: Jerome Villegas

--- a/docs/_data/meetups/usa-washingtondc.yaml
+++ b/docs/_data/meetups/usa-washingtondc.yaml
@@ -2,7 +2,6 @@ region: North America
 country: USA
 state: DC
 city: Washington
-website: https://www.meetup.com/write-the-docs-dc/events/
 meetup: Write-the-Docs-DC
 organizers:
   - name: Allison Gisinger

--- a/docs/_ext/meetup_events.py
+++ b/docs/_ext/meetup_events.py
@@ -23,10 +23,10 @@ def load_meetups():
     for yaml_file in glob.glob(os.path.join(PATH, '../_data/meetups/*.yaml')):
         print('Loading meetup YAML: %s' % yaml_file)
         meetup = load_yaml(yaml_file)
-        if 'website' not in meetup:
+        if 'meetup' not in meetup:
             pprint(meetup)
-            raise Exception('Meetup needs a website')
-        meetup_urls.append(meetup['website'])
+            raise Exception('Meetup needs a meetup key')
+        meetup_urls.append('https://www.meetup.com/%s/events/' % meetup['meetup'])
     return meetup_urls
 
 # Expects $MEETUP_API_KEY to de defined as an environment variable

--- a/docs/_ext/meetups.py
+++ b/docs/_ext/meetups.py
@@ -41,7 +41,7 @@ def load_meetups_by_region():
         # Conditionally show the meetup meta data block
         meetup['has_meta'] = any([(key in meetup) for key in [
             'organizers',
-            'website',
+            'links',
             'twitter',
         ]])
         if 'meetup' not in meetup:

--- a/docs/_scripts/get_upcoming_meetups.py
+++ b/docs/_scripts/get_upcoming_meetups.py
@@ -85,11 +85,7 @@ for yaml_file in yaml_files:
         # If no city, just use the country
         except KeyError:
             location = f"{data['country']}"
-        url_to_check = ''
-        if data['website'].startswith("https://www.meetup.com"):
-            url_to_check = data['website']
-        else:
-            url_to_check = f"https://www.meetup.com/{data['meetup']}/events"
+        url_to_check = f"https://www.meetup.com/{data['meetup']}/events"
         meetup_links.append({"location": location, "url": url_to_check})
 
 # Run the URL checks asynchronously

--- a/docs/_templates/include/meetups/listing.jinja
+++ b/docs/_templates/include/meetups/listing.jinja
@@ -35,6 +35,15 @@
               </div>
             {% endif %}
 
+            {# Other internet presence #}
+            {% if meetup['links'] %}
+              <ul>
+                {% for text, link in meetup['links'].items() %}
+                  <li><a href="{{ link }}">{{ text }}</a></li>
+                {% endfor %}
+              </ul>
+            {% endif %}
+
             {# On twitter #}
             {% if meetup['twitter'] %}
               <div>


### PR DESCRIPTION
## Summary

Clean reimplementation of #2242 rebased on current main.

- Remove redundant `website` field from all 27 meetup YAML files (the Meetup.com URL is already derivable from the `meetup` key)
- Add support for a `links` dictionary in the meetup listing template, enabling multiple external links with custom labels (e.g. Meetup, LinkedIn, Discord)
- Update `meetups.py`, `meetup_events.py`, and `get_upcoming_meetups.py` to no longer depend on the `website` field

Addresses review feedback from @ericholscher on #2242 to use a `links` dict structure.

## Test plan

- [x] Site builds successfully with `make html`
- [ ] Verify meetup listing pages render correctly
- [ ] Add a `links` dict to a meetup YAML file and confirm it renders as a list of links


<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2607.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->