### PR TITLE
Add sponsor sessions to Portland 2026 unconference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,10 @@
 .DS_Store
 _build
 .env
-.tox
+.venv
 venv*
 *.pyc
+.tox
 node_modules
 .sass-cache
 docs/meetups/events.rst

--- a/docs/_data/portland-2026-schedule.yaml
+++ b/docs/_data/portland-2026-schedule.yaml
@@ -67,7 +67,7 @@ talks_day1:
     title: "<a href='../unconference'>Unconference starts</a>"
   - time: '10:00'
     duration: '0:00'
-    title: "☕ <a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Promptless, with free handcrafted espresso"
+    title: "☕ <a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Promptless"
   - duration: '0:30'
     slug: documentation-thinking-beyond-the-docs-lessons-from-decision-facing-technical-w-mary-elise-dedicke
   - duration: '0:05'
@@ -135,7 +135,7 @@ talks_day2:
     title: "<a href='../unconference'>Unconference starts</a>"
   - time: '10:00'
     duration: '0:00'
-    title: "🍵 <a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Mintlify, with free handcrafted matcha"
+    title: "🍵 <a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Mintlify"
   - duration: '0:30'
     slug: what-i-learned-building-an-ai-documentation-auditor-and-what-it-found-in-500-p-rakesh-pasupuleti
   - duration: '0:05'

--- a/docs/_data/portland-2026-schedule.yaml
+++ b/docs/_data/portland-2026-schedule.yaml
@@ -67,7 +67,7 @@ talks_day1:
     title: "<a href='../unconference'>Unconference starts</a>"
   - time: '10:00'
     duration: '0:00'
-    title: "<a href='../unconference/#sponsor-sessions'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Promptless"
+    title: "<a href='../unconference/#sponsor-sessions-in-marthas'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Promptless"
   - duration: '0:30'
     slug: documentation-thinking-beyond-the-docs-lessons-from-decision-facing-technical-w-mary-elise-dedicke
   - duration: '0:05'
@@ -135,7 +135,7 @@ talks_day2:
     title: "<a href='../unconference'>Unconference starts</a>"
   - time: '10:00'
     duration: '0:00'
-    title: "<a href='../unconference/#sponsor-sessions'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Mintlify"
+    title: "<a href='../unconference/#sponsor-sessions-in-marthas'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Mintlify"
   - duration: '0:30'
     slug: what-i-learned-building-an-ai-documentation-auditor-and-what-it-found-in-500-p-rakesh-pasupuleti
   - duration: '0:05'

--- a/docs/_data/portland-2026-schedule.yaml
+++ b/docs/_data/portland-2026-schedule.yaml
@@ -67,7 +67,7 @@ talks_day1:
     title: "<a href='../unconference'>Unconference starts</a>"
   - time: '10:00'
     duration: '0:00'
-    title: "<a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Promptless"
+    title: "☕ <a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Promptless, with free handcrafted espresso"
   - duration: '0:30'
     slug: documentation-thinking-beyond-the-docs-lessons-from-decision-facing-technical-w-mary-elise-dedicke
   - duration: '0:05'
@@ -135,7 +135,7 @@ talks_day2:
     title: "<a href='../unconference'>Unconference starts</a>"
   - time: '10:00'
     duration: '0:00'
-    title: "<a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Mintlify"
+    title: "🍵 <a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Mintlify, with free handcrafted matcha"
   - duration: '0:30'
     slug: what-i-learned-building-an-ai-documentation-auditor-and-what-it-found-in-500-p-rakesh-pasupuleti
   - duration: '0:05'

--- a/docs/_data/portland-2026-schedule.yaml
+++ b/docs/_data/portland-2026-schedule.yaml
@@ -65,6 +65,9 @@ talks_day1:
     title: 5 minute break
   - duration: '0:00'
     title: "<a href='../unconference'>Unconference starts</a>"
+  - time: '10:00'
+    duration: '0:00'
+    title: "<a href='../unconference/#sponsor-sessions'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Promptless"
   - duration: '0:30'
     slug: documentation-thinking-beyond-the-docs-lessons-from-decision-facing-technical-w-mary-elise-dedicke
   - duration: '0:05'
@@ -130,6 +133,9 @@ talks_day2:
     title: 5 minute break
   - duration: '0:00'
     title: "<a href='../unconference'>Unconference starts</a>"
+  - time: '10:00'
+    duration: '0:00'
+    title: "<a href='../unconference/#sponsor-sessions'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Mintlify"
   - duration: '0:30'
     slug: what-i-learned-building-an-ai-documentation-auditor-and-what-it-found-in-500-p-rakesh-pasupuleti
   - duration: '0:05'

--- a/docs/_data/portland-2026-schedule.yaml
+++ b/docs/_data/portland-2026-schedule.yaml
@@ -67,7 +67,7 @@ talks_day1:
     title: "<a href='../unconference'>Unconference starts</a>"
   - time: '10:00'
     duration: '0:00'
-    title: "<a href='../unconference/#sponsor-sessions-in-marthas'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Promptless"
+    title: "<a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Promptless"
   - duration: '0:30'
     slug: documentation-thinking-beyond-the-docs-lessons-from-decision-facing-technical-w-mary-elise-dedicke
   - duration: '0:05'
@@ -135,7 +135,7 @@ talks_day2:
     title: "<a href='../unconference'>Unconference starts</a>"
   - time: '10:00'
     duration: '0:00'
-    title: "<a href='../unconference/#sponsor-sessions-in-marthas'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Mintlify"
+    title: "<a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Mintlify"
   - duration: '0:30'
     slug: what-i-learned-building-an-ai-documentation-auditor-and-what-it-found-in-500-p-rakesh-pasupuleti
   - duration: '0:05'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,6 +101,9 @@ extensions = [
 ]
 
 myst_heading_anchors = 4
+# Treat markdown links as plain URLs. Without this, myst tries to resolve
+# relative links like `../foo/#anchor` as cross-references and mangles them.
+myst_all_links_external = True
 
 
 ogp_site_name = "Write the Docs"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,9 +101,6 @@ extensions = [
 ]
 
 myst_heading_anchors = 4
-# Treat markdown links as plain URLs. Without this, myst tries to resolve
-# relative links like `../foo/#anchor` as cross-references and mangles them.
-myst_all_links_external = True
 
 
 ogp_site_name = "Write the Docs"

--- a/docs/conf/portland/2026/attendee-guide.md
+++ b/docs/conf/portland/2026/attendee-guide.md
@@ -33,6 +33,18 @@ View our [Venue page](/conf/{{shortcode}}/{{year}}/venue/) for details and the l
 
 We will provide a venue map onsite.
 
+## Attendee Lounge
+
+Take a break in the Attendee Lounge, a quiet wellness and recharging space with comfortable seating, charging stations, light snacks, and noise-canceling headphones on loan. Open throughout Monday and Tuesday.
+
+*The Attendee Lounge is sponsored by [{{ sponsors.keystone[1].brand }}]({{ sponsors.keystone[1].link }}).*
+
+## Professional Headshots
+
+Free professional headshots are available for all attendees at the headshot booth. Come grab a new photo for your LinkedIn or professional profile!
+
+*The headshot booth is sponsored by [{{ sponsors.keystone[1].brand }}]({{ sponsors.keystone[1].link }}).*
+
 ## Food and Drinks
 
 - Snacks, coffee, tea, and water are included with your ticket. Vegan, vegetarian, gluten-free, and dairy-free options will be offered. 

--- a/docs/conf/portland/2026/attendee-guide.md
+++ b/docs/conf/portland/2026/attendee-guide.md
@@ -37,13 +37,13 @@ We will provide a venue map onsite.
 
 Take a break in the Attendee Lounge, a quiet wellness and recharging space with comfortable seating, charging stations, light snacks, and noise-canceling headphones on loan. Open throughout Monday and Tuesday.
 
-*The Attendee Lounge is sponsored by [{{ sponsors.keystone[1].brand }}]({{ sponsors.keystone[1].link }}).*
+*The Attendee Lounge is sponsored by [Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral).*
 
 ## Professional Headshots
 
 Free professional headshots are available for all attendees at the headshot booth. Come grab a new photo for your LinkedIn or professional profile!
 
-*The headshot booth is sponsored by [{{ sponsors.keystone[1].brand }}]({{ sponsors.keystone[1].link }}).*
+*The headshot booth is sponsored by [Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral).*
 
 ## Food and Drinks
 

--- a/docs/conf/portland/2026/social-events.md
+++ b/docs/conf/portland/2026/social-events.md
@@ -22,6 +22,8 @@ and make sure you know your way around the conference venue.
 
 *Both alcoholic and non-alcoholic drinks and snacks will be provided.*
 
+*The Sunday Reception is sponsored by [{{ sponsors.keystone[1].brand }}]({{ sponsors.keystone[1].link }}).*
+
 ## Monday Night Social
 
 Join us for our Monday night social event! This is a great chance to meet more of your fellow documentarians 

--- a/docs/conf/portland/2026/social-events.md
+++ b/docs/conf/portland/2026/social-events.md
@@ -22,7 +22,7 @@ and make sure you know your way around the conference venue.
 
 *Both alcoholic and non-alcoholic drinks and snacks will be provided.*
 
-*The Sunday Reception is sponsored by [{{ sponsors.keystone[1].brand }}]({{ sponsors.keystone[1].link }}).*
+*The Sunday Reception is sponsored by [Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral).*
 
 ## Monday Night Social
 

--- a/docs/conf/portland/2026/unconference.md
+++ b/docs/conf/portland/2026/unconference.md
@@ -8,7 +8,7 @@ banner: _static/conf/images/headers/2026/unconference.jpg
 
 The Unconference consists of attendee-driven sessions that provide the opportunity for anyone who is attending the conference to lead, contribute, share ideas, and discuss problems in an organized setting away from the main stage talks. Many attendees consider this one of their favorite aspects of the conference.
 
-The Unconference is sponsored by **[Promptless](https://promptless.ai/?ref=writethedocs)** on Monday and **[Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral)** on Tuesday.
+The Unconference is sponsored by **[Promptless](https://promptless.ai/?ref=writethedocs)** on Monday and **[Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral)** on Tuesday. Stop by Martha's each morning from 10:00 AM to 12:00 PM for **free handcrafted espresso on Monday ☕** and **free handcrafted matcha on Tuesday 🍵**, plus sponsor-led discussions.
 
 **Who can lead an Unconference session?**
 
@@ -68,10 +68,10 @@ These ideas were borrowed from Scott Berkun. Read more of his [post on Unconfere
 
 ## Sponsor Sessions in Martha's
 
-Each morning from 10:00 AM to 12:00 PM, Martha's hosts a sponsor-led session alongside the rest of the unconference:
+Each morning from 10:00 AM to 12:00 PM, Martha's hosts a sponsor-led session alongside the rest of the unconference. Stop by for free handcrafted drinks and discussion:
 
-- **Monday:** Sponsor Session hosted by **[Promptless](https://promptless.ai/?ref=writethedocs)**
-- **Tuesday:** Sponsor Session hosted by **[Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral)**
+- **Monday ☕ — free espresso:** Sponsor Session hosted by **[Promptless](https://promptless.ai/?ref=writethedocs)**
+- **Tuesday 🍵 — free matcha:** Sponsor Session hosted by **[Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral)**
 
 **Enjoy the Unconference!**
 

--- a/docs/conf/portland/2026/unconference.md
+++ b/docs/conf/portland/2026/unconference.md
@@ -8,6 +8,8 @@ banner: _static/conf/images/headers/2026/unconference.jpg
 
 The Unconference consists of attendee-driven sessions that provide the opportunity for anyone who is attending the conference to lead, contribute, share ideas, and discuss problems in an organized setting away from the main stage talks. Many attendees consider this one of their favorite aspects of the conference.
 
+The Unconference is sponsored by **[{{ sponsors.keystone[0].brand }}]({{ sponsors.keystone[0].link }})** on Monday and **[{{ sponsors.keystone[1].brand }}]({{ sponsors.keystone[1].link }})** on Tuesday.
+
 **Who can lead an Unconference session?**
 
 Everyone! All attendees are invited to lead a session on a topic. Sessions can be organized around a presentation, group discussion or anything in between.
@@ -63,6 +65,13 @@ These ideas were borrowed from Scott Berkun. Read more of his [post on Unconfere
 - Find the table and have a seat. You can also join mid-session!
 - Listen or contribute to the discussion.
 - You're welcome to change sessions mid-slot! Please make sure you leave politely.
+
+## Sponsor Sessions
+
+On Monday and Tuesday mornings (10:00–12:00), Martha's will host a **Sponsor Session** led by one of our sponsors. These sessions follow the same interactive format as other Unconference sessions, but are led by a sponsor representative.
+
+- **Monday:** Hosted by **[{{ sponsors.keystone[0].brand }}]({{ sponsors.keystone[0].link }})**
+- **Tuesday:** Hosted by **[{{ sponsors.keystone[1].brand }}]({{ sponsors.keystone[1].link }})**
 
 **Enjoy the Unconference!**
 

--- a/docs/conf/portland/2026/unconference.md
+++ b/docs/conf/portland/2026/unconference.md
@@ -8,7 +8,7 @@ banner: _static/conf/images/headers/2026/unconference.jpg
 
 The Unconference consists of attendee-driven sessions that provide the opportunity for anyone who is attending the conference to lead, contribute, share ideas, and discuss problems in an organized setting away from the main stage talks. Many attendees consider this one of their favorite aspects of the conference.
 
-The Unconference is sponsored by **[{{ sponsors.keystone[0].brand }}]({{ sponsors.keystone[0].link }})** on Monday and **[{{ sponsors.keystone[1].brand }}]({{ sponsors.keystone[1].link }})** on Tuesday.
+The Unconference is sponsored by **[Promptless](https://promptless.ai/?ref=writethedocs)** on Monday and **[Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral)** on Tuesday.
 
 **Who can lead an Unconference session?**
 
@@ -70,8 +70,8 @@ These ideas were borrowed from Scott Berkun. Read more of his [post on Unconfere
 
 Each morning from 10:00 AM to 12:00 PM, Martha's hosts a sponsor-led session alongside the rest of the unconference:
 
-- **Monday:** Sponsor Session hosted by **[{{ sponsors.keystone[0].brand }}]({{ sponsors.keystone[0].link }})**
-- **Tuesday:** Sponsor Session hosted by **[{{ sponsors.keystone[1].brand }}]({{ sponsors.keystone[1].link }})**
+- **Monday:** Sponsor Session hosted by **[Promptless](https://promptless.ai/?ref=writethedocs)**
+- **Tuesday:** Sponsor Session hosted by **[Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral)**
 
 **Enjoy the Unconference!**
 

--- a/docs/conf/portland/2026/unconference.md
+++ b/docs/conf/portland/2026/unconference.md
@@ -66,12 +66,12 @@ These ideas were borrowed from Scott Berkun. Read more of his [post on Unconfere
 - Listen or contribute to the discussion.
 - You're welcome to change sessions mid-slot! Please make sure you leave politely.
 
-## Sponsor Sessions
+## Sponsor Sessions in Martha's
 
-On Monday and Tuesday mornings (10:00–12:00), Martha's will host a **Sponsor Session** led by one of our sponsors. These sessions follow the same interactive format as other Unconference sessions, but are led by a sponsor representative.
+Each morning from 10:00 AM to 12:00 PM, Martha's hosts a sponsor-led session alongside the rest of the unconference:
 
-- **Monday:** Hosted by **[{{ sponsors.keystone[0].brand }}]({{ sponsors.keystone[0].link }})**
-- **Tuesday:** Hosted by **[{{ sponsors.keystone[1].brand }}]({{ sponsors.keystone[1].link }})**
+- **Monday:** Sponsor Session hosted by **[{{ sponsors.keystone[0].brand }}]({{ sponsors.keystone[0].link }})**
+- **Tuesday:** Sponsor Session hosted by **[{{ sponsors.keystone[1].brand }}]({{ sponsors.keystone[1].link }})**
 
 **Enjoy the Unconference!**
 

--- a/docs/conf/portland/2026/venue.md
+++ b/docs/conf/portland/2026/venue.md
@@ -41,8 +41,8 @@ Bus transit stops are located near the venue. All transit in Portland announce m
 - Speaker Talks: Auditorium
 - Sponsor Expo: Hallway
 - Catering: Assembly Lounge
-- [Attendee Lounge](/conf/{{shortcode}}/{{year}}/attendee-guide/#attendee-lounge) and additional seating: Sunset Room
-- [Professional Headshot Booth](/conf/{{shortcode}}/{{year}}/attendee-guide/#professional-headshots): near the Sponsor Expo
+- <a href="../attendee-guide/#attendee-lounge">Attendee Lounge</a> and additional seating: Sunset Room
+- <a href="../attendee-guide/#professional-headshots">Professional Headshot Booth</a>: near the Sponsor Expo
 
 ### Other Venue Spaces (open to the public)
 

--- a/docs/conf/portland/2026/venue.md
+++ b/docs/conf/portland/2026/venue.md
@@ -41,8 +41,8 @@ Bus transit stops are located near the venue. All transit in Portland announce m
 - Speaker Talks: Auditorium
 - Sponsor Expo: Hallway
 - Catering: Assembly Lounge
-- [Attendee Lounge](../attendee-guide/#attendee-lounge) and additional seating: Sunset Room
-- [Professional Headshot Booth](../attendee-guide/#professional-headshots): near the Sponsor Expo
+- <a href="../attendee-guide/#attendee-lounge">Attendee Lounge</a> and additional seating: Sunset Room
+- <a href="../attendee-guide/#professional-headshots">Professional Headshot Booth</a>: near the Sponsor Expo
 
 ### Other Venue Spaces (open to the public)
 

--- a/docs/conf/portland/2026/venue.md
+++ b/docs/conf/portland/2026/venue.md
@@ -41,7 +41,8 @@ Bus transit stops are located near the venue. All transit in Portland announce m
 - Speaker Talks: Auditorium
 - Sponsor Expo: Hallway
 - Catering: Assembly Lounge
-- Lounge/additional seating: Sunset Room
+- [Attendee Lounge](/conf/{{shortcode}}/{{year}}/attendee-guide/#attendee-lounge) and additional seating: Sunset Room
+- [Professional Headshot Booth](/conf/{{shortcode}}/{{year}}/attendee-guide/#professional-headshots): near the Sponsor Expo
 
 ### Other Venue Spaces (open to the public)
 

--- a/docs/conf/portland/2026/venue.md
+++ b/docs/conf/portland/2026/venue.md
@@ -41,8 +41,8 @@ Bus transit stops are located near the venue. All transit in Portland announce m
 - Speaker Talks: Auditorium
 - Sponsor Expo: Hallway
 - Catering: Assembly Lounge
-- <a href="../attendee-guide/#attendee-lounge">Attendee Lounge</a> and additional seating: Sunset Room
-- <a href="../attendee-guide/#professional-headshots">Professional Headshot Booth</a>: near the Sponsor Expo
+- [Attendee Lounge](../attendee-guide/#attendee-lounge) and additional seating: Sunset Room
+- [Professional Headshot Booth](../attendee-guide/#professional-headshots): near the Sponsor Expo
 
 ### Other Venue Spaces (open to the public)
 


### PR DESCRIPTION
## Summary
- Add Promptless (Monday) and Mintlify (Tuesday) sponsor sessions to the schedule (10am-12pm in Marthas)
- Add unconference sponsorship note at the top of the unconference page
- Add Sponsor Sessions section to the unconference page with details and sponsor links via Jinja2 config variables

## Test plan
- [ ] Build site and verify schedule renders sponsor session entries on both days
- [ ] Verify unconference page shows sponsor names/links correctly from config data

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2624.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->