### PR TITLE
portland: Fix pre-conf TBDs for food carts, urban walk, and unconference

### DIFF
--- a/docs/conf/portland/2026/attendee-guide.md
+++ b/docs/conf/portland/2026/attendee-guide.md
@@ -49,8 +49,9 @@ Free professional headshots are available for all attendees at the headshot boot
 
 - Snacks, coffee, tea, and water are included with your ticket. Vegan, vegetarian, gluten-free, and dairy-free options will be offered. 
 - Bring a water bottle as there are refill stations located around the venue.
-- We'll provide three food carts for Monday and Tuesday lunches from 11:30 AM-2:00 PM. This is a great option for folks who want to stay onsite.
-  - Food Carts TBD
+- Two food carts will be on site for Monday and Tuesday lunches from 11:30 AM-2:00 PM:
+  - Let's Roll
+  - Nacho's House
 - There are many food and beverage options within 0.5 miles (0.8 km) around the conference venue. Explore {{city}}’s amazing food scene on the [Visiting {{city}} page](/conf/{{shortcode}}/{{year}}/visiting/).
   
 ## Dress Code

--- a/docs/conf/portland/2026/hike.md
+++ b/docs/conf/portland/2026/hike.md
@@ -43,7 +43,7 @@ The walk from the Rose Garden to Powell's is 1.5 miles long and has 400 feet of 
   - 4:00-5:00 PM: Explore Powell's 
   - 5:00 PM: Meet back up for those who want to take public transportation, rideshare, or walk back to the Rose Garden together. 
 - **Lunch (optional):** You're welcome to join us at [Nob Hill food carts](https://www.google.com/maps/place/Nob+Hill+Food+Carts/@45.5360531,-122.7007924,19.6z/data=!4m7!3m6!1s0x54950942eb34ca71:0xe277fed8c0cec152!8m2!3d45.5362156!4d-122.7000932!15sChZmb29kIGNhcnRzIG53IHBvcnRsYW5kkgEKZm9vZF9jb3VydOABAA!16s%2Fg%2F11vwhg4f9_?entry=tts) at 12:30pm for lunch. We'll leave at 1:30pm and walk 1.4 miles to the Rose Garden.
-- **Start:** [International Rose Test Garden](https://google.com/maps/place/International+Rose+Test+Garden/data=!4m2!3m1!1s0x0:0x91fbfe94968fdfc6?sa=X&ved=1t:2428&ictx=111), exact location TBD
+- **Start:** Meet at the patio by the [Rose Garden Store](https://maps.app.goo.gl/qcCUVUDJFpYMqsKq6). Parking is available near the tennis courts and along SW Sherwood Blvd ($2.40/hr, pay at the stations or via the Parking Kitty app).
 - **End:** [Powell's Books](https://www.google.com/maps/search/Powell's+Books/@45.518945,-122.7438128,13z?entry=ttu&g_ep=EgoyMDI2MDIyMy4wIKXMDSoASAFQAw%3D%3D]), where you're welcome to browse on your own or walk around with another attendee.
 
 ## What to Bring

--- a/docs/conf/portland/2026/unconference.md
+++ b/docs/conf/portland/2026/unconference.md
@@ -33,7 +33,7 @@ Stop by Martha's each morning from 10:00 AM to 12:00 PM for **free handcrafted e
 - **Monday ☕ — free espresso:** Sponsor Session hosted by **[Promptless](https://promptless.ai/?ref=writethedocs)**
 - **Tuesday 🍵 — free matcha:** Sponsor Session hosted by **[Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral)**
 
-Martha's will be open to attendee sessions in the afternoon, along with the 
+Martha's will be open to attendee sessions in the afternoon, along with the Library and Astoria rooms.
 
 ### Scheduling a Session
 

--- a/docs/conf/portland/2026/visiting.md
+++ b/docs/conf/portland/2026/visiting.md
@@ -59,7 +59,8 @@ Lunch and dinners are on your own and an opportunity to connect with attendees. 
 
 **Lunch only (Monday and Tuesday 11:30am-2pm)**
 
-- Food carts TBD
+- Let's Roll
+- Nacho's House
 
 ### Food and Drinks near Revolution Hall (within a 10-minute walk)
 


### PR DESCRIPTION
## Summary

- Add food cart names (Let's Roll, Nacho's House) to attendee guide and visiting page
- Add urban walk meeting location (Rose Garden Store patio) with parking details
- Fix truncated sentence on unconference page about afternoon session rooms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2657.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->