### PR TITLE
Extract sponsorship cost variables into config

### DIFF
--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -89,6 +89,14 @@ sponsorship:
   keystone:
     price: €10,000
     tickets: 6
+  lightning_talks:
+    price: €4,000
+  opportunity_grants:
+    price: €2,000
+  extra_ticket:
+    price: €300
+  monitor_rental:
+    price: €300
 
 grants:
   url: ""

--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -89,6 +89,14 @@ sponsorship:
   keystone:
     price: $15,000
     tickets: 8
+  lightning_talks:
+    price: $3,500
+  opportunity_grants:
+    price: $2,000
+  extra_ticket:
+    price: $500
+  monitor_rental:
+    price: $500
 
 grants:
   url: "https://docs.google.com/forms/d/e/1FAIpQLSctdb3MT_MvB1x_o8iKKhp_xik8YXDLVCnnDT_tv2k2LPlrJg/viewform?usp=dialog"

--- a/docs/_data/schema-config.yaml
+++ b/docs/_data/schema-config.yaml
@@ -148,6 +148,10 @@ sponsorship-details:
   job_fair: include('price2', required=False)
   lanyard: include('price2', required=False)
   writing_day: include('price2', required=False)
+  lightning_talks: include('price2', required=False)
+  opportunity_grants: include('price2', required=False)
+  extra_ticket: include('price2', required=False)
+  monitor_rental: include('price2', required=False)
 
 sponsors-details:
   media: list(include('sponsor-detail'), required=False)

--- a/docs/conf/berlin/2026/sponsors/prospectus.md
+++ b/docs/conf/berlin/2026/sponsors/prospectus.md
@@ -68,7 +68,7 @@ The **Keystone** sponsorship highlights you as the primary sponsor of the confer
 
 #### Benefits
 
-- {{sponsorship.keystone.tickets}} tickets, with additional available to purchase at a discounted rate of €300/ticket.
+- {{sponsorship.keystone.tickets}} tickets, with additional available to purchase at a discounted rate of {{sponsorship.extra_ticket.price}}/ticket.
 - Most visible **sponsorship booth** for the entire conference (Monday & Tuesday). Monitor included in booth. Booths placed in order of purchase.
 - Sponsorship of a primary Write the Docs conference event (Unconference, Writing Day, or Social Event).
 - **60 second introduction** on the main stage introducing your company.
@@ -90,8 +90,8 @@ The **Patron** package is great for a larger company to get in front of our atte
 
 #### Benefits
 
-- {{sponsorship.patron.tickets}} tickets, with additional available to purchase at a discounted rate of €300/ticket.
-- A **sponsorship booth** for the entire conference (Monday & Tuesday). Monitor rental available for €300.
+- {{sponsorship.patron.tickets}} tickets, with additional available to purchase at a discounted rate of {{sponsorship.extra_ticket.price}}/ticket.
+- A **sponsorship booth** for the entire conference (Monday & Tuesday). Monitor rental available for {{sponsorship.monitor_rental.price}}.
 - **30 second introduction** on the main stage introducing your company.
 - Dedicated social media post.
 - Logo included in intermission slides and on talk videos.
@@ -107,7 +107,7 @@ The **Publisher** package is great for a company looking to send some employees 
 
 #### Benefits
 
-- {{sponsorship.publisher.tickets}} tickets, with additional available to purchase at a discounted rate of €300/ticket.
+- {{sponsorship.publisher.tickets}} tickets, with additional available to purchase at a discounted rate of {{sponsorship.extra_ticket.price}}/ticket.
 - Logo included in intermission slides and on talk videos.
 - Dedicated social media post.
 - Logo and description (100 words) on the conference website.
@@ -122,7 +122,7 @@ The **Second Draft** package gives you visibility on the conference website and 
 
 #### Benefits
 
-- {{sponsorship.second_draft.tickets}} tickets, with additional available to purchase at a discounted rate of €300/ticket.
+- {{sponsorship.second_draft.tickets}} tickets, with additional available to purchase at a discounted rate of {{sponsorship.extra_ticket.price}}/ticket.
 - Logo on the conference website.
 - Name included in all conference emails to attendees.
 - Display promotional (“Swag”) items on the conference swag table (provided by sponsor).
@@ -133,7 +133,7 @@ The following a la carte offerings are available either independently or combine
 
 ### Lightning Talks
 
-**€4,000** - **Limit 2**
+**{{sponsorship.lightning_talks.price}}** - **Limit 2**
 
 Sponsor one day of Lightning Talks, where attendees have 5 minutes to share something they are excited about working on. You will have 60 seconds at the start to introduce your company.
 
@@ -146,7 +146,7 @@ Sponsor one day of Lightning Talks, where attendees have 5 minutes to share some
 
 ### Opportunity Grants
 
-**€2,000** - **Limit 2**
+**{{sponsorship.opportunity_grants.price}}** - **Limit 2**
 
 Provide additional funding for our Opportunity Grant program, which supports equity and accessibility and provides funding for low-income, marginalized people to attend the conference. These individuals would otherwise not be able to attend.
 

--- a/docs/conf/portland/2026/sponsors/prospectus.md
+++ b/docs/conf/portland/2026/sponsors/prospectus.md
@@ -66,7 +66,7 @@ The **Keystone** sponsorship highlights you as the primary sponsor of the confer
 
 #### Benefits
 
-- {{sponsorship.keystone.tickets}} tickets, with additional available to purchase at a discounted rate of \$500/ticket.
+- {{sponsorship.keystone.tickets}} tickets, with additional available to purchase at a discounted rate of {{sponsorship.extra_ticket.price}}/ticket.
 - Most visible **sponsorship booth** for the entire conference (Monday & Tuesday). Monitor included in booth. Booths placed in order of purchase.
 - Sponsorship of a primary Write the Docs conference event (Unconference, Writing Day, or Social Event).
 - **60 second introduction** on the main stage introducing your company.
@@ -86,8 +86,8 @@ The **Patron** package is great for a larger company to get in front of our atte
 
 #### Benefits
 
-- {{sponsorship.patron.tickets}} tickets, with additional available to purchase at a discounted rate of \$500/ticket.
-- A **sponsorship booth** for the entire conference (Monday & Tuesday). Monitor rental available for \$500.
+- {{sponsorship.patron.tickets}} tickets, with additional available to purchase at a discounted rate of {{sponsorship.extra_ticket.price}}/ticket.
+- A **sponsorship booth** for the entire conference (Monday & Tuesday). Monitor rental available for {{sponsorship.monitor_rental.price}}.
 - **30 second introduction** on the main stage introducing your company.
 - Dedicated social media post.
 - Logo included in intermission slides and on talk videos.
@@ -103,7 +103,7 @@ The **Publisher** package is great for a company looking to send some employees 
 
 #### Benefits
 
-- {{sponsorship.publisher.tickets}} tickets, with additional available to purchase at a discounted rate of \$500/ticket.
+- {{sponsorship.publisher.tickets}} tickets, with additional available to purchase at a discounted rate of {{sponsorship.extra_ticket.price}}/ticket.
 - Logo included in intermission slides and on talk videos.
 - Dedicated social media post.
 - Logo and description (100 words) on the conference website.
@@ -118,7 +118,7 @@ The **Second Draft** package gives you visibility on the conference website and 
 
 #### Benefits
 
-- {{sponsorship.second_draft.tickets}} tickets, with additional available to purchase at a discounted rate of \$500/ticket.
+- {{sponsorship.second_draft.tickets}} tickets, with additional available to purchase at a discounted rate of {{sponsorship.extra_ticket.price}}/ticket.
 - Logo on the conference website.
 - Name included in all conference emails to attendees.
 - Display promotional (“Swag”) items on the conference swag table (provided by sponsor).
@@ -129,7 +129,7 @@ The following a la carte offerings are available either independently or combine
 
 ### Lightning Talks
 
-**\$3,500** - **Limit 2**
+**{{sponsorship.lightning_talks.price}}** - **Limit 2**
 
 Sponsor one day of Lightning Talks, where attendees have 5 minutes to share something they are excited about working on. You will have 60 seconds at the start to introduce your company.
 
@@ -142,7 +142,7 @@ Sponsor one day of Lightning Talks, where attendees have 5 minutes to share some
 
 ### Opportunity Grants
 
-**\$2,000** - **Limit 2**
+**{{sponsorship.opportunity_grants.price}}** - **Limit 2**
 
 Provide additional funding for our Opportunity Grant program, which supports equity and accessibility and provides funding for low-income, marginalized people to attend the conference. These individuals would otherwise not be able to attend.
 


### PR DESCRIPTION
## Summary
- Pulls the remaining hard-coded prices out of the Portland and Berlin 2026 prospectus pages so the prospectus copy can be shared safely across conferences
- New optional fields on `sponsorship-details`: `extra_ticket`, `monitor_rental`, `lightning_talks`, `opportunity_grants`
- Both prospectus pages now render these values from config — the only remaining diff between them is a smart-quote and a Keystone `{% if %}` guard

## Test plan
- [ ] Build the site and confirm prices render correctly on both Portland and Berlin prospectus pages
- [ ] YAML validation passes for both configs

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2628.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->