### PR TITLE
Add requests for assistants to Writing Day project descriptions

### DIFF
--- a/docs/conf/portland/2026/writing-day.md
+++ b/docs/conf/portland/2026/writing-day.md
@@ -115,7 +115,9 @@ These are suggestions and not requirements. It is perfectly valid to show up to 
 
 ### Contribute to a Project
 
-Writing Day is the perfect opportunity to participate and learn about new projects and technologies. You are welcome to stay with one project all day, or project hop.
+Writing Day is the perfect opportunity to participate and learn about new projects and technologies. You are welcome to stay with one project all day or project hop.
+
+Some projects also request project assistants to help answer questions. Serving as a project assistant can be a great way to get more exposure to the project's topic or processes and give you some experience of what running a project is like.
 
 **Tips to contribute to a project:**
 
@@ -126,7 +128,7 @@ Writing Day is the perfect opportunity to participate and learn about new projec
 
 ## Project List
 
-If you are planning to contribute, review the project list before the conference. We're still adding projects as they're submitted, so check back here as the conference draws closer.
+If you are planning to contribute or are interested in assisting with a project, review the project list before the conference. We're still adding projects as they're submitted, so check back here as the conference draws closer.
 
 ### Docs as Tests and Doc Detective: Let's Get Your Docs Tested!
 
@@ -149,6 +151,8 @@ We want every writer to be confident in their docs. Come by our table, and we'll
 
 Establish a zero-trust relationship between your docs and product, catching bugs in both as you go.
 
+**Assistant opportunities**: Manny's always happy to have some assistants. If you have docs or code testing experience, or if you just want to come by, learn, and help others figure out how to test their docs, reach out to him directly in Write the Docs Slack @Manny Silva or show up at Writing Day and tell him you'd like to help!
+
 ### Can AI Find Your Docs? A Community Audit and Pattern Catalog
 
 * Project organizer: Rakesh Pasupuleti, he/him
@@ -163,6 +167,8 @@ I've been building an open documentation auditing tool as a side project--one th
 Here's what we'll do: bring your docs site URL, run an AI readiness audit, and review the results together. What patterns show up? What's easy to fix? What surprises us? You'll walk away with a personalized readiness report for your site, a concrete artifact you can take back to your team.
 
 If you want to go deeper into what happens *after* AI finds your docs--whether the content itself is accurate, fresh, and complete--I'll be covering that in my [Tuesday talk](https://www.writethedocs.org/conf/portland/2026/speakers/#speaker-rakesh-pasupuleti-what-i-learned-building-an-ai-documentation-auditor-and-what-it-found-in-500-p-rakesh-pasupuleti).
+
+**Assistant opportunities**: Rakesh is looking for one or two assistants. You'd help participants run AI readiness audits on their doc sites and write up findings — think of it as a second set of hands at the table. You can help in-person or remotely via Slack. If you're comfortable with docs concepts and want to help people discover what AI can (and can't) see in their documentation, reach out to Rakesh directly in Write the Docs Slack @Rakesh Pasupuleti or show up at Writing Day and tell him you'd like to help!
 
 ### Open-source documentation observability: Measure less, learn more
 
@@ -190,6 +196,8 @@ Most documentation teams know their docs could be better, but it's hard to know 
 [Syllago](https://syllago.dev) is a content manager for AI coding tools. It converts content between providers, bundles rules, skills, agents, hooks, and MCP configs into shareable loadouts and installs them in the correct location for each agent (Cursor, Windsurf, Claude Code, Gemini CLI, Amp, Codex, and more). If you manage your company's AI content, such as skills and rules, Syllago can help you centrally manage and share them across your entire company. This eliminates the headache of manually translating the different formats between AI agents or harnesses.
   
 This session is a hands-on playground for both the tool and its docs. Bring a laptop and an AI coding agent (or two, or five) you already use, and help stress-test Syllago's CLI and TUI in the wild: migrate your Claude Code setup to Gemini CLI, port a Cursor rule set to Windsurf, try the cross-provider conversion paths, and see where things break. On the docs side, you'll help identify gaps in the documentation site, tackle open issues, and explore a question I'm actively working on--how much of a CLI/TUI's docs can be auto-generated from the real codebase, and what's still worth writing by hand? You'll leave with practical exposure to how different agent runtimes and harnesses actually differ under the hood, experience contributing to an open-source project with AI in the loop, and (hopefully) a cleaner docs site for everyone who shows up after you.
+
+**Assistant opportunities**: Holden's looking for one or two assistants. If you've used an AI coding agent (Cursor, Claude Code, Gemini CLI, Windsurf, Codex, Amp, or similar) and are comfortable helping others get a CLI tool running, answering questions about agent-specific quirks, or reviewing docs as people work through them, Holden would love your help. No Syllago experience needed. If you know your way around any of these agents, you're qualified. Reach out to him directly in Write the Docs Slack at @Holden Hewett or show up at Writing Day and tell him you'd like to help!
 
 ### Audit Your Docs Metrics (Sponsor session)
 


### PR DESCRIPTION
So far the Slack call for help hasn't produced much, so I'd like to try adding this on the website directly to see how that works. Go big or go home!

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2672.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->