### PR TITLE
Make sponsorship ticket counts configurable per conference

### DIFF
--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -79,12 +79,16 @@ tickets:
 sponsorship:
   second_draft:
     price: €2,250
+    tickets: 2
   publisher:
     price: €4,000
+    tickets: 3
   patron:
     price: €6,000
+    tickets: 4
   keystone:
     price: €10,000
+    tickets: 6
 
 grants:
   url: ""

--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -79,12 +79,16 @@ tickets:
 sponsorship:
   second_draft:
     price: $3,000
+    tickets: 2
   publisher:
     price: $5,000
+    tickets: 4
   patron:
     price: $10,000
+    tickets: 6
   keystone:
     price: $15,000
+    tickets: 8
 
 grants:
   url: "https://docs.google.com/forms/d/e/1FAIpQLSctdb3MT_MvB1x_o8iKKhp_xik8YXDLVCnnDT_tv2k2LPlrJg/viewform?usp=dialog"

--- a/docs/_data/schema-config.yaml
+++ b/docs/_data/schema-config.yaml
@@ -112,6 +112,7 @@ price-type:
 price2:
   price: str(required=False)
   half: str(required=False)
+  tickets: int(required=False)
 
 date-details:
   main: str()

--- a/docs/conf/berlin/2026/sponsors/prospectus.md
+++ b/docs/conf/berlin/2026/sponsors/prospectus.md
@@ -68,7 +68,7 @@ The **Keystone** sponsorship highlights you as the primary sponsor of the confer
 
 #### Benefits
 
-- Eight (8) tickets, with additional available to purchase at a discounted rate of €300/ticket.
+- {{sponsorship.keystone.tickets}} tickets, with additional available to purchase at a discounted rate of €300/ticket.
 - Most visible **sponsorship booth** for the entire conference (Monday & Tuesday). Monitor included in booth. Booths placed in order of purchase.
 - Sponsorship of a primary Write the Docs conference event (Unconference, Writing Day, or Social Event).
 - **60 second introduction** on the main stage introducing your company.
@@ -90,7 +90,7 @@ The **Patron** package is great for a larger company to get in front of our atte
 
 #### Benefits
 
-- Six (6) tickets, with additional available to purchase at a discounted rate of €300/ticket.
+- {{sponsorship.patron.tickets}} tickets, with additional available to purchase at a discounted rate of €300/ticket.
 - A **sponsorship booth** for the entire conference (Monday & Tuesday). Monitor rental available for €300.
 - **30 second introduction** on the main stage introducing your company.
 - Dedicated social media post.
@@ -107,7 +107,7 @@ The **Publisher** package is great for a company looking to send some employees 
 
 #### Benefits
 
-- Four (4) tickets, with additional available to purchase at a discounted rate of €300/ticket.
+- {{sponsorship.publisher.tickets}} tickets, with additional available to purchase at a discounted rate of €300/ticket.
 - Logo included in intermission slides and on talk videos.
 - Dedicated social media post.
 - Logo and description (100 words) on the conference website.
@@ -122,7 +122,7 @@ The **Second Draft** package gives you visibility on the conference website and 
 
 #### Benefits
 
-- Two (2) tickets, with additional available to purchase at a discounted rate of €300/ticket.
+- {{sponsorship.second_draft.tickets}} tickets, with additional available to purchase at a discounted rate of €300/ticket.
 - Logo on the conference website.
 - Name included in all conference emails to attendees.
 - Display promotional (“Swag”) items on the conference swag table (provided by sponsor).

--- a/docs/conf/portland/2026/sponsors/prospectus.md
+++ b/docs/conf/portland/2026/sponsors/prospectus.md
@@ -66,7 +66,7 @@ The **Keystone** sponsorship highlights you as the primary sponsor of the confer
 
 #### Benefits
 
-- Eight (8) tickets, with additional available to purchase at a discounted rate of \$500/ticket.
+- {{sponsorship.keystone.tickets}} tickets, with additional available to purchase at a discounted rate of \$500/ticket.
 - Most visible **sponsorship booth** for the entire conference (Monday & Tuesday). Monitor included in booth. Booths placed in order of purchase.
 - Sponsorship of a primary Write the Docs conference event (Unconference, Writing Day, or Social Event).
 - **60 second introduction** on the main stage introducing your company.
@@ -86,7 +86,7 @@ The **Patron** package is great for a larger company to get in front of our atte
 
 #### Benefits
 
-- Six (6) tickets, with additional available to purchase at a discounted rate of \$500/ticket.
+- {{sponsorship.patron.tickets}} tickets, with additional available to purchase at a discounted rate of \$500/ticket.
 - A **sponsorship booth** for the entire conference (Monday & Tuesday). Monitor rental available for \$500.
 - **30 second introduction** on the main stage introducing your company.
 - Dedicated social media post.
@@ -103,7 +103,7 @@ The **Publisher** package is great for a company looking to send some employees 
 
 #### Benefits
 
-- Four (4) tickets, with additional available to purchase at a discounted rate of \$500/ticket.
+- {{sponsorship.publisher.tickets}} tickets, with additional available to purchase at a discounted rate of \$500/ticket.
 - Logo included in intermission slides and on talk videos.
 - Dedicated social media post.
 - Logo and description (100 words) on the conference website.
@@ -118,7 +118,7 @@ The **Second Draft** package gives you visibility on the conference website and 
 
 #### Benefits
 
-- Two (2) tickets, with additional available to purchase at a discounted rate of \$500/ticket.
+- {{sponsorship.second_draft.tickets}} tickets, with additional available to purchase at a discounted rate of \$500/ticket.
 - Logo on the conference website.
 - Name included in all conference emails to attendees.
 - Display promotional (“Swag”) items on the conference swag table (provided by sponsor).


### PR DESCRIPTION
## Summary
- Adds a `tickets` field to the sponsorship schema so each conference can set its own ticket allotment per tier
- Portland 2026 keeps its current counts: Keystone 8, Patron 6, Publisher 4, Second Draft 2
- Berlin 2026 gets smaller allotments at the higher tiers to match its lower price points: Keystone 6, Patron 4, Publisher 3, Second Draft 2
- Both prospectus pages now render the counts from config

## Test plan
- [ ] Build the site and verify the Portland and Berlin prospectus pages show the correct ticket counts
- [ ] Confirm YAML validation still passes

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2627.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->