### PR TITLE
docs: Update Portland 2026 menus and sponsors

### DIFF
--- a/docs/_templates/2026/menu-desktop.html
+++ b/docs/_templates/2026/menu-desktop.html
@@ -47,6 +47,7 @@
         <div class="uk-navbar-dropdown">
           <ul class="uk-nav uk-navbar-dropdown-nav">
             <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/tickets') }}">Tickets</a></li>
+            <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/virtual') }}">Virtual Attendance</a></li>
             <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/opportunity-grants') }}">Opportunity Grants</a></li>
             <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/convince-your-manager') }}">Convince Your
                 Manager</a></li>
@@ -74,7 +75,6 @@
                 <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/volunteer') }}">Volunteer Info</a></li>
 
             {% endif %}
-            <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/virtual') }}">Virtual Attendance</a></li>
             {% if not flagisvirtual %}
                 <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/health') }}">Health and Safety Policy</a></li>
             {% endif %}

--- a/docs/_templates/2026/menu-mobile.html
+++ b/docs/_templates/2026/menu-mobile.html
@@ -38,6 +38,7 @@
     <a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/tickets') }}">Tickets</a>
     <ul class="uk-nav-sub">
       <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/tickets') }}">Tickets</a></li>
+      <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/virtual') }}">Virtual Attendance</a></li>
       <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/opportunity-grants') }}">Opportunity Grants</a></li>
       <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/convince-your-manager') }}">Convince Your
           Manager</a></li>
@@ -58,7 +59,6 @@
           {% endif %}
           <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/volunteer') }}">Volunteer Info</a></li>
       {% endif %}
-      <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/virtual') }}">Virtual Attendance</a></li>
       {% if not flagisvirtual %}
           <li><a href="{{ pathto('conf/'+shortcode+'/'+year_str+'/health') }}">Health and Safety Policy</a></li>
       {% endif %}

--- a/docs/conf/portland/2026/lightning-talks.md
+++ b/docs/conf/portland/2026/lightning-talks.md
@@ -29,6 +29,8 @@ Submit your Monday Lightning Talk
 ```
 {% endif %}
 
+*The Monday Lightning Talks are sponsored by [Expert Support](https://expertsupport.com/?ref=writethedocs), and the Tuesday Lightning Talks are sponsored by [KnowledgeOwl](https://www.knowledgeowl.com?ref=writethedocs).*
+
 ### Submitting a Talk
 
 Submissions are open:


### PR DESCRIPTION
Updates the Portland 2026 conference navigation so the virtual attendance page appears under the Tickets menu in both desktop and mobile navigation.

Also adds the Monday and Tuesday Lightning Talks sponsor acknowledgements to the Lightning Talks page.

Validated with:

- `cd docs && uv run make html`

Generated by AI.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2673.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->