### PR TITLE
conf: credit Promptless as Monday Night Social sponsor

### DIFF
--- a/docs/conf/portland/2026/social-events.md
+++ b/docs/conf/portland/2026/social-events.md
@@ -33,3 +33,5 @@ and chat about the conference in a relaxed atmosphere.
 **When**: 7-9 PM
 
 *Both alcoholic and non-alcoholic drinks and snacks will be provided.*
+
+*The Monday Night Social is sponsored by [Promptless](https://promptless.ai/?ref=writethedocs).*


### PR DESCRIPTION
Adds a sponsor credit line for Promptless under the Monday Night Social on the Portland 2026 social events page, mirroring the existing Sunday Reception pattern.

---
_This PR was generated by AI._

---
_Generated by [Claude Code](https://claude.ai/code/session_01SKkev9369Adr6o17oQSyek)_

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2661.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->