### PR TITLE
sponsors: Update sponsor info schedule and add venue accessibility section

### DIFF
--- a/docs/conf/portland/2026/venue.md
+++ b/docs/conf/portland/2026/venue.md
@@ -44,6 +44,12 @@ Bus transit stops are located near the venue. All transit in Portland announce m
 - <a href="../attendee-guide/#attendee-lounge">Attendee Lounge</a> and additional seating: Sunset Room
 - <a href="../attendee-guide/#professional-headshots">Professional Headshot Booth</a>: near the Sponsor Expo
 
+## Accessibility
+
+The venue is fully step-free and wheelchair accessible. Elevator access is available to the 2nd and 3rd floors. There are two ADA parking spots in the guest parking lot south of the venue.
+
+For full details on accessibility accommodations, see the [Accessibility section of our Attendee Guide](/conf/{{shortcode}}/{{year}}/attendee-guide/#accessibility).
+
 ### Other Venue Spaces (open to the public)
 
 - Show Bar: 5-11 PM


### PR DESCRIPTION
## Summary

- Fix Day 2 schedule times on sponsor info page to match rendered conference schedule (9:20am-4:25pm)
- Update booth specs by sponsor tier (Keystone: 8-foot table + monitor, Patron: 6-foot table)
- Add accessibility section to venue page with key details and link to attendee guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2653.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->