### PR TITLE
conf: set Portland 2026 to post-conf state

### DIFF
--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -26,10 +26,10 @@ buttons:
     #   link: /tickets
     #- text: See the Speakers
     #  link: /speakers
-    - text: See the Schedule!
-      link: /schedule
-    - text: Attendee Guide
-      link: /attendee-guide
+    # - text: See the Schedule!
+    #   link: /schedule
+    # - text: Attendee Guide
+    #   link: /attendee-guide
     # - text: Watch the Live Stream
     #   link: /livestream
     # - text: Watch the videos!
@@ -45,16 +45,16 @@ buttons:
     #   link: /cfp
     # - text: Buy a Ticket!
     #   link: /tickets
-    - text: See the Schedule
-      link: /schedule
+    # - text: See the Schedule
+    #   link: /schedule
     # - text: See the Talks
     #   link: /speakers
-    - text: Read the Guide
-      link: /attendee-guide
+    # - text: Read the Guide
+    #   link: /attendee-guide
     # - text: Watch the Live Stream
     #   link: /livestream
-    # - text: Browse the photos
-    #   link_absolute: https://www.flickr.com/photos/writethedocs/albums/72177720308088427
+    - text: Browse the photos
+      link_absolute: https://www.flickr.com/photos/writethedocs/albums/72177720333452248
     # - text: Watch the videos!
     #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHplMbtJtidqFFtL7rt3ASNSR
     # - text: Conference recap

--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -26,16 +26,16 @@ buttons:
     #   link: /tickets
     #- text: See the Speakers
     #  link: /speakers
-    # - text: See the Schedule!
-    #   link: /schedule
-    # - text: Attendee Guide
-    #   link: /attendee-guide
+    - text: See the Schedule!
+      link: /schedule
+    - text: Attendee Guide
+      link: /attendee-guide
     # - text: Watch the Live Stream
     #   link: /livestream
     # - text: Watch the videos!
     #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHplMbtJtidqFFtL7rt3ASNSR
-    - text: Conference recap
-      link: /news/thanks-recap
+    # - text: Conference recap
+    #   link: /news/thanks-recap
   bottom:
     # - text: Welcome to our conference
     #   link: /news/welcome
@@ -45,20 +45,20 @@ buttons:
     #   link: /cfp
     # - text: Buy a Ticket!
     #   link: /tickets
-    # - text: See the Schedule
-    #   link: /schedule
+    - text: See the Schedule
+      link: /schedule
     # - text: See the Talks
     #   link: /speakers
-    # - text: Read the Guide
-    #   link: /attendee-guide
+    - text: Read the Guide
+      link: /attendee-guide
     # - text: Watch the Live Stream
     #   link: /livestream
-    - text: Browse the photos
-      link_absolute: https://www.flickr.com/photos/writethedocs/albums/72177720333452248
+    # - text: Browse the photos
+    #   link_absolute: https://www.flickr.com/photos/writethedocs/albums/72177720308088427
     # - text: Watch the videos!
     #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHplMbtJtidqFFtL7rt3ASNSR
-    - text: Conference recap
-      link: /news/thanks-recap
+    # - text: Conference recap
+    #   link: /news/thanks-recap
 
 tickets:
   concierge:

--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -26,16 +26,16 @@ buttons:
     #   link: /tickets
     #- text: See the Speakers
     #  link: /speakers
-    - text: See the Schedule!
-      link: /schedule
-    - text: Attendee Guide
-      link: /attendee-guide
+    # - text: See the Schedule!
+    #   link: /schedule
+    # - text: Attendee Guide
+    #   link: /attendee-guide
     # - text: Watch the Live Stream
     #   link: /livestream
     # - text: Watch the videos!
     #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHplMbtJtidqFFtL7rt3ASNSR
-    # - text: Conference recap
-    #   link: /news/thanks-recap
+    - text: Conference recap
+      link: /news/thanks-recap
   bottom:
     # - text: Welcome to our conference
     #   link: /news/welcome
@@ -45,20 +45,20 @@ buttons:
     #   link: /cfp
     # - text: Buy a Ticket!
     #   link: /tickets
-    - text: See the Schedule
-      link: /schedule
+    # - text: See the Schedule
+    #   link: /schedule
     # - text: See the Talks
     #   link: /speakers
-    - text: Read the Guide
-      link: /attendee-guide
+    # - text: Read the Guide
+    #   link: /attendee-guide
     # - text: Watch the Live Stream
     #   link: /livestream
-    # - text: Browse the photos
-    #   link_absolute: https://www.flickr.com/photos/writethedocs/albums/72177720308088427
+    - text: Browse the photos
+      link_absolute: https://www.flickr.com/photos/writethedocs/albums/72177720333452248
     # - text: Watch the videos!
     #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHplMbtJtidqFFtL7rt3ASNSR
-    # - text: Conference recap
-    #   link: /news/thanks-recap
+    - text: Conference recap
+      link: /news/thanks-recap
 
 tickets:
   concierge:
@@ -331,7 +331,7 @@ flaghasschedule: True
 flaghasshirts: True
 flaglivestreaming: True
 flagvideos: False
-flagpostconf: False
+flagpostconf: True
 
 # Truthy things that don't change
 flaghasunconf: True


### PR DESCRIPTION
Sets Portland 2026 to its post-conference state:

- `flagpostconf: True`
- Top buttons: replace schedule/attendee-guide with the Conference recap link
- Bottom buttons: replace schedule/attendee-guide with the photos album link and Conference recap link

The recap post itself follows in a separate PR.

---
*Generated by AI*

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2685.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->