### PR TITLE
conf: fix missing document title in 2026 index pages

### DIFF
--- a/docs/_templates/2026/index.html
+++ b/docs/_templates/2026/index.html
@@ -7,7 +7,8 @@ Home - Write the Docs {{ name }} {{ year }}
 {% block head_link %}
 <style>
 /* Don't show headers */
-.page-content h1 {
+.page-content h1,
+section > h1 {
     display: none;
 }
 </style>

--- a/docs/conf/berlin/2026/index.md
+++ b/docs/conf/berlin/2026/index.md
@@ -2,8 +2,9 @@
 template: 2026/index.html
 banner: _static/conf/images/headers/berlin-2026-small-group.jpg
 og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
-title: Home | Write the Docs Berlin 2026
 ---
+
+# Home | Write the Docs Berlin 2026
 
 <div class="news-block">
 <div class="uk-container">

--- a/docs/conf/berlin/2026/index.md
+++ b/docs/conf/berlin/2026/index.md
@@ -4,7 +4,7 @@ banner: _static/conf/images/headers/berlin-2026-small-group.jpg
 og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
 ---
 
-# Home | Write the Docs Berlin 2026
+# Home | Write the Docs {{ name }} {{ year }}
 
 <div class="news-block">
 <div class="uk-container">

--- a/docs/conf/portland/2026/index.md
+++ b/docs/conf/portland/2026/index.md
@@ -4,7 +4,7 @@ banner: _static/conf/images/headers/portland-2026-small-group.jpg
 og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
 ---
 
-# Home | Write the Docs Portland 2026
+# Home | Write the Docs {{ name }} {{ year }}
 
 <div class="news-block">
 <div class="uk-container">

--- a/docs/conf/portland/2026/index.md
+++ b/docs/conf/portland/2026/index.md
@@ -2,8 +2,9 @@
 template: 2026/index.html
 banner: _static/conf/images/headers/portland-2026-small-group.jpg
 og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
-title: Home | Write the docs Portland 2026
 ---
+
+# Home | Write the Docs Portland 2026
 
 <div class="news-block">
 <div class="uk-container">


### PR DESCRIPTION
Frontmatter 'title:' was not picked up as document title, causing
og:title to render as '<no title>'. Replace with H1 heading and
hide it via CSS in the index template.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2643.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->