### PR TITLE
Update devcontainer config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/python:1-3.12-bookworm
+
+# Remove broken yarn apt source whose GPG key is expired (devcontainers/images#1752)
+# Install Ruby for htmlproofer (link checking in CI and locally)
+RUN rm -f /etc/apt/sources.list.d/yarn.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+    ruby ruby-dev build-essential zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,23 @@
 {
-  "name": "Python and Ruby",
-	"image": "mcr.microsoft.com/devcontainers/python:1-3.12-bookworm",
-  "features": {
-    "ghcr.io/devcontainers/features/ruby:1": {
-      "version": "3.4.1"
-    }
+  "name": "Write the Docs",
+  "dockerComposeFile": ["docker-compose.yml", "docker-compose.local.yml"],
+  "service": "app",
+  "workspaceFolder": "/workspaces/www",
+  "initializeCommand": ".devcontainer/ensure-local-compose.sh",
+  "postCreateCommand": "pip3 install uv && uv sync && bundle install",
+  "forwardPorts": [8888],
+  "remoteEnv": {
+    "SSH_AUTH_SOCK": "${containerEnv:SSH_AUTH_SOCK}"
   },
-  "postCreateCommand": "pip3 install uv && uv sync && bundle install"
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-python.debugpy",
+        "kevinrose.vsc-python-indent",
+        "trond-snekvik.simple-rst"
+      ]
+    }
+  }
 }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,8 @@
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspaces/www:cached
+    command: sleep infinity

--- a/.devcontainer/ensure-local-compose.sh
+++ b/.devcontainer/ensure-local-compose.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Ensure a docker-compose.local.yml exists for the devcontainer.
+# Runs on the HOST before the container starts (initializeCommand).
+#
+# Priority:
+#   1. Already exists in .devcontainer/ — do nothing
+#   2. User has one at ~/.devcontainer/docker-compose.local.yml — symlink it
+#   3. Otherwise — create a no-op stub
+
+LOCAL=".devcontainer/docker-compose.local.yml"
+
+if [ -e "$LOCAL" ]; then
+    exit 0
+fi
+
+HOME_OVERRIDE="$HOME/.devcontainer/docker-compose.local.yml"
+if [ -f "$HOME_OVERRIDE" ]; then
+    ln -s "$HOME_OVERRIDE" "$LOCAL"
+    exit 0
+fi
+
+echo 'services: {}' > "$LOCAL"

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ docs/_scripts/mc-info.md
 *-cfp-reviews.csv
 *.code-workspace
 docs/_scripts/playlist.txt
+.devcontainer/docker-compose.local.yml


### PR DESCRIPTION
Updated to work with our current uv setup, and supports local overrides from ~/.devcontainer/docker-compose.local.yml.

I want to use more devcontainers for isolation, and this allows me to still attach it to my ssh key used for git, along with other local tweaks. It still allows local htmlproofer (#2285), the ruby isntall is a bit weird because of broken ruby images.

From the file history, I think nobody else is actively using this? If anyone is, we should make sure their workflow still works.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2626.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->