### PR TITLE
Enable myst_all_links_external to simplify cross-doc linking

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -101,6 +101,9 @@ extensions = [
 ]
 
 myst_heading_anchors = 4
+# Treat markdown links as plain URLs. Without this, myst tries to resolve
+# relative links like `../foo/#anchor` as cross-references and mangles them.
+myst_all_links_external = True
 
 
 ogp_site_name = "Write the Docs"

--- a/docs/conf/berlin/2026/cfp.md
+++ b/docs/conf/berlin/2026/cfp.md
@@ -115,7 +115,7 @@ Make sure you read this entire page before putting your proposal together, and p
 - **Spoilers** – It's pretty normal not to want to include your main point in your abstract, but please make sure to highlight it for the selection committee!
 - **Research** – We don't need all talks to be about an entirely new topic, but if you're suggesting a talk that looks really similar to one that was given last year, demonstrate that you realize this and mention why yours is different.
 - **Tooling** – We're pretty serious about preferring talks about people, process or principles than talks about tooling. If you are submitting a proposal about tooling, tell us what makes this one special.
-- **Example proposal** – Check out our [example proposal](example-proposal) so you know what we expect to see in each field.
+- **Example proposal** – Check out our [example proposal](../example-proposal/) so you know what we expect to see in each field.
 
 ## Unsure about speaking?
 
@@ -178,7 +178,7 @@ Folks start giving talks on stage!
 
 ## Example proposal
 
-Take a look at our [Example proposal](example-proposal), with additional guidance on the proposal format:
+Take a look at our [Example proposal](../example-proposal/), with additional guidance on the proposal format:
 
 ## Submit your proposal
 

--- a/docs/conf/berlin/2026/sponsors/index.md
+++ b/docs/conf/berlin/2026/sponsors/index.md
@@ -24,7 +24,7 @@ banner: _static/conf/images/headers/2026/sponsors.jpg
 # Sponsors
 
 We are seeking corporate partners to help us create the best conference possible.
-You can find more information in our [prospectus](prospectus).
+You can find more information in our [prospectus](./prospectus/).
 
 {% if conf_sponsors|trim %}
 

--- a/docs/conf/portland/2026/cfp.md
+++ b/docs/conf/portland/2026/cfp.md
@@ -109,7 +109,7 @@ Make sure you read this entire page before putting your proposal together, and p
 - **Spoilers** – It's pretty normal not to want to include your main point in your abstract, but please make sure to highlight it for the selection committee!
 - **Research** – We don't need all talks to be about an entirely new topic, but if you're suggesting a talk that looks really similar to one that was given last year, demonstrate that you realize this and mention why yours is different.
 - **Tooling** – We're pretty serious about preferring talks about people, process or principles than talks about tooling. If you are submitting a proposal about tooling, tell us what makes this one special.
-- **Example proposal** – Check out our [example proposal](example-proposal) so you know what we expect to see in each field.
+- **Example proposal** – Check out our [example proposal](../example-proposal/) so you know what we expect to see in each field.
 
 ## Unsure about speaking?
 
@@ -172,7 +172,7 @@ Folks start giving talks on stage!
 
 ## Example proposal
 
-Take a look at our [Example proposal](example-proposal), with additional guidance on the proposal format:
+Take a look at our [Example proposal](../example-proposal/), with additional guidance on the proposal format:
 
 ## Submit your proposal
 

--- a/docs/conf/portland/2026/sponsors/activations.md
+++ b/docs/conf/portland/2026/sponsors/activations.md
@@ -58,7 +58,7 @@ Sponsor branding for the Unconference track, which runs in parallel with speaker
 
 ## Sunday Welcome Reception Sponsorship
 
-Sponsor branding at the Sunday pre-conference Welcome Reception. Can be combined with a [Branded Food & Dessert Station](#branded-food--dessert-station) for additional presence and signage.
+Sponsor branding at the Sunday pre-conference Welcome Reception. Can be combined with a [Branded Food & Dessert Station](#branded-food-dessert-station) for additional presence and signage.
 
 - **Time:** 5:00–7:00 PM, Sunday
 - **Location:** Conference venue
@@ -76,7 +76,7 @@ Sponsor branding at the Sunday pre-conference Welcome Reception. Can be combined
 
 ## Monday Evening Social Sponsorship
 
-Sponsor branding at the Monday evening party, including branded bar menu and entrance signage. Can be combined with a [Branded Food & Dessert Station](#branded-food--dessert-station) for additional presence and signage.
+Sponsor branding at the Monday evening party, including branded bar menu and entrance signage. Can be combined with a [Branded Food & Dessert Station](#branded-food-dessert-station) for additional presence and signage.
 
 - **Time:** 7:00–9:00 PM, Monday
 - **Location:** Jupiter NEXT (900 E Burnside St, 2nd floor)

--- a/docs/conf/portland/2026/sponsors/index.md
+++ b/docs/conf/portland/2026/sponsors/index.md
@@ -24,7 +24,7 @@ banner: _static/conf/images/headers/2026/sponsors.jpg
 # Sponsors
 
 We are seeking corporate partners to help us create the best conference possible.
-You can find more information in our [prospectus](prospectus).
+You can find more information in our [prospectus](./prospectus/).
 
 {% if conf_sponsors|trim %}
 

--- a/docs/hiring-guide/freelancing/business-identity.md
+++ b/docs/hiring-guide/freelancing/business-identity.md
@@ -1,6 +1,6 @@
 # Business identity
 
-Your business identity is how you position yourself in the market, and your corporate personality. It should reflect your [core values](core-values.md), and underpin your [business plan](business-plan.md).
+Your business identity is how you position yourself in the market, and your corporate personality. It should reflect your [core values](../core-values/), and underpin your [business plan](../business-plan/).
 
 ## Consider
 
@@ -10,8 +10,8 @@ Your business identity is how you position yourself in the market, and your corp
 "I love the startup vibe."
 
 #### Related  
-[Core values > What sort of work do I want to do?](core-values.md#what-sort-of-work-do-i-want-to-do)
-[Core values > Where do I want to work?](core-values.md#where-do-i-want-to-work)
+[Core values > What sort of work do I want to do?](../core-values/#what-sort-of-work-do-i-want-to-do)
+[Core values > Where do I want to work?](../core-values/#where-do-i-want-to-work)
 
 ### How do I present myself to the world / what is the tone of my interaction with clients?
 
@@ -20,8 +20,8 @@ Your business identity is how you position yourself in the market, and your corp
 "I will adapt to each client's tone."
 
 #### Related
-[Core values > What sort of relationship do I want with my clients?](core-values.md#what-sort-of-relationship-do-i-want-with-my-clients)
-[Core values > How much of myself do I want in my work?](core-values.md#how-much-of-myself-do-i-want-in-my-work)
+[Core values > What sort of relationship do I want with my clients?](../core-values/#what-sort-of-relationship-do-i-want-with-my-clients)
+[Core values > How much of myself do I want in my work?](../core-values/#how-much-of-myself-do-i-want-in-my-work)
 
 ### What do I offer my client?
 
@@ -33,7 +33,7 @@ Think about your value proposition. Be specialized: the clearer you are about yo
 
 #### Related
 
-[Core values > What sort of work do I want to do?](core-values.md#what-sort-of-work-do-i-want-to-do)
+[Core values > What sort of work do I want to do?](../core-values/#what-sort-of-work-do-i-want-to-do)
 
 ### What tools do I specialize in?
 

--- a/docs/hiring-guide/freelancing/business-plan.md
+++ b/docs/hiring-guide/freelancing/business-plan.md
@@ -1,6 +1,6 @@
 # Business plan
 
-Your business plan is the practical implementation of the [values](core-values.md) and [identity](business-identity.md)
+Your business plan is the practical implementation of the [values](../core-values/) and [identity](../business-identity/)
 
 ## Consider
 
@@ -12,10 +12,10 @@ Your business plan is the practical implementation of the [values](core-values.m
 
 #### Related
 
-[Core values > What sort of work do I want to do?](core-values.md#what-sort-of-work-do-i-want-to-do)
-[Core values > Where do I want to work?](core-values.md#where-do-i-want-to-work)
-[Business identity > What type of clients do I want?](business-identity.md#what-type-of-clients-do-i-want)
-[Finding work](find-work.md)
+[Core values > What sort of work do I want to do?](../core-values/#what-sort-of-work-do-i-want-to-do)
+[Core values > Where do I want to work?](../core-values/#where-do-i-want-to-work)
+[Business identity > What type of clients do I want?](../business-identity/#what-type-of-clients-do-i-want)
+[Finding work](../find-work/)
 
 ### What are my rates?
 
@@ -28,7 +28,7 @@ A range of factors contribute to your rates:
 
 #### Related
 
-[Cost estimate](cost-estimate.md)
+[Cost estimate](../cost-estimate/)
 
 ### What is my marketing plan?
 
@@ -39,7 +39,7 @@ A range of factors contribute to your rates:
 
 #### Related
 
-[Business identity > What type of clients do I want?](business-identity.md#what-type-of-clients-do-i-want)
+[Business identity > What type of clients do I want?](../business-identity/#what-type-of-clients-do-i-want)
 
 ### Where do I want to be in *X* years?
 
@@ -50,8 +50,8 @@ A range of factors contribute to your rates:
 
 #### Related
 
-[Core values > Why do I want to freelance?](core-values.md#why-do-i-want-to-freelance)
-[Core values > What is my key motivator?](core-values.md#what-is-my-key-motivator)
+[Core values > Why do I want to freelance?](../core-values/#why-do-i-want-to-freelance)
+[Core values > What is my key motivator?](../core-values/#what-is-my-key-motivator)
 
 ## Template
 

--- a/docs/hiring-guide/freelancing/core-values.md
+++ b/docs/hiring-guide/freelancing/core-values.md
@@ -1,6 +1,6 @@
 # Core values and first thoughts
 
-Your core values are guiding principles for you and your business. They help focus your [business plan](business-plan.md), and inform your [business identity](business-identity.md). The questions on this page help you identify your core values and goals.
+Your core values are guiding principles for you and your business. They help focus your [business plan](../business-plan/), and inform your [business identity](../business-identity/). The questions on this page help you identify your core values and goals.
 
 ## Consider
 

--- a/docs/hiring-guide/freelancing/cost-estimate.md
+++ b/docs/hiring-guide/freelancing/cost-estimate.md
@@ -1,6 +1,6 @@
 # Cost estimate
 
-Provide a cost estimate to potential clients, based on the costs and rates considered in your [business plan](business-plan.md).
+Provide a cost estimate to potential clients, based on the costs and rates considered in your [business plan](../business-plan/).
 
 ## Consider
 


### PR DESCRIPTION
## Summary

Enable `myst_all_links_external = True` in [conf.py](docs/conf.py) so that myst-parser treats all markdown links as plain URLs instead of trying to resolve them as Sphinx cross-references.

## Why

myst-parser was mangling relative fragment links like `[text](../foo/#anchor)` by trying to resolve them as cross-references, failing, and emitting malformed `#/conf/...` hrefs. This setting makes myst treat markdown links as plain URLs, which is more predictable.

Side benefit: removes a pre-existing myst xref_missing warning on `tickets.md #official-conference-shirts` (an HTML div anchor that myst couldn't resolve).

## Trade-off

myst no longer auto-resolves bare labels or `.md` extensions to built URLs. A handful of links had to be rewritten as URL paths:

- `hiring-guide/freelancing/`: sibling `.md` refs rewritten to `../FILE/` form
- `conf/{portland,berlin}/2026/cfp.md`: `[example proposal](example-proposal)` to `../example-proposal/`
- `conf/{portland,berlin}/2026/sponsors/index.md`: `[prospectus](prospectus)` to `./prospectus/`

## Test plan
- [ ] Sphinx builds cleanly (verified locally, 11 warnings vs 12 on main)
- [ ] htmlproofer passes in CI (internal link check)
- [ ] Spot-check hiring-guide freelancing, CFP, and sponsors pages render links correctly

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2625.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->