### PR TITLE
Scope down CODEOWNERS to reduce unnecessary pings

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,7 +2,8 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Portland conference
-docs/conf/portland/news/ @ericholscher @plaindocs @janine-c
+docs/conf/portland/news/ @ericholscher @janine-c
+docs/conf/portland/ @ericholscher @plaindocs
 
 # Berlin conference
 docs/conf/berlin/ @mxsasha @plaindocs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,7 +3,7 @@
 
 # Portland conference
 docs/conf/portland/news/ @ericholscher @janine-c
-docs/conf/portland/ @ericholscher @plaindocs
+docs/conf/portland/ @ericholscher 
 
 # Berlin conference
 docs/conf/berlin/ @mxsasha @plaindocs

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@ docs/conf/portland/ @ericholscher
 docs/conf/berlin/ @mxsasha @plaindocs
 
 # Australia conference
-docs/conf/australia/ @swapnilogale
+docs/conf/australia/ @swapnilogale @ericholscher
 
 # Newsletter
 docs/blog/newsletter-* @CollierCZ 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,23 +1,14 @@
 # Write the Docs CODEOWNERS
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Default owners for everything in the repo
-* @ericholscher @plaindocs @mxsasha
-
 # Portland conference
-docs/conf/portland/ @ericholscher @plaindocs @janine-c
+docs/conf/portland/news/ @ericholscher @plaindocs @janine-c
 
-# Berlin conference (formerly Prague / Atlantic)
+# Berlin conference
 docs/conf/berlin/ @mxsasha @plaindocs
-docs/conf/atlantic/ @mxsasha @plaindocs
-docs/conf/prague/ @mxsasha @plaindocs
 
 # Australia conference
-docs/conf/australia/ @swapnilogale @ericholscher
+docs/conf/australia/ @swapnilogale
 
 # Newsletter
-docs/blog/newsletter-* @CollierCZ @ericholscher
-
-# Guide and learning resources
-docs/guide/ @ericholscher @CollierCZ
-docs/hiring-guide/ @ericholscher @CollierCZ
+docs/blog/newsletter-* @CollierCZ 


### PR DESCRIPTION
## Summary
- Removed the catch-all `*` default owners that was pinging everyone on every PR
- Narrowed conference ownership to specific directories instead of broad patterns
- Removed guide/hiring-guide ownership and legacy Atlantic/Prague paths

## Test plan
- [ ] Verify PR reviewers are only auto-requested for matching paths

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2611.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->