### PR TITLE
Lower Berlin 2026 a la carte sponsor prices

### DIFF
--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -90,9 +90,9 @@ sponsorship:
     price: €10,000
     tickets: 6
   lightning_talks:
-    price: €4,000
+    price: €2,500
   opportunity_grants:
-    price: €2,000
+    price: €1,500
   extra_ticket:
     price: €300
   monitor_rental:


### PR DESCRIPTION
## Summary
Berlin has half the attendees of Portland, so its a la carte sponsor prices should not exceed Portland's. Found two disparities:

- **Lightning Talks**: Berlin €4,000 → €2,500 (Portland is \$3,500 — Berlin was actually *higher*)
- **Opportunity Grants**: Berlin €2,000 → €1,500 (Portland is \$2,000 — was equal despite smaller conf)

Both now sit at roughly 70% of Portland's prices, matching the ratio used across the other sponsorship tiers (Patron 60%, Keystone 67%, Second Draft 75%, Publisher 80%).

Attendee ticket prices and package sponsorship tiers were already scaled appropriately — no other disparities found.

## Test plan
- [ ] YAML validation passes
- [ ] Rendered Berlin prospectus shows updated prices

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2631.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->