### PR TITLE
portland: Add sponsor session details for Promptless and Mintlify

### DIFF
--- a/docs/conf/portland/2026/unconference.md
+++ b/docs/conf/portland/2026/unconference.md
@@ -38,7 +38,13 @@ Sign up to Lead a Monday Unconference
 Stop by Martha's each morning from 10:00 AM to 12:00 PM for **free handcrafted espresso on Monday ☕** and **free handcrafted matcha on Tuesday 🍵**, plus sponsor-led discussions.
 
 - **Monday ☕ — free espresso:** Sponsor Session hosted by **[Promptless](https://promptless.ai/?ref=writethedocs)**
+  - 10:00 AM — Context Engineering for Agents with Manny Silva
+  - 10:45 AM — Docs as Code: Starting from Scratch with Mike Jang
+  - 11:30 AM — Docs Observability: Measure Less, Learn More with Mano Toth
 - **Tuesday 🍵 — free matcha:** Sponsor Session hosted by **[Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral)**
+  - 10:00 AM — Working Session: Evaluate current documentation + map out improvements
+  - 10:40 AM — Open Discussion: Workflows with agents
+  - 11:20 AM — Casual Conversation: Joyful task we never want to automate
 
 Martha's will be open to attendee sessions in the afternoon, along with the Library and Astoria rooms.
 


### PR DESCRIPTION
## Summary

- Add Promptless Monday session schedule (Context Engineering, Docs as Code, Docs Observability)
- Add Mintlify Tuesday session schedule (Working Session, Open Discussion, Casual Conversation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2669.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->