### PR TITLE
docs: Add Berlin 2026 sponsors

### DIFF
--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -195,6 +195,13 @@ sponsors:
     - name: readthedocs
       link: https://about.readthedocs.com/?ref=writethedocs
       brand: Read the Docs
+    - name: knowledgeowl
+      brand: KnowledgeOwl
+      link: https://www.knowledgeowl.com?ref=writethedocs
+      width: 250px
+    - name: fern
+      brand: Fern
+      link: https://buildwithfern.com/?ref=writethedocs
   first:
   in_kind:
     - name: readthedocs

--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -190,6 +190,9 @@ sponsors:
     - name: gitbook
       link: https://www.gitbook.com/?ref=writethedocs
       brand: GitBook
+    - name: fern
+      brand: Fern
+      link: https://buildwithfern.com/?ref=writethedocs
   publisher:
   second:
     - name: readthedocs
@@ -199,9 +202,6 @@ sponsors:
       brand: KnowledgeOwl
       link: https://www.knowledgeowl.com?ref=writethedocs
       width: 250px
-    - name: fern
-      brand: Fern
-      link: https://buildwithfern.com/?ref=writethedocs
   first:
   in_kind:
     - name: readthedocs


### PR DESCRIPTION
Adds Fern and KnowledgeOwl to the Berlin 2026 sponsor data so they appear on the conference sponsor page.

Validated with `uvx --with yamale pre-commit run --files docs/_data/berlin-2026-config.yaml`.

Generated by AI.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2674.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->