### PR TITLE
dev container fix: remove expired Yarn apt repo before Ruby feature install

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
+
+# The Yarn apt repo bundled in this base image has an expired GPG key,
+# which breaks any subsequent apt-get update (e.g. during feature installs).
+# Remove it so downstream steps don't fail.
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+          /etc/apt/sources.list.d/yarn.list.save 2>/dev/null; exit 0

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,8 @@
 {
   "name": "Python and Ruby",
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
+	"build": {
+    "dockerfile": "Dockerfile"
+  },
   "features": {
     "ghcr.io/devcontainers/features/ruby:1": {
       "version": "3.4.1"


### PR DESCRIPTION
## Problem

Opening this repo in a dev container fails during the Ruby feature install with:

    E: The repository 'https://dl.yarnpkg.com/debian stable InRelease' is not signed.
    ERROR: Feature "Ruby (via rvm)" failed to install!

The `mcr.microsoft.com/devcontainers/python` base image ships with a Yarn apt repository pre-configured, and its GPG key (`62D54FD4003F6525`) has expired. Any `apt-get update` in a subsequent build step fails hard.

## Fix

- Added `.devcontainer/Dockerfile` that extends the base image and removes the bad Yarn apt source list before anything else runs
- Switched `devcontainer.json` from `"image":` to `"build.dockerfile":` to use the new Dockerfile

## Testing

Rebuilt the container from scratch — Ruby feature installs cleanly, pip install -r requirements.txt` succeeds, and `make livehtml` works.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2620.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->