### PR TITLE
Update Portland 2026 conference docs with dynamic templates and 2026 assets

### DIFF
--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -148,6 +148,7 @@ about:
   social_venue:  Jupiter NEXT, 900 E Burnside St (2nd floor)
   venue: Revolution Hall
   venue_address: Revolution Hall, 1300 SE Stark St, Portland, Oregon 97214
+  venue_map_url: https://maps.app.goo.gl/Z38CyRjmUukr3eSL6
   photos: TBD
   mainroom: Main stage
   unconfroom: Library & Astoria room (1st floor)

--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -245,10 +245,10 @@ sponsors:
 
 photos:
   default:
-    - _static/conf/images/headers/2025/grants.jpg
-    - _static/conf/images/headers/2025/unconference.jpg
-    - _static/conf/images/headers/2025/volunteer.jpg
-    - _static/conf/images/headers/2025/writing-day.jpg
+    - _static/conf/images/headers/2026/unconference.jpg
+    - _static/conf/images/headers/2026/volunteer.jpg
+    - _static/conf/images/headers/2026/writing-day.jpg
+    - _static/conf/images/headers/2026/tickets.jpg
   index:
     - _static/conf/images/pics/writing-day.jpg
     - _static/conf/images/pics/reg.jpg
@@ -264,7 +264,7 @@ flagscheduleincomplete: False
 flagspeakersannounced: True
 flagrunofshow: True
 flaghasschedule: True
-flaghasshirts: False
+flaghasshirts: True
 flaglivestreaming: False
 flagvideos: False
 flagpostconf: False

--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -168,6 +168,7 @@ unconf:
 writing_day:
   url: "https://docs.google.com/forms/d/e/1FAIpQLSfr5-2yJOFVjYLA2jaik8nP17nxm3fKDX6GA64SAyC14uKr1Q/viewform?usp=header"
   date: Sunday, May 3, 9 AM - 5 PM
+  project_deadline: "April 22, 2026"
 
 volunteer:
   form_url: "https://docs.google.com/forms/d/e/1FAIpQLSeJvA3uhXDuFsl_kFYWyTyTIyYs6ItHMPspOVq_iSlIloFo6g/viewform?usp=sharing&ouid=109538527958730243648"

--- a/docs/_data/schema-config.yaml
+++ b/docs/_data/schema-config.yaml
@@ -174,6 +174,7 @@ about-details:
   summary: str(required=False)
   venue: str(required=False)
   venue_address: str(required=False)
+  venue_map_url: str(required=False)
   attendees: any(int(), str())
   mainroom: str(required=False)
   unconfroom: str(required=False)

--- a/docs/_data/schema-config.yaml
+++ b/docs/_data/schema-config.yaml
@@ -211,6 +211,7 @@ unconf-details:
 writing_day-details:
   url: str(required=False)
   date: str(required=True)
+  project_deadline: str(required=False)
 
 hike-details:
   date: str(required=True)

--- a/docs/conf/portland/2026/attendee-guide.md
+++ b/docs/conf/portland/2026/attendee-guide.md
@@ -132,7 +132,7 @@ Join us for our Sunday night welcome party! Drinks and snacks included.
 
 ### Monday Conference Party:
 
-This is our main social event of the conference, and this year is held at [Jupiter NEXT](https://www.jupiterhotel.com/). Drinks and snacks provided by us. 
+This is our main social event of the conference. Drinks and snacks provided by us. 
 
 It is a time to connect with other attendees outside of the scheduled programming.  Come for an hour or stay the entire time!
 
@@ -140,9 +140,7 @@ It is a time to connect with other attendees outside of the scheduled programmin
 7-9 PM
 
 **Location:**
-Jupiter NEXT
-900 E Burnside St
-2nd floor
+{{ about.social_venue }}
 
 ### Hike:
 

--- a/docs/conf/portland/2026/cfp.md
+++ b/docs/conf/portland/2026/cfp.md
@@ -1,7 +1,7 @@
 ---
 template: {{year}}/generic.html
 og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
-banner: _static/conf/images/headers/2025/lightning-talks.jpg
+banner: _static/conf/images/headers/2026/lightning-talks.jpg
 ---
 
 # Call for Proposals
@@ -155,14 +155,14 @@ All Speakers must read, understand, and agree to our [Code of Conduct](/code-of-
 **{{cfp.ends}}**  
 Call for Proposal ends
 
+**{{cfp.notification}}**  
+We'll let you know whether your proposal was accepted, and ask for some supplementary information about you. Make sure to confirm your talk as soon as you get the email.
+
 **{{cfp.speaker_tickets_by}}**  
 Register for speaker ticket (with dietary preferences, hoodie size, etc.)
 
 **April 9, 2026**  
 Upload date for recorded talks (remote speakers)
-
-**{{cfp.notification}}**  
-We'll let you know whether your proposal was accepted, and ask for some supplementary information about you. Make sure to confirm your talk as soon as you get the email.
 
 **{{cfp.slides_by}}**  
 We'll ask for a copy of your slides so our human captioners can prepare for your talk

--- a/docs/conf/portland/2026/hike.md
+++ b/docs/conf/portland/2026/hike.md
@@ -57,6 +57,6 @@ The temperature will likely be in the upper 50s and 60s, with a chance of rain. 
 
 ## Tickets
 
-Participating in the hike or urban walk is free, but please register for your free [hike ticket]({{ hike.register_url }}) or [nature walk ticket](https://ti.to/writethedocs/write-the-docs-portland-2026/with/nature-walk) so that we can confirm number of folks and contact you in advance for day-of weather and logistics information. 
+Participating in the hike or urban walk is free, but please register for your free [hike ticket]({{ hike.register_url }}) or [urban walk ticket](https://ti.to/writethedocs/write-the-docs-portland-2026/with/nature-walk) so that we can confirm number of folks and contact you in advance for day-of weather and logistics information. 
 
 We hope you will join us for one of these pre-conference activities!

--- a/docs/conf/portland/2026/news/announcing-schedule.md
+++ b/docs/conf/portland/2026/news/announcing-schedule.md
@@ -49,15 +49,15 @@ Write the Docs is more than a conference. In addition to Speaker Talks, Writing 
 
 * **Saturday Hike or Walk:**
   * Join us for the hike in the amazing Forest Park, the largest urban forested park in the country. We'll be hiking along a beautiful creek and start at Lower Macleay Park at 2 PM. Please register a [free hike ticket](https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}/with/hike-ticket) so we can contact you with any last minute weather and logistics information.
-  * Not in the mood for a full hike? This year, we've added a shorter urban walk that starts with a tour at the International Rose Test Garden at 2:30 PM and optionally continues to Powell's Books. Register for a [free nature walk ticket](https://ti.to/writethedocs/write-the-docs-portland-2026/with/nature-walk).
+  * Not in the mood for a full hike? This year, we've added a shorter urban walk that starts with a tour at the International Rose Test Garden at 2:30 PM and optionally continues to Powell's Books. Register for a [free urban walk ticket](https://ti.to/writethedocs/write-the-docs-portland-2026/with/nature-walk).
 * **Sunday Welcome Reception:** Join us for our evening conference reception. This is a great chance to meet other attendees, get your badge (if you don't have it yet), and familiarize yourself with the venue. Drinks and snacks provided by us.
-* **Monday Conference Party**. On Monday night we'll be hosting a social event off-site at [Jupiter NEXT](https://www.jupiterhotel.com/), 900 E Burnside St, 2nd floor. This is a great chance to get to know more folks in the community and have a drink or two on us. Non-alcoholic options and snacks also provided. Event is 7-9 PM.
+* **Monday Conference Party**. On Monday night we'll be hosting a social event off-site at {{ about.social_venue }}. This is a great chance to get to know more folks in the community and have a drink or two on us. Non-alcoholic options and snacks also provided. Event is 7-9 PM.
 
 ## T-shirts Are Now Available
 
-The [Write the Docs {{city}} {{year}} T-shirt Shop](https://shirt.writethedocs.org/) is open! We have loose and fitted options from different fabrics, and you can choose exactly the size and cut you want. As in previous years, we're doing a mail order shop so people can order the exact shirt they want, if they want one.
+The [Write the Docs {{city}} {{year}} T-shirt Shop]({{ shirts.url }}) is open! We have loose and fitted options from different fabrics, and you can choose exactly the size and cut you want. As in previous years, we're doing a mail order shop so people can order the exact shirt they want, if they want one.
 
-The campaign will run in batches until May 31st. Shipping is available from the USA or Europe. We recommend you order your shirt at least 2-3 weeks in advance if you want to sport your fancy new garb during the conference.
+The campaign will run in batches until {{ shirts.ends }}. Shipping is available from the USA or Europe. We recommend you order your shirt at least 2-3 weeks in advance if you want to sport your fancy new garb during the conference.
 
 ## Website Resources
 

--- a/docs/conf/portland/2026/news/one-month-out.md
+++ b/docs/conf/portland/2026/news/one-month-out.md
@@ -11,7 +11,7 @@ banner: _static/conf/images/headers/2026/registration.jpg
 
 # One Month Until Write the Docs Portland
 
-Write the Docs Portland 2026 is just under one month away on May 3-5! Whether you're a programmer, tech writer, designer, project manager, or developer advocate, we have talks and a community for you.
+Write the Docs {{ name }} {{ year }} is just under one month away on {{ date.short }}! Whether you're a programmer, tech writer, designer, project manager, or developer advocate, we have talks and a community for you.
 
 ## New in 2026
 
@@ -50,7 +50,7 @@ Join Slack today
 
 ## Writing Day Projects
 
-Call for Writing Day projects! Submit your project by **April 22, 2026** to be promoted in our pre-conference Writing Day blog post and email.
+Call for Writing Day projects! Submit your project by **{{ writing_day.project_deadline }}** to be promoted in our pre-conference Writing Day blog post and email.
 
 Online project submission is optional, and we have several day-of project submissions. We adore all of our projects and volunteers, no matter when they sign up. And don't forget that this year we've added Git and GitHub workshops, resume and portfolio writing and review sessions, and roundtable discussions. All are welcome!
 

--- a/docs/conf/portland/2026/news/two-months-out.md
+++ b/docs/conf/portland/2026/news/two-months-out.md
@@ -34,7 +34,7 @@ Want more information? Look no further than the [Writing Day page](https://www.w
 
 ### Project submissions are open
 
-Got an idea for a Writing Day project? Submit it by **April 22, 2026** so we can share it in a blog post and email with our attendees before the conference! And you're always more than welcome to bring a project the day of and announce it during the actual Writing Day.
+Got an idea for a Writing Day project? Submit it by **{{ writing_day.project_deadline }}** so we can share it in a blog post and email with our attendees before the conference! And you're always more than welcome to bring a project the day of and announce it during the actual Writing Day.
 
 <div class="announcement" style="background-color:white;">
     <div class="uk-container">

--- a/docs/conf/portland/2026/news/visiting-info.md
+++ b/docs/conf/portland/2026/news/visiting-info.md
@@ -17,7 +17,7 @@ We're just over three months out from the conference and want to share a few imp
 
 ## Visiting Portland page is live!
 
-Our [Visiting Portland](https://www.writethedocs.org/conf/portland/2026/visiting/) page has the latest updates. This year, we're excited to partner with two new hotels, and share even more delicious food and drink options. 
+Our [Visiting Portland](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/visiting/) page has the latest updates. This year, we're excited to partner with two new hotels, and share even more delicious food and drink options. 
 
 ### Hotel Recommendations
 
@@ -35,16 +35,16 @@ Both are close to the Pearl district and Powell's books, offer a nightly drink h
 
 Be sure to book through the links above to get the Write the Docs rates.
 
-View our [Visiting Portland](https://www.writethedocs.org/conf/portland/2026/visiting/) page for more information.
+View our [Visiting Portland](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/visiting/) page for more information.
 
-### Opportunity grant application closes February 5
+### Opportunity grant application closes {{ grants.ends }}
 
-The [Opportunity Grant](https://www.writethedocs.org/conf/portland/2026/opportunity-grants/) supports people who would otherwise not be able to attend the conference by covering ticket and/or other attendance costs. Applications are open to anyone who wants to attend Write the Docs. [Learn more at the website. ](https://www.writethedocs.org/conf/portland/2026/opportunity-grants/)
+The [Opportunity Grant](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/opportunity-grants/) supports people who would otherwise not be able to attend the conference by covering ticket and/or other attendance costs. Applications are open to anyone who wants to attend Write the Docs. [Learn more at the website. ](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/opportunity-grants/)
 
 
 ### Volunteer with Us!
 
-Interested in volunteering? It's a great way to get involved and help make the conference happen. We are approaching volunteer capacity, so complete the application today. [Visit the website for additional information. ](https://www.writethedocs.org/conf/portland/2026/volunteer/)
+Interested in volunteering? It's a great way to get involved and help make the conference happen. We are approaching volunteer capacity, so complete the application today. [Visit the website for additional information. ](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/volunteer/)
 
 ## Join our community of Sponsors
 Each year, we are grateful for the support of like-minded organizations that share our belief in a collaborative and welcoming community spirit, helping to make the conference a success.
@@ -60,7 +60,7 @@ Thanks to our current sponsors:
 
 
 
-Check out our [sponsorship prospectus](https://www.writethedocs.org/conf/portland/2026/sponsors/prospectus/) to learn more and join the community.
+Check out our [sponsorship prospectus](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/sponsors/prospectus/) to learn more and join the community.
 
 We look forward to an excellent year!
 

--- a/docs/conf/portland/2026/opportunity-grants.md
+++ b/docs/conf/portland/2026/opportunity-grants.md
@@ -29,7 +29,7 @@ Grant applicants, like all other participants in the Write the Docs community, a
 ## Schedule
 
 - **Now - {{ grants.ends }}:** Grant applications open
-- **February 13, 2026:** Grant recipients notified
+- **{{ grants.notification }}:** Grant recipients notified
 
 ## What is Covered
 

--- a/docs/conf/portland/2026/social-events.md
+++ b/docs/conf/portland/2026/social-events.md
@@ -17,7 +17,7 @@ We encourage everyone to drop by on Sunday evening for the conference reception.
 This is a great chance to meet other attendees,
 and make sure you know your way around the conference venue.
 
-**Where**: {{about.venue}}, {{about.unconfroom}}  
+**Where**: {{about.venue}}, {{about.unconfroom}} and Show Bar  
 **When**: 5-7 PM
 
 *Both alcoholic and non-alcoholic drinks and snacks will be provided.*

--- a/docs/conf/portland/2026/sponsors/activations.md
+++ b/docs/conf/portland/2026/sponsors/activations.md
@@ -1,7 +1,7 @@
 ---
 template: {{year}}/generic.html
 og:image: _static/conf/images/headers/{{ shortcode }}-{{year}}-opengraph.jpg
-banner: _static/conf/images/headers/2025/sponsors.jpg
+banner: _static/conf/images/headers/2026/sponsors.jpg
 orphan: true
 ---
 

--- a/docs/conf/portland/2026/sponsors/activations.md
+++ b/docs/conf/portland/2026/sponsors/activations.md
@@ -180,7 +180,7 @@ Free professional headshots for all attendees, sponsored by your company. Sponso
 
 A useful, co-branded item distributed to all attendees featuring both the Write the Docs and sponsor logos. Items should be practical and conference-appropriate (e.g., cable organizers, portable chargers). Write the Docs manages production and distribution.
 
-- **Quantity:** All registered attendees (~400)
+- **Quantity:** All registered attendees (~{{ about.attendees }})
 
 ### What Write the Docs Provides
 

--- a/docs/conf/portland/2026/sponsors/information.md
+++ b/docs/conf/portland/2026/sponsors/information.md
@@ -11,7 +11,7 @@ Hi sponsors! We're excited to have you join us for Write the Docs {{ name }} {{ 
 ## Location
 
 {{ about.venue }}: 
-[1300 SE Stark St](https://maps.app.goo.gl/Z38CyRjmUukr3eSL6)
+[1300 SE Stark St]({{ about.venue_map_url }})
 
 ## Schedule
 

--- a/docs/conf/portland/2026/sponsors/information.md
+++ b/docs/conf/portland/2026/sponsors/information.md
@@ -1,7 +1,7 @@
 ---
 template: {{year}}/generic.html
 og:image: _static/conf/images/headers/{{ shortcode }}-{{year}}-opengraph.jpg
-banner: _static/conf/images/headers/2025/sponsors.jpg
+banner: _static/conf/images/headers/2026/sponsors.jpg
 ---
 
 # Sponsor Information
@@ -26,17 +26,17 @@ Revolution Hall:
 * 7:00am: Arrival and booth setup for Keystone/Patron sponsors
 * 8:00am: Doors to venue/sponsor booths open
 * 9:00am-5:00pm: Speaker Talks and Unconference
-* 10:50am: Booth sponsor introductions on main stage
-* 5:00-7:00pm: Evening break
+* 11:05am: Booth sponsor introductions on main stage
+* 5:05pm: Conference Day 1 ends
 * 7:00-9:00pm: Evening party at Jupiter NEXT (900 E Burnside St, 2nd floor)
 
 **TUESDAY, MAY 5**:
 
-* 8:15am: Keystone/Patron sponsor arrival
+* 8:00am: Keystone/Patron sponsor arrival
 * 8:30am: Doors to venue/sponsor booths open
 * 9:00am-4:00pm: Speaker Talks and Unconference
 * 4:30pm: Conference ends/load out
-* 5:30pm: Out of venue 
+* 6:00pm: Out of venue 
 
 ## Conference Overview
 

--- a/docs/conf/portland/2026/sponsors/information.md
+++ b/docs/conf/portland/2026/sponsors/information.md
@@ -6,31 +6,31 @@ banner: _static/conf/images/headers/2026/sponsors.jpg
 
 # Sponsor Information
 
-Hi sponsors! We're excited to have you join us for Write the Docs Portland 2026. Below is a conference overview, schedule, and detailed information regarding your participation.
+Hi sponsors! We're excited to have you join us for Write the Docs {{ name }} {{ year }}. Below is a conference overview, schedule, and detailed information regarding your participation.
 
 ## Location
 
-Revolution Hall: 
+{{ about.venue }}: 
 [1300 SE Stark St](https://maps.app.goo.gl/Z38CyRjmUukr3eSL6)
 
 ## Schedule
 
-**SUNDAY, MAY 3**:
+**{{ date.day_two.dotw | upper }}, {{ date.day_two.date | upper }}**:
 
 * 8:00am: Doors open
 * 9:00am-5:00pm: Writing Day and check in
 * 5:00-7:00pm: Welcome reception
 
-**MONDAY, MAY 4**:
+**{{ date.day_three.dotw | upper }}, {{ date.day_three.date | upper }}**:
 
 * 7:00am: Arrival and booth setup for Keystone/Patron sponsors
 * 8:00am: Doors to venue/sponsor booths open
 * 9:00am-5:00pm: Speaker Talks and Unconference
 * 11:05am: Booth sponsor introductions on main stage
 * 5:05pm: Conference Day 1 ends
-* 7:00-9:00pm: Evening party at Jupiter NEXT (900 E Burnside St, 2nd floor)
+* 7:00-9:00pm: Evening party at {{ about.social_venue }}
 
-**TUESDAY, MAY 5**:
+**{{ date.day_four.dotw | upper }}, {{ date.day_four.date | upper }}**:
 
 * 8:00am: Keystone/Patron sponsor arrival
 * 8:30am: Doors to venue/sponsor booths open
@@ -107,7 +107,7 @@ If you are sponsoring a Lightning Talk, you will be given 60 seconds to share ab
 Host a project at Writing Day. This is a place where the community gathers to get actual work done and is a great opportunity to meet with a small group and have extended interaction with attendees. 
 
 * View our [Lead a Project](https://www.writethedocs.org/conf/{{ shortcode }}/{{ year }}/writing-day/#lead-a-project) for more information.
-* [Submit your Writing Day project here.](https://docs.google.com/forms/d/e/1FAIpQLSfr5-2yJOFVjYLA2jaik8nP17nxm3fKDX6GA64SAyC14uKr1Q/viewform?usp=dialog) All projects submitted by April 22 will be published to our website, which encourages attendees to attend, engage with your product, and contribute to your documentation.
+* [Submit your Writing Day project here.](https://docs.google.com/forms/d/e/1FAIpQLSfr5-2yJOFVjYLA2jaik8nP17nxm3fKDX6GA64SAyC14uKr1Q/viewform?usp=dialog) All projects submitted by {{ writing_day.project_deadline }} will be published to our website, which encourages attendees to attend, engage with your product, and contribute to your documentation.
 
 ### Host an Unconference Session
 

--- a/docs/conf/portland/2026/tickets.md
+++ b/docs/conf/portland/2026/tickets.md
@@ -102,7 +102,7 @@ If you need to cancel your ticket because of fear of traveling internationally t
 
 {% if shirts and flaghasshirts %}
 
-<div class="ticket">
+<div class="ticket" id="official-conference-shirts">
   <h2>
     <strong>Official Conference Shirts</strong>
   </h2>

--- a/docs/conf/portland/2026/venue.md
+++ b/docs/conf/portland/2026/venue.md
@@ -24,8 +24,8 @@ Bus transit stops are located near the venue. All transit in Portland announce m
 ### Registration and Welcome Wagon
 
 **Location:**
-- May 3: 1st floor near Martha's Cafe
-- May 4-5: 2nd floor
+- {{ date.day_two.date }}: 1st floor near Martha's Cafe
+- {{ date.conference.date }}: 2nd floor
 
 ### Writing Day, Unconference, and Welcome Reception
 

--- a/docs/conf/portland/2026/venue.md
+++ b/docs/conf/portland/2026/venue.md
@@ -1,6 +1,6 @@
 ---
 template: {{year}}/generic.html
-banner: _static/conf/images/headers/portland-2024-venue.jpg
+banner: _static/conf/images/headers/2026/portland.jpg
 og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
 ---
 
@@ -8,7 +8,7 @@ og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
 
 ## Revolution Hall
 
-1300 SE Stark Ave
+1300 SE Stark St
 Portland, OR 97214
 
 Our conference will be held at Revolution Hall, a beautiful venue located in the thriving inner east side of Portland. It was originally a high school, and was converted into the versatile space it is today, including an 800+ seat auditorium, coffee shop, bar/restaurant, rooftop bar, rooms to support events, and local businesses. The venue still has some lockers in the hallway for that extra ambiance.
@@ -29,7 +29,11 @@ Bus transit stops are located near the venue. All transit in Portland announce m
 
 ### Writing Day, Unconference, and Welcome Reception
 
-**Location:** 1st Floor: Library/Astoria Room
+**Location:** 1st Floor: Library/Astoria Room, Martha's, and Sunset Room
+
+- Writing Day projects and Unconference sessions: Library/Astoria Room
+- GitHub workshops: Sunset Room
+- Roundtable discussions, resume/portfolio review, and sponsor activations: Martha's
 
 ### Speaker Talks, Sponsor Expo, and Catering
 **Location:** 2nd/3rd floor auditorium and surrounding spaces

--- a/docs/conf/portland/2026/writing-day.md
+++ b/docs/conf/portland/2026/writing-day.md
@@ -81,7 +81,7 @@ Leading a project at Writing Day is a wonderful opportunity to engage with docum
 
 #### Submit
 
-**If you submit your project by April 22, 2026, we will share your project in a blog post and email with our attendees before the conference.**
+**If you submit your project by {{ writing_day.project_deadline }}, we will share your project in a blog post and email with our attendees before the conference.**
 
 [Submit projects]({{ writing_day.url }})
 
@@ -101,7 +101,7 @@ Walk-on projects are always welcome. You are still more than welcome to bring a 
 - **Clear onboarding:** Ensure your README, contribution guidelines, or onboarding instructions are accurate and up to date.
 - **Project experts:** We recommend having 1-2 people leading a project. You are welcome to call for virtual reinforcements from your community. If you need additional support onboarding volunteers, the WTD staff team will share this opportunity with the community. View further information in the [Call for Projects form]({{ writing_day.url }}).
 - **Flexibility and understanding:** Reminder that attendees may need additional info to be successful in onboarding to your project.
-- **Submit your Writing Day project before the conference:** Projects submitted by **April 22, 2026** are featured in our pre-conference blog post and email. Many attendees have shared that their curiosity for specific projects motivated them to attend. Project submissions open in February/March.
+- **Submit your Writing Day project before the conference:** Projects submitted by **{{ writing_day.project_deadline }}** are featured in our pre-conference blog post and email. Many attendees have shared that their curiosity for specific projects motivated them to attend. Project submissions open in February/March.
 
 These are suggestions and not requirements. It is perfectly valid to show up to Writing Day the day of, tell us about your project, and ask for volunteers. It has been done before and it will be done again.
 


### PR DESCRIPTION
## Summary
This PR updates the Write the Docs Portland 2026 conference documentation to use dynamic template variables instead of hardcoded values, and updates image assets to reference 2026 instead of 2025. This makes the configuration more maintainable and reusable across conference instances.

## Notable Implementation Details

The changes enable the conference documentation to be more easily reused for future years by centralizing configuration in the YAML data file rather than embedding values in markdown content. Template variables are processed during site generation to produce the final conference-specific pages.

https://claude.ai/code/session_01J3GQpEM52hFKabSXtZoAib

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2615.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->