### PR TITLE
portland: Add unconference schedule URL

### DIFF
--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -176,7 +176,7 @@ cfp:
   preview: "https://writethedocs-www--2552.org.readthedocs.build/conf/portland/2026/schedule/"
 
 unconf:
-  url: ""
+  url: "https://docs.google.com/spreadsheets/d/1eHLcr2C8om67M9qfYJHKg0MRxdwZYijqvsboeIRX3Fc/edit?gid=1637667081#gid=1637667081"
   date: "All day, Monday, May 4 and Tuesday, May 5"
 
 writing_day:

--- a/docs/conf/portland/2026/unconference.md
+++ b/docs/conf/portland/2026/unconference.md
@@ -37,10 +37,10 @@ Martha's will be open to attendee sessions in the afternoon, along with the
 
 ### Scheduling a Session
 
-- Sign up online one week prior to the conference (Monday morning sessions only).
+- [Sign up online]({{ unconf.url }}) one week prior to the conference (Monday morning sessions only).
 - Sign up for all sessions in-person anytime during the conference, Sunday through Tuesday.
 - During the conference, write the title and your name on a sticky note. Select a time slot and table number and place the note on the large schedule.
-- The online schedule will be available to view only during the conference. This will be updated regularly.
+- The [online schedule]({{ unconf.url }}) will be updated regularly during the conference.
 
 Exact times to be posted on our [Schedule](/conf/{{shortcode}}/{{year}}/schedule) page.
 
@@ -71,7 +71,7 @@ These ideas were borrowed from Scott Berkun. Read more of his [post on Unconfere
 
 ## Attending a Session
 
-- View the Session Schedule. This will be posted online and in the Unconference room during the conference only.
+- View the [Session Schedule]({{ unconf.url }}). This will be posted online and in the Unconference room during the conference.
 - Find the table and have a seat. You can also join mid-session!
 - Listen or contribute to the discussion.
 - You're welcome to change sessions mid-slot! Please make sure you leave politely.


### PR DESCRIPTION
## Summary

- Add Google Sheets unconference schedule URL to config
- Link it on the unconference page for online signup and viewing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2656.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->