### PR TITLE
sponsors: suggest FedEx pickup for swag returns

### DIFF
--- a/docs/conf/berlin/2026/sponsors/information.md
+++ b/docs/conf/berlin/2026/sponsors/information.md
@@ -109,5 +109,6 @@ You should have received a unique URL with a discount code for your sponsorship 
 * Please contact us for shipping details, as the venue doesn't accept packages directly.
 * Sponsors are responsible for all sponsorship materials after they arrive at the venue. 
 * Sponsors are responsible for mailing all materials after the conference.
+* We suggest scheduling a FedEx pickup for your return shipment so your materials can be collected directly from the venue.
 
 If you have any further questions, reach out to Eric Holscher or <sponsorship@writethedocs.org>.

--- a/docs/conf/berlin/2026/sponsors/information.md
+++ b/docs/conf/berlin/2026/sponsors/information.md
@@ -109,6 +109,5 @@ You should have received a unique URL with a discount code for your sponsorship 
 * Please contact us for shipping details, as the venue doesn't accept packages directly.
 * Sponsors are responsible for all sponsorship materials after they arrive at the venue. 
 * Sponsors are responsible for mailing all materials after the conference.
-* We suggest scheduling a FedEx pickup for your return shipment so your materials can be collected directly from the venue.
 
 If you have any further questions, reach out to Eric Holscher or <sponsorship@writethedocs.org>.

--- a/docs/conf/portland/2026/sponsors/information.md
+++ b/docs/conf/portland/2026/sponsors/information.md
@@ -142,6 +142,7 @@ You should have received a unique URL with a discount code for your sponsorship 
 * Sponsors are responsible for all sponsorship materials after they arrive at the venue. 
 * Sponsors are responsible for mailing all materials after the conference. 
 * Please print your return shipping labels prior to coming to the venue to send your materials back.
+* We suggest scheduling a FedEx pickup for your return shipment so your materials can be collected directly from the venue.
 * **All materials must be out of the venue by 5:30pm on {{ date.day_four.dotw }}.**
 
 If you have any further questions, reach out to Eric Holscher or <sponsorship@writethedocs.org>.


### PR DESCRIPTION
## Summary

- Adds a note to the Portland 2026 sponsor information page suggesting sponsors schedule a FedEx pickup for their return shipment.
- Gives sponsors a simple, venue-friendly option for getting leftover swag and booth materials back home.

## Test plan

- [ ] Build the site locally and verify the new bullet renders under "How should I send my booth materials?" on the Portland 2026 sponsor information page.

---

_This PR was generated by AI._