### PR TITLE
Fix per-conference CoC pages broken by heading rename in #2633

### DIFF
--- a/docs/conf/atlantic/2024/code-of-conduct.rst
+++ b/docs/conf/atlantic/2024/code-of-conduct.rst
@@ -1,7 +1,7 @@
 :template: {{year}}/generic.html
 
 .. include:: ../../../code-of-conduct.rst
-   :end-before: Portland conference Code of Conduct Team
+   :end-before: Portland Code of Conduct Team
 
 Atlantic conference Code of Conduct Team
 ----------------------------------------

--- a/docs/conf/australia/2024/code-of-conduct.rst
+++ b/docs/conf/australia/2024/code-of-conduct.rst
@@ -1,4 +1,4 @@
 :template: {{year}}/generic.html
 
 .. include:: ../../../code-of-conduct.rst
-   :end-before: Australia Code-of-Conduct Team
+   :end-before: Australia Code of Conduct Team

--- a/docs/conf/australia/2025/code-of-conduct.rst
+++ b/docs/conf/australia/2025/code-of-conduct.rst
@@ -1,4 +1,4 @@
 :template: {{year}}/generic.html
 
 .. include:: ../../../code-of-conduct.rst
-   :end-before: Australia Code-of-Conduct Team
+   :end-before: Australia Code of Conduct Team

--- a/docs/conf/berlin/2025/code-of-conduct.rst
+++ b/docs/conf/berlin/2025/code-of-conduct.rst
@@ -1,7 +1,7 @@
 :template: {{year}}/generic.html
 
 .. include:: ../../../code-of-conduct.rst
-   :end-before: Portland conference Code of Conduct Team
+   :end-before: Portland Code of Conduct Team
 
 Berlin conference Code of Conduct Team
 ---------------------------------------

--- a/docs/conf/berlin/2026/code-of-conduct.md
+++ b/docs/conf/berlin/2026/code-of-conduct.md
@@ -4,7 +4,7 @@ template: {{year}}/generic.html
 
 ```{eval-rst}
 .. include:: ../../../code-of-conduct.rst
-   :end-before: Berlin conference Code of Conduct Team
+   :end-before: Berlin Code of Conduct Team
 ```
 
 ```{eval-rst}

--- a/docs/conf/portland/2024/code-of-conduct.rst
+++ b/docs/conf/portland/2024/code-of-conduct.rst
@@ -1,4 +1,4 @@
 :template: {{year}}/generic.html
 
 .. include:: ../../../code-of-conduct.rst
-   :end-before: Portland conference Code of Conduct Team
+   :end-before: Portland Code of Conduct Team

--- a/docs/conf/portland/2025/code-of-conduct.rst
+++ b/docs/conf/portland/2025/code-of-conduct.rst
@@ -1,6 +1,6 @@
 :template: {{year}}/generic.html
 
 .. include:: ../../../code-of-conduct.rst
-   :end-before: Portland conference Code of Conduct Team
+   :end-before: Portland Code of Conduct Team
 
 .. include:: /include/conf/coc/na-coc.rst

--- a/docs/conf/portland/2026/code-of-conduct.md
+++ b/docs/conf/portland/2026/code-of-conduct.md
@@ -4,7 +4,7 @@ template: {{year}}/generic.html
 
 ```{eval-rst}
 .. include:: ../../../code-of-conduct.rst
-   :end-before: Portland conference Code of Conduct Team
+   :end-before: Portland Code of Conduct Team
 ```
 
 ```{eval-rst}


### PR DESCRIPTION
## Summary

PR #2633 renamed the team section headings in `docs/code-of-conduct.rst`:

- `Portland conference Code of Conduct Team` → `Portland Code of Conduct Team`
- `Berlin conference Code of Conduct Team` → `Berlin Code of Conduct Team`
- `Australia Code-of-Conduct Team` → `Australia Code of Conduct Team`

Eight per-conference CoC pages `.. include::` that file with `:end-before:` pointing at the old heading text. Sphinx now raises CRITICAL `Text not found` errors on every one of those pages, and the rendered CoC content is replaced by a system-message stub — so the conference CoC pages are effectively broken on the live site.

This PR updates the `:end-before:` markers to match the new heading text:

- `docs/conf/portland/{2024,2025,2026}/code-of-conduct.*`
- `docs/conf/berlin/{2025,2026}/code-of-conduct.*`
- `docs/conf/australia/{2024,2025}/code-of-conduct.rst`
- `docs/conf/atlantic/2024/code-of-conduct.rst`

## Why didn't CI catch this?

The Ubuntu Build job runs `make html` without `-W`, so docutils `CRITICAL` system messages from the `include` directive are emitted to stderr but don't fail the build — Sphinx exits 0 and publishes a page containing a `system_message` node in place of the included content. The `check_unparsed_markup.py` post-check only scans rendered HTML for literal directive syntax, which doesn't match the stub Sphinx emits here, so it passes too.

Worth considering as a follow-up: either run the build with `-W --keep-going` in CI, or extend `check_unparsed_markup.py` to flag `system_message` / `Problem with ... directive` text in the output.

## Test plan

- [x] Local `sphinx-build` — no more CRITICAL errors on the CoC pages
- [ ] CI build passes
- [ ] Spot-check a rendered conference CoC page (e.g. `/conf/portland/2026/code-of-conduct/`) to confirm the main CoC content renders above the Portland team section

https://claude.ai/code/session_014xQW73RQhCDgmV6xMq6ihZ

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2635.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->