### PR TITLE
conf: sponsor logos and credits on primary events

### DIFF
--- a/docs/conf/portland/2026/attendee-guide.md
+++ b/docs/conf/portland/2026/attendee-guide.md
@@ -37,19 +37,11 @@ We will provide a venue map onsite.
 
 Take a break in the Attendee Lounge, a quiet wellness and recharging space with comfortable seating, charging stations, light snacks, and noise-canceling headphones on loan. Open throughout Monday and Tuesday.
 
-<p style="text-align: center; margin-top: 1.5em;">
-<a href="https://mintlify.com/?utm_source=writethedocs&utm_medium=referral"><img src="/_static/img/sponsors/mintlify.png" alt="Mintlify" style="max-width: 250px;"></a>
-</p>
-
 *The Attendee Lounge is sponsored by [Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral).*
 
 ## Professional Headshots
 
 Free professional headshots are available for all attendees at the headshot booth. Come grab a new photo for your LinkedIn or professional profile! A professional photographer will be onsite — no appointment needed, just stop by. Check the [schedule](/conf/{{shortcode}}/{{year}}/schedule/) for times.
-
-<p style="text-align: center; margin-top: 1.5em;">
-<a href="https://mintlify.com/?utm_source=writethedocs&utm_medium=referral"><img src="/_static/img/sponsors/mintlify.png" alt="Mintlify" style="max-width: 250px;"></a>
-</p>
 
 *The headshot booth is sponsored by [Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral).*
 

--- a/docs/conf/portland/2026/attendee-guide.md
+++ b/docs/conf/portland/2026/attendee-guide.md
@@ -37,11 +37,19 @@ We will provide a venue map onsite.
 
 Take a break in the Attendee Lounge, a quiet wellness and recharging space with comfortable seating, charging stations, light snacks, and noise-canceling headphones on loan. Open throughout Monday and Tuesday.
 
+<p style="text-align: center; margin-top: 1.5em;">
+<a href="https://mintlify.com/?utm_source=writethedocs&utm_medium=referral"><img src="/_static/img/sponsors/mintlify.png" alt="Mintlify" style="max-width: 250px;"></a>
+</p>
+
 *The Attendee Lounge is sponsored by [Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral).*
 
 ## Professional Headshots
 
 Free professional headshots are available for all attendees at the headshot booth. Come grab a new photo for your LinkedIn or professional profile! A professional photographer will be onsite — no appointment needed, just stop by. Check the [schedule](/conf/{{shortcode}}/{{year}}/schedule/) for times.
+
+<p style="text-align: center; margin-top: 1.5em;">
+<a href="https://mintlify.com/?utm_source=writethedocs&utm_medium=referral"><img src="/_static/img/sponsors/mintlify.png" alt="Mintlify" style="max-width: 250px;"></a>
+</p>
 
 *The headshot booth is sponsored by [Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral).*
 

--- a/docs/conf/portland/2026/social-events.md
+++ b/docs/conf/portland/2026/social-events.md
@@ -23,7 +23,7 @@ and make sure you know your way around the conference venue.
 *Both alcoholic and non-alcoholic drinks and snacks will be provided.*
 
 <p style="text-align: center; margin-top: 1.5em;">
-<a href="https://mintlify.com/?utm_source=writethedocs&utm_medium=referral"><img src="/_static/img/sponsors/mintlify.png" alt="Mintlify" style="max-width: 250px;"></a>
+<a href="https://mintlify.com/?utm_source=writethedocs&utm_medium=referral" style="border-bottom: none;"><img src="/_static/img/sponsors/mintlify.png" alt="Mintlify" style="max-width: 250px;"></a>
 </p>
 
 *The Sunday Reception is sponsored by [Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral).*
@@ -39,7 +39,7 @@ and chat about the conference in a relaxed atmosphere.
 *Both alcoholic and non-alcoholic drinks and snacks will be provided.*
 
 <p style="text-align: center; margin-top: 1.5em;">
-<a href="https://promptless.ai/?ref=writethedocs"><img src="/_static/img/sponsors/promptless.png" alt="Promptless" style="max-width: 250px;"></a>
+<a href="https://promptless.ai/?ref=writethedocs" style="border-bottom: none;"><img src="/_static/img/sponsors/promptless.png" alt="Promptless" style="max-width: 250px;"></a>
 </p>
 
 *The Monday Night Social is sponsored by [Promptless](https://promptless.ai/?ref=writethedocs).*

--- a/docs/conf/portland/2026/social-events.md
+++ b/docs/conf/portland/2026/social-events.md
@@ -22,6 +22,10 @@ and make sure you know your way around the conference venue.
 
 *Both alcoholic and non-alcoholic drinks and snacks will be provided.*
 
+<p style="text-align: center; margin-top: 1.5em;">
+<a href="https://mintlify.com/?utm_source=writethedocs&utm_medium=referral"><img src="/_static/img/sponsors/mintlify.png" alt="Mintlify" style="max-width: 250px;"></a>
+</p>
+
 *The Sunday Reception is sponsored by [Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral).*
 
 ## Monday Night Social
@@ -33,5 +37,9 @@ and chat about the conference in a relaxed atmosphere.
 **When**: 7-9 PM
 
 *Both alcoholic and non-alcoholic drinks and snacks will be provided.*
+
+<p style="text-align: center; margin-top: 1.5em;">
+<a href="https://promptless.ai/?ref=writethedocs"><img src="/_static/img/sponsors/promptless.png" alt="Promptless" style="max-width: 250px;"></a>
+</p>
 
 *The Monday Night Social is sponsored by [Promptless](https://promptless.ai/?ref=writethedocs).*

--- a/docs/conf/portland/2026/unconference.md
+++ b/docs/conf/portland/2026/unconference.md
@@ -27,7 +27,7 @@ Everyone!
 See the [Schedule](/conf/{{shortcode}}/{{year}}/schedule) page for exact times.
 
 <p style="text-align: center; margin-top: 1.5em;">
-<a href="https://readme.com/?ref=writethedocs"><img src="/_static/img/sponsors/readme.png" alt="ReadMe" style="max-width: 250px;"></a>
+<a href="https://readme.com/?ref=writethedocs" style="border-bottom: none;"><img src="/_static/img/sponsors/readme.png" alt="ReadMe" style="max-width: 250px;"></a>
 </p>
 
 *The Unconference is sponsored by [ReadMe](https://readme.com/?ref=writethedocs).*

--- a/docs/conf/portland/2026/unconference.md
+++ b/docs/conf/portland/2026/unconference.md
@@ -8,6 +8,12 @@ banner: _static/conf/images/headers/2026/unconference.jpg
 
 The Unconference consists of attendee-driven sessions that provide the opportunity for anyone who is attending the conference to lead, contribute, share ideas, and discuss problems in an organized setting away from the main stage talks. Many attendees consider this one of their favorite aspects of the conference.
 
+<p style="text-align: center; margin-top: 1.5em;">
+<a href="https://readme.com/?ref=writethedocs" style="border-bottom: none;"><img src="/_static/img/sponsors/readme.png" alt="ReadMe" style="max-width: 250px;"></a>
+</p>
+
+*The Unconference is sponsored by [ReadMe](https://readme.com/?ref=writethedocs).*
+
 **Who can lead an Unconference session?**
 
 Everyone! All attendees are invited to lead a session on a topic. Sessions can be organized around a presentation, group discussion or anything in between.
@@ -25,12 +31,6 @@ Everyone!
 - Hosted in {{ about.unconfroom }}
 
 See the [Schedule](/conf/{{shortcode}}/{{year}}/schedule) page for exact times.
-
-<p style="text-align: center; margin-top: 1.5em;">
-<a href="https://readme.com/?ref=writethedocs" style="border-bottom: none;"><img src="/_static/img/sponsors/readme.png" alt="ReadMe" style="max-width: 250px;"></a>
-</p>
-
-*The Unconference is sponsored by [ReadMe](https://readme.com/?ref=writethedocs).*
 
 ## Sponsor Sessions in Martha's
 

--- a/docs/conf/portland/2026/unconference.md
+++ b/docs/conf/portland/2026/unconference.md
@@ -26,6 +26,10 @@ Everyone!
 
 See the [Schedule](/conf/{{shortcode}}/{{year}}/schedule) page for exact times.
 
+<p style="text-align: center; margin-top: 1.5em;">
+<a href="https://readme.com/?ref=writethedocs"><img src="/_static/img/sponsors/readme.png" alt="ReadMe" style="max-width: 250px;"></a>
+</p>
+
 *The Unconference is sponsored by [ReadMe](https://readme.com/?ref=writethedocs).*
 
 ## Sponsor Sessions in Martha's

--- a/docs/conf/portland/2026/unconference.md
+++ b/docs/conf/portland/2026/unconference.md
@@ -8,12 +8,6 @@ banner: _static/conf/images/headers/2026/unconference.jpg
 
 The Unconference consists of attendee-driven sessions that provide the opportunity for anyone who is attending the conference to lead, contribute, share ideas, and discuss problems in an organized setting away from the main stage talks. Many attendees consider this one of their favorite aspects of the conference.
 
-<p style="text-align: center; margin-top: 1.5em;">
-<a href="https://readme.com/?ref=writethedocs" style="border-bottom: none;"><img src="/_static/img/sponsors/readme.png" alt="ReadMe" style="max-width: 250px;"></a>
-</p>
-
-*The Unconference is sponsored by [ReadMe](https://readme.com/?ref=writethedocs).*
-
 **Who can lead an Unconference session?**
 
 Everyone! All attendees are invited to lead a session on a topic. Sessions can be organized around a presentation, group discussion or anything in between.
@@ -31,6 +25,14 @@ Everyone!
 - Hosted in {{ about.unconfroom }}
 
 See the [Schedule](/conf/{{shortcode}}/{{year}}/schedule) page for exact times.
+
+### Sponsored by
+
+<p style="text-align: center; margin-top: 1em;">
+<a href="https://readme.com/?ref=writethedocs" style="border-bottom: none;"><img src="/_static/img/sponsors/readme.png" alt="ReadMe" style="max-width: 250px;"></a>
+</p>
+
+*The Unconference is sponsored by [ReadMe](https://readme.com/?ref=writethedocs).*
 
 ## Sponsor Sessions in Martha's
 

--- a/docs/conf/portland/2026/writing-day.md
+++ b/docs/conf/portland/2026/writing-day.md
@@ -50,7 +50,7 @@ Writing Day is an all-day event designed for you to join in throughout the day. 
 Exact times will be posted on our [schedule page](/conf/{{shortcode}}/{{year}}/schedule/).
 
 <p style="text-align: center; margin-top: 1.5em;">
-<a href="https://www.stainless.com/?utm_source=write_the_docs&utm_medium=conference&utm_campaign=write_the_docs_2026"><img src="/_static/img/sponsors/stainless.png" alt="Stainless" style="max-width: 250px;"></a>
+<a href="https://www.stainless.com/?utm_source=write_the_docs&utm_medium=conference&utm_campaign=write_the_docs_2026" style="border-bottom: none;"><img src="/_static/img/sponsors/stainless.png" alt="Stainless" style="max-width: 250px;"></a>
 </p>
 
 *Writing Day is sponsored by [Stainless](https://www.stainless.com/?utm_source=write_the_docs&utm_medium=conference&utm_campaign=write_the_docs_2026).*

--- a/docs/conf/portland/2026/writing-day.md
+++ b/docs/conf/portland/2026/writing-day.md
@@ -49,6 +49,12 @@ Writing Day is an all-day event designed for you to join in throughout the day. 
 
 Exact times will be posted on our [schedule page](/conf/{{shortcode}}/{{year}}/schedule/).
 
+<p style="text-align: center; margin-top: 1.5em;">
+<a href="https://www.stainless.com/?utm_source=write_the_docs&utm_medium=conference&utm_campaign=write_the_docs_2026"><img src="/_static/img/sponsors/stainless.png" alt="Stainless" style="max-width: 250px;"></a>
+</p>
+
+*Writing Day is sponsored by [Stainless](https://www.stainless.com/?utm_source=write_the_docs&utm_medium=conference&utm_campaign=write_the_docs_2026).*
+
 ## How to Prepare
 
 **Come prepared with the following tools:**

--- a/docs/conf/portland/2026/writing-day.md
+++ b/docs/conf/portland/2026/writing-day.md
@@ -49,7 +49,9 @@ Writing Day is an all-day event designed for you to join in throughout the day. 
 
 Exact times will be posted on our [schedule page](/conf/{{shortcode}}/{{year}}/schedule/).
 
-<p style="text-align: center; margin-top: 1.5em;">
+### Sponsored by
+
+<p style="text-align: center; margin-top: 1em;">
 <a href="https://www.stainless.com/?utm_source=write_the_docs&utm_medium=conference&utm_campaign=write_the_docs_2026" style="border-bottom: none;"><img src="/_static/img/sponsors/stainless.png" alt="Stainless" style="max-width: 250px;"></a>
 </p>
 


### PR DESCRIPTION
Adds centered sponsor logos above the "sponsored by" credit lines for the four primary Portland 2026 events, and introduces Stainless as the Writing Day sponsor:

- Writing Day — Stainless (new credit + logo)
- Sunday Reception — Mintlify
- Monday Night Social — Promptless
- Unconference — ReadMe

Uses existing logos at `_static/img/sponsors/*.png` with a consistent centered HTML block (`max-width: 250px`).

---
_This PR was generated by AI._