### PR TITLE
Add explicit start times to Portland 2026 schedule

### DIFF
--- a/docs/_data/portland-2026-schedule.yaml
+++ b/docs/_data/portland-2026-schedule.yaml
@@ -18,7 +18,8 @@ writing_day:
   - time: '8:00'
     duration: '1:00'
     title: Doors open
-  - duration: '0:30'
+  - time: '9:00'
+    duration: '0:30'
     title: Morning introduction - Introduction to Sprints & Project Introductions
   - duration: '0:00'
     title: 'Projects team up and start <a href="../writing-day">writing</a>'
@@ -39,7 +40,8 @@ writing_day:
     title: Projects team up and start writing
   - duration: '0:00'
     title: New to Git and GitHub workshop
-  - duration: '2:30'
+  - time: '14:00'
+    duration: '2:30'
     title: '<a href="../writing-day/#roundtable-discussions">Roundtable Discussions</a>'
   - time: '16:30'
     duration: '0:00'
@@ -47,7 +49,8 @@ writing_day:
   - time: '17:00'
     duration: '0:00'
     title: End of Writing Day
-  - duration: '2:00'
+  - time: '17:00'
+    duration: '2:00'
     title: '<a href="../social-events/#sunday-reception">Reception starts</a>'
   - duration: '0:00'
     title: Reception ends
@@ -65,7 +68,8 @@ talks_day1:
     title: 5 minute break
   - duration: '0:00'
     title: "<a href='../unconference'>Unconference starts</a>"
-  - duration: '0:30'
+  - time: '9:30'
+    duration: '0:30'
     slug: documentation-thinking-beyond-the-docs-lessons-from-decision-facing-technical-w-mary-elise-dedicke
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
@@ -75,7 +79,8 @@ talks_day1:
   - time: '10:05'
     duration: '0:10'
     title: 10 minute break
-  - duration: '0:30'
+  - time: '10:15'
+    duration: '0:30'
     slug: how-we-deprecated-500-articles-cleaning-up-documentation-at-scale-aileen-mary
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
@@ -83,11 +88,13 @@ talks_day1:
     title: '☕ 15 minute coffee break'
   - duration: '0:10'
     title: Sponsor introductions
-  - duration: '0:30'
+  - time: '11:15'
+    duration: '0:30'
     slug: the-git-commands-i-avoided-for-9-years-and-why-i-wish-i-hadn-t-sarah-deaton
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
-  - duration: '1:25'
+  - time: '11:50'
+    duration: '1:25'
     title: '🍽️ Lunch Break (85 mins)'
   - time: '13:30'
     duration: '0:00'
@@ -97,25 +104,29 @@ talks_day1:
     title: '<a href="../lightning-talks">Lightning Talks</a> (35 mins)'
   - duration: '0:10'
     title: 10 minute break
-  - duration: '0:30'
+  - time: '14:30'
+    duration: '0:30'
     slug: the-most-human-documentation-christian-miles
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
   - duration: '0:10'
     title: 10 minute break
-  - duration: '0:30'
+  - time: '15:15'
+    duration: '0:30'
     slug: pillars-that-hold-structuring-documentation-around-user-progress-annie-zempel
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
   - duration: '0:15'
     title: '☕ 15 minute snack break'
-  - duration: '0:30'
+  - time: '16:05'
+    duration: '0:30'
     slug: how-to-win-docs-and-influence-robots-improving-robot-accuracy-through-better-do-sarah-lin
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
   - duration: '0:10'
     title: 10 minute break
-  - duration: '0:30'
+  - time: '16:50'
+    duration: '0:30'
     slug: chat-are-we-cooked-help-in-the-moment-designing-policy-documentation-for-hi-darlene-chanimaya-postma
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
@@ -138,7 +149,8 @@ talks_day2:
     title: 5 minute break
   - duration: '0:00'
     title: "<a href='../unconference'>Unconference starts</a>"
-  - duration: '0:30'
+  - time: '9:30'
+    duration: '0:30'
     slug: what-i-learned-building-an-ai-documentation-auditor-and-what-it-found-in-500-p-rakesh-pasupuleti
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
@@ -148,7 +160,8 @@ talks_day2:
   - time: '10:05'
     duration: '0:10'
     title: 10 minute break
-  - duration: '0:30'
+  - time: '10:15'
+    duration: '0:30'
     slug: the-invisible-work-what-it-takes-to-be-the-first-and-only-tech-writer-on-the-alina-desiatnikova
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
@@ -156,33 +169,40 @@ talks_day2:
     title: '☕ 15 minute coffee break'
   - duration: '0:10'
     title: Meetup announcement (TBD)
-  - duration: '0:30'
+  - time: '11:15'
+    duration: '0:30'
     slug: you-don-t-need-more-new-contributors-you-need-onboarding-that-actually-works-busayo-ojo
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
-  - duration: '1:25'
+  - time: '11:50'
+    duration: '1:25'
     title: '🍽️ Lunch Break (85 mins)'
-  - duration: '0:35'
+  - time: '13:15'
+    duration: '0:35'
     title: '<a href="../lightning-talks">Lightning Talks</a> (35 mins)'
   - duration: '0:10'
     title: 10 minute break
-  - duration: '0:30'
+  - time: '14:00'
+    duration: '0:30'
     slug: what-the-data-shows-when-docs-meet-llms-and-why-i-m-excited-for-the-future-ethan-palm
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
   - duration: '0:10'
     title: 10 minute break
-  - duration: '0:30'
+  - time: '14:45'
+    duration: '0:30'
     slug: drops-of-jupyter-an-exploration-of-the-notebook-ecosystem-adam-michael-wood
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
   - duration: '0:15'
     title: '☕ 15 minute snack break'
-  - duration: '0:30'
+  - time: '15:35'
+    duration: '0:30'
     slug: writing-the-docs-when-the-protocol-is-the-product-alex-garnett
   - duration: '0:05'
     title: '✋ 5 minute Q&A'
-  - duration: '0:15'
+  - time: '16:10'
+    duration: '0:15'
     title: Write the Docs team - Conference closing
   - duration: '0:00'
     title: '<b>Conference ends 😔</b>'


### PR DESCRIPTION
## Summary

- Add explicit `time` values to all talks, lunch breaks, lightning talks, roundtable discussions, reception, and conference closing in the Portland 2026 schedule
- Prevents cascading time bugs when an upstream duration is adjusted — major events are now pinned to their intended start times
- Short breaks, Q&A, and zero-duration markers remain relative since they naturally flow between pinned events

## Test plan

- [ ] Verify `uv run make html` builds without errors
- [ ] Verify schedule page renders with correct times for all events
- [ ] Verify YAML validation passes (`yamale -s docs/_data/schema-schedule.yaml docs/_data/portland-2026-schedule.yaml`)

https://claude.ai/code/session_01YRAWfBR3SELJnWEaSCfHkY

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2641.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->