### PR TITLE
portland-2026: small copy fixes (livestream link, convince-your-manager bullets)

### DIFF
--- a/docs/conf/portland/2026/convince-your-manager.md
+++ b/docs/conf/portland/2026/convince-your-manager.md
@@ -49,7 +49,7 @@ When discussing how to pitch the conference, a few generally helpful tips emerge
 - Establishes your team's reputation for caring about their docs.
 - Share info about previous conferences. View the [main page overview](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/) explaining Write the Docs, history, and schedule overview.
 
-## Sample Email # 2
+## Sample Email #2
 
 ### Convince your manager or community to participate in Writing Day
 
@@ -77,8 +77,8 @@ Remember to change the things in [brackets]!
 - *Get highlighted as a project in the conference blog and announcements (must submit online by {{ writing_day.project_deadline }})*
 - *Onboard documentation enthusiasts to increase the likelihood of post-conference contributions*
 - *Strategically tackle documentation tickets and requests*
-- *Update existing documentation
-Peer review new and existing documentation*
+- *Update existing documentation*
+- *Peer review new and existing documentation*
 
 *Conference Benefits:*
 

--- a/docs/conf/portland/2026/livestream.md
+++ b/docs/conf/portland/2026/livestream.md
@@ -8,6 +8,6 @@ The livestream page will be updated with the live stream link shortly before the
 Refresh the page on the day of the conference talks to see them!
 
 You do **not** need a ticket to watch the live stream,
-however we do provide a [livestream ticket](https://ti.to/writethedocs/write-the-docs-portland-2024/with/livestream-ticket) without a set price if you want to give back.
+however we do provide a [livestream ticket](https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}/with/livestream-ticket) without a set price if you want to give back.
 
 If you experience technical issues, please report them in the #wtd-conferences channel on Slack.


### PR DESCRIPTION
Two small copy fixes spotted while reviewing 2026 pages:

- **`livestream.md:11`** — ticket URL hardcoded to `portland-2024`; switched to `{{shortcode}}-{{year}}` so it auto-tracks the year. Note: assumes the 2026 ti.to event has a `livestream-ticket` slot — please verify on preview.
- **`convince-your-manager.md:52`** — heading inconsistency: `## Sample Email # 2` → `## Sample Email #2` (matches `## Sample Email #1` on line 11).
- **`convince-your-manager.md:80-81`** — `Update existing documentation` and `Peer review new and existing documentation` were merged into one bullet by a missing line break and dash; split into two bullets.

🤖 Generated by Claude Code.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2658.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->