### PR TITLE
Fix Portland 2026 first talk start time shifted by sponsor sessions

### DIFF
--- a/docs/_data/portland-2026-schedule.yaml
+++ b/docs/_data/portland-2026-schedule.yaml
@@ -65,15 +65,15 @@ talks_day1:
     title: 5 minute break
   - duration: '0:00'
     title: "<a href='../unconference'>Unconference starts</a>"
-  - time: '10:00'
-    duration: '0:00'
-    title: "☕ <a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Promptless"
-  - time: '9:30'
-    duration: '0:30'
+  - duration: '0:30'
     slug: documentation-thinking-beyond-the-docs-lessons-from-decision-facing-technical-w-mary-elise-dedicke
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
-  - duration: '0:10'
+  - time: '10:00'
+    duration: '0:00'
+    title: "☕ <a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Promptless"
+  - time: '10:05'
+    duration: '0:10'
     title: 10 minute break
   - duration: '0:30'
     slug: how-we-deprecated-500-articles-cleaning-up-documentation-at-scale-aileen-mary
@@ -134,15 +134,15 @@ talks_day2:
     title: 5 minute break
   - duration: '0:00'
     title: "<a href='../unconference'>Unconference starts</a>"
-  - time: '10:00'
-    duration: '0:00'
-    title: "🍵 <a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Mintlify"
-  - time: '9:30'
-    duration: '0:30'
+  - duration: '0:30'
     slug: what-i-learned-building-an-ai-documentation-auditor-and-what-it-found-in-500-p-rakesh-pasupuleti
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
-  - duration: '0:10'
+  - time: '10:00'
+    duration: '0:00'
+    title: "🍵 <a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Mintlify"
+  - time: '10:05'
+    duration: '0:10'
     title: 10 minute break
   - duration: '0:30'
     slug: the-invisible-work-what-it-takes-to-be-the-first-and-only-tech-writer-on-the-alina-desiatnikova

--- a/docs/_data/portland-2026-schedule.yaml
+++ b/docs/_data/portland-2026-schedule.yaml
@@ -68,7 +68,8 @@ talks_day1:
   - time: '10:00'
     duration: '0:00'
     title: "☕ <a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Promptless"
-  - duration: '0:30'
+  - time: '9:30'
+    duration: '0:30'
     slug: documentation-thinking-beyond-the-docs-lessons-from-decision-facing-technical-w-mary-elise-dedicke
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
@@ -136,7 +137,8 @@ talks_day2:
   - time: '10:00'
     duration: '0:00'
     title: "🍵 <a href='../unconference/#sponsor-sessions-in-martha-s'>Sponsor Session in Martha's (10am-12pm)</a> - hosted by Mintlify"
-  - duration: '0:30'
+  - time: '9:30'
+    duration: '0:30'
     slug: what-i-learned-building-an-ai-documentation-auditor-and-what-it-found-in-500-p-rakesh-pasupuleti
   - duration: '0:05'
     title: '✋ 5 minute Q&A'


### PR DESCRIPTION
The sponsor session entries added in #2624 include an explicit
time: '10:00', which the schedule renderer treats as a reset of
the time accumulator. This pushed the first talk on each day
from 9:30 to 10:00 (and every subsequent item by 30 minutes).

Restore the pre-#2624 9:30 start for the first talk on both days
by adding an explicit time override, letting the rest of the
schedule accumulate from 9:30 as it did before.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2637.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->