### PR TITLE
Update Slido event ID for Portland 2026 Q&A

### DIFF
--- a/docs/conf/portland/2026/qa.md
+++ b/docs/conf/portland/2026/qa.md
@@ -8,8 +8,8 @@ banner: _static/conf/images/headers/2026/qa.jpg
 
 This page allows you to ask questions of our speakers, and to vote on questions that you would like to see answered. Refresh this page on the day of the conference talks to see them!
 
- <iframe src="https://app.sli.do/event/pheuiBqUcsduHbivhQgBQV" height="100%" width="100%" frameBorder="0" style="min-height: 560px;" allow="clipboard-write" title="Slido"></iframe>
+ <iframe src="https://app.sli.do/event/a2qmjbDYGqei5UxQQpy554" height="100%" width="100%" frameBorder="0" style="min-height: 560px;" allow="clipboard-write" title="Slido"></iframe>
 
-You can also use this link: <https://app.sli.do/event/pheuiBqUcsduHbivhQgBQV>
+You can also use this link: <https://app.sli.do/event/a2qmjbDYGqei5UxQQpy554>
 
 If you experience technical issues, please report them in the \#wtd-conferences channel on Slack.


### PR DESCRIPTION
## Summary
Updates the Slido event ID for the Portland 2026 conference Q&A page to use the correct event link.

## Changes
- Updated the Slido iframe `src` attribute from `pheuiBqUcsduHbivhQgBQV` to `a2qmjbDYGqei5UxQQpy554`
- Updated the alternative Slido link in the documentation to match the new event ID

## Details
This change ensures that conference attendees will be directed to the correct Slido Q&A event for the Portland 2026 Write the Docs conference talks.

https://claude.ai/code/session_019Z1WAeiZLkEqwrPWrUKmSw

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2645.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->