### PR TITLE
news: add Portland 2026 thanks-recap post

### DIFF
--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -32,10 +32,10 @@ buttons:
     #   link: /attendee-guide
     # - text: Watch the Live Stream
     #   link: /livestream
-    # - text: Watch the videos!
-    #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHpkMzZFXFye22pKbafhhC3Cp
-    - text: Browse the photos
-      link_absolute: https://www.flickr.com/photos/writethedocs/albums/72177720333452248
+    # - text: Browse the photos
+    #   link_absolute: https://www.flickr.com/photos/writethedocs/albums/72177720333452248
+    - text: Watch the videos!
+      link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHpkMzZFXFye22pKbafhhC3Cp
     - text: Conference recap
       link: /news/thanks-recap
   bottom:
@@ -55,10 +55,10 @@ buttons:
     #   link: /attendee-guide
     # - text: Watch the Live Stream
     #   link: /livestream
-    - text: Browse the photos
-      link_absolute: https://www.flickr.com/photos/writethedocs/albums/72177720333452248
-    # - text: Watch the videos!
-    #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHpkMzZFXFye22pKbafhhC3Cp
+    # - text: Browse the photos
+    #   link_absolute: https://www.flickr.com/photos/writethedocs/albums/72177720333452248
+    - text: Watch the videos!
+      link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHpkMzZFXFye22pKbafhhC3Cp
     - text: Conference recap
       link: /news/thanks-recap
 

--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -340,12 +340,12 @@ flaghasunconf: True
 flaghashike: True
 flaghasfood: True
 flaghaswritingday: True
-flaghasteam: True
 flaghaslightningtalks: True
 flaghassponsorexpo: True
 flaghasboat: False
 
 # Pages to be linked in January 2026
 flaghasvisiting: True
+flaghasteam: True
 flaghasattendeeguide: True
 flaghasbadgeflair: False

--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -33,7 +33,9 @@ buttons:
     # - text: Watch the Live Stream
     #   link: /livestream
     # - text: Watch the videos!
-    #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHplMbtJtidqFFtL7rt3ASNSR
+    #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHpkMzZFXFye22pKbafhhC3Cp
+    - text: Browse the photos
+      link_absolute: https://www.flickr.com/photos/writethedocs/albums/72177720333452248
     - text: Conference recap
       link: /news/thanks-recap
   bottom:
@@ -56,7 +58,7 @@ buttons:
     - text: Browse the photos
       link_absolute: https://www.flickr.com/photos/writethedocs/albums/72177720333452248
     # - text: Watch the videos!
-    #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHplMbtJtidqFFtL7rt3ASNSR
+    #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHpkMzZFXFye22pKbafhhC3Cp
     - text: Conference recap
       link: /news/thanks-recap
 
@@ -331,19 +333,19 @@ flaghasschedule: True
 flaghasshirts: True
 flaglivestreaming: True
 flagvideos: False
-flagpostconf: False
+flagpostconf: True
 
 # Truthy things that don't change
 flaghasunconf: True
 flaghashike: True
 flaghasfood: True
 flaghaswritingday: True
+flaghasteam: True
 flaghaslightningtalks: True
 flaghassponsorexpo: True
 flaghasboat: False
 
 # Pages to be linked in January 2026
 flaghasvisiting: True
-flaghasteam: True
 flaghasattendeeguide: True
 flaghasbadgeflair: False

--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -26,16 +26,16 @@ buttons:
     #   link: /tickets
     #- text: See the Speakers
     #  link: /speakers
-    - text: See the Schedule!
-      link: /schedule
-    - text: Attendee Guide
-      link: /attendee-guide
+    # - text: See the Schedule!
+    #   link: /schedule
+    # - text: Attendee Guide
+    #   link: /attendee-guide
     # - text: Watch the Live Stream
     #   link: /livestream
     # - text: Watch the videos!
     #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHplMbtJtidqFFtL7rt3ASNSR
-    # - text: Conference recap
-    #   link: /news/thanks-recap
+    - text: Conference recap
+      link: /news/thanks-recap
   bottom:
     # - text: Welcome to our conference
     #   link: /news/welcome
@@ -45,20 +45,20 @@ buttons:
     #   link: /cfp
     # - text: Buy a Ticket!
     #   link: /tickets
-    - text: See the Schedule
-      link: /schedule
+    # - text: See the Schedule
+    #   link: /schedule
     # - text: See the Talks
     #   link: /speakers
-    - text: Read the Guide
-      link: /attendee-guide
+    # - text: Read the Guide
+    #   link: /attendee-guide
     # - text: Watch the Live Stream
     #   link: /livestream
-    # - text: Browse the photos
-    #   link_absolute: https://www.flickr.com/photos/writethedocs/albums/72177720308088427
+    - text: Browse the photos
+      link_absolute: https://www.flickr.com/photos/writethedocs/albums/72177720333452248
     # - text: Watch the videos!
     #   link_absolute: https://www.youtube.com/playlist?list=PLZAeFn6dfHplMbtJtidqFFtL7rt3ASNSR
-    # - text: Conference recap
-    #   link: /news/thanks-recap
+    - text: Conference recap
+      link: /news/thanks-recap
 
 tickets:
   concierge:

--- a/docs/conf/portland/2026/news/thanks-recap.md
+++ b/docs/conf/portland/2026/news/thanks-recap.md
@@ -18,15 +18,15 @@ It was wonderful to be back at Revolution Hall in Portland for another great yea
 
 ## Conference recap
 
-With **over 400 in-person attendees** and **over 175 virtual attendees**, we had another great turnout this year! We had the usual mix of talks on the main stage along with Q&A, lightning talks, Unconference sessions, writing day sprints, and a couple social events.
+With **over 400 in-person attendees** and **over 175 virtual attendees**, we had another great turnout this year! We had the usual mix of talks on the main stage along with Q&A, Lightning Talks, Unconference sessions, Writing Day sprints, and a couple social events.
 
-We also tried a few new things this year. We took over the Martha's Coffee Shop space, giving the Unconference and Writing Day room to breathe with quieter, more focused conversations. [Promptless](https://promptless.ai/?ref=writethedocs) and [Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral) hosted sponsor coffee sessions in that space on Monday and Tuesday mornings, and we expanded Writing Day with a new Git and GitHub workshop, resume and portfolio reviews, and pre-scheduled roundtable discussions.
+We also tried a few new things this year. We took over the Martha's Coffee Shop space, giving the Unconference and Writing Day room to breathe with quieter, more focused conversations. [Promptless](https://promptless.ai/?ref=writethedocs) and [Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral) hosted sponsor sessions in that space on Monday and Tuesday mornings, and we expanded Writing Day with a new Git and GitHub workshop, resume and portfolio reviews, and pre-scheduled roundtable discussions.
 
 We will continue to work on improving the conference experience for everyone, and we appreciate all the feedback we've received already.
 
 ## Talk videos
 
-All of the conference talks, Q&A, and lightning talks are now up on the [Portland 2026 playlist](https://www.youtube.com/playlist?list=PLZAeFn6dfHpkMzZFXFye22pKbafhhC3Cp) on our YouTube channel.
+All of the conference talks, Q&A, and Lightning Talks are now up on the [Portland 2026 playlist](https://www.youtube.com/playlist?list=PLZAeFn6dfHpkMzZFXFye22pKbafhhC3Cp) on our YouTube channel.
 
 Thanks again to all our speakers, emcees, and folks who asked wonderful questions!
 
@@ -39,17 +39,6 @@ You're welcome to use them for non-commercial purposes, such as conference write
 ## Talk sketchnotes
 
 Sketchnotes for the talks are now up on our [Flickr account](https://www.flickr.com/photos/writethedocs/). Thanks to our talented sketchnote artist [Dennis](https://dennissdawson.wixsite.com/mr--dawson/portfolio) for capturing the talks in such a creative way!
-
-## Come to our upcoming events
-
-We have more conferences coming up. Keep an eye on our conference pages and newsletter for announcements and dates:
-
-- [Kenya 2026](https://www.meetup.com/wtd-kenya/events/314376384/), August 8
-- [Berlin 2026](https://www.writethedocs.org/conf/berlin/2026/), September 6-8
-- Australia 2026, December 3-4
-
-And for the first time ever, we have a date for our next Portland conference. Mark your calendars for **May 2-4, 2027** — back here at Revolution Hall.
-
 
 ## Code of Conduct transparency report
 
@@ -67,11 +56,33 @@ We are happy to report that we received no Code of Conduct reports during the co
 
 Attendees can always report incidents, even after the conference, by emailing us at [conduct@writethedocs.org](mailto:conduct@writethedocs.org).
 
+## Join our Slack network
+
+Our Slack network is a great way to stay connected to the community beyond our conferences. We have channels for specific doc tools, meetups, career advice, and other areas of discussion.
+
+Check out the [Slack page](https://www.writethedocs.org/slack/) on our website for more information.
+
+## Join a local meetup
+
+Participating in your [local meetup](https://www.writethedocs.org/meetups/) is a great way to keep in touch with other documentarians. We have meetups in cities around the world.
+
+## Come to our upcoming events
+
+We have more conferences coming up. Keep an eye on our conference pages and newsletter for announcements and dates:
+
+- [Kenya 2026](https://www.meetup.com/wtd-kenya/events/314376384/), August 8
+- [Berlin 2026](https://www.writethedocs.org/conf/berlin/2026/), September 6-8
+- Australia 2026, December 3-4
+
+And for the first time ever, we have a date for our next Portland conference. Mark your calendars for **May 2-4, 2027** — back here at Revolution Hall.
+
 ## Thanks again
 
-The conference is possible only because folks like you make it a great experience. Thanks for making it another wonderful year. 
+The conference is possible only because folks like you make it a great experience. Thanks for making it another wonderful year. We hope to see you back again next year, or even sooner at one of our other events!
 
-And thanks so much to the sponsors who supported us this year:
+## Thanks to our sponsors
+
+Thanks so much to the sponsors who supported Write the Docs Portland 2026:
 
 ```{eval-rst}
 .. datatemplate::

--- a/docs/conf/portland/2026/news/thanks-recap.md
+++ b/docs/conf/portland/2026/news/thanks-recap.md
@@ -5,7 +5,7 @@ banner: _static/conf/images/headers/2026/unconference.jpg
 ---
 
 ```{eval-rst}
-.. post:: May 19, 2026
+.. post:: May 14, 2026
    :tags: {{shortcode}}-{{year}}
 ```
 
@@ -27,19 +27,19 @@ We will continue to work on improving the conference experience for everyone, an
 
 ## Talk videos
 
-Talk videos for all conference talks, Q&A, and lightning talks are being edited and will be released over the next 1-2 weeks. We'll be uploading them to the [Portland 2026 playlist](https://www.youtube.com/playlist?list=PLZAeFn6dfHpkMzZFXFye22pKbafhhC3Cp) on our YouTube channel as they're ready.
+All of the conference talks, Q&A, and lightning talks are now up on the [Portland 2026 playlist](https://www.youtube.com/playlist?list=PLZAeFn6dfHpkMzZFXFye22pKbafhhC3Cp) on our YouTube channel.
 
 Thanks again to all our speakers, emcees, and folks who asked wonderful questions!
 
 ## Conference photos
 
-The initial conference photos are now available in our [Portland 2026 Flickr album](https://www.flickr.com/photos/writethedocs/albums/72177720333452248), thanks to our wonderful photographer [Kay](https://www.instagram.com/goatladykay/)! The fully edited set will be published over the next 1-2 weeks.
+The full set of conference photos is available in our [Portland 2026 Flickr album](https://www.flickr.com/photos/writethedocs/albums/72177720333452248), thanks to our wonderful photographer [Kay](https://www.instagram.com/goatladykay/)!
 
 You're welcome to use them for non-commercial purposes, such as conference write-ups, as per our [Creative Commons License](https://creativecommons.org/licenses/by-nc-sa/2.0/).
 
 ## Talk sketchnotes
 
-Sketchnotes for the talks from the conference will be shared on our Flickr account once they're ready. Thanks to our talented sketchnote artist [Dennis](https://dennissdawson.wixsite.com/mr--dawson/portfolio) for capturing the talks in such a creative way!
+Sketchnotes for the talks are now up on our [Flickr account](https://www.flickr.com/photos/writethedocs/). Thanks to our talented sketchnote artist [Dennis](https://dennissdawson.wixsite.com/mr--dawson/portfolio) for capturing the talks in such a creative way!
 
 ## Code of Conduct transparency report
 

--- a/docs/conf/portland/2026/news/thanks-recap.md
+++ b/docs/conf/portland/2026/news/thanks-recap.md
@@ -25,12 +25,6 @@ We also tried a few new things this year. We took over the Martha's Coffee Shop 
 
 We will continue to work on improving the conference experience for everyone, and we appreciate all the feedback we've received already.
 
-## Tell us how we did
-
-**Our [short feedback survey](https://docs.google.com/forms/d/e/1FAIpQLScc0bcg3SZeeylKnprCNbrAkeOBW85L5gqy-TaEOp2a3IBDkA/viewform?usp=dialog) is quick and easy**, so please fill it out.
-
-Your feedback helps us improve our other events, and we really appreciate everyone who fills it out each year.
-
 ## Talk videos
 
 Talk videos for all conference talks, Q&A, and lightning talks are being edited and will be released over the next 1-2 weeks. We'll be uploading them to the [Portland 2026 playlist](https://www.youtube.com/playlist?list=PLZAeFn6dfHpkMzZFXFye22pKbafhhC3Cp) on our YouTube channel as they're ready.
@@ -91,16 +85,8 @@ The conference is possible only because folks like you make it a great experienc
 
 Thanks so much to the sponsors who supported Write the Docs Portland 2026:
 
-- [Promptless](https://promptless.ai/?ref=writethedocs)
-- [Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral)
-- [ReadMe](https://readme.com/?ref=writethedocs)
-- [Stainless](https://www.stainless.com/?utm_source=write_the_docs&utm_medium=conference&utm_campaign=write_the_docs_2026)
-- [GitBook](https://www.gitbook.com/?ref=writethedocs)
-- [Fern](https://buildwithfern.com/?ref=writethedocs)
-- [MongoDB](https://www.mongodb.com/?ref=writethedocs)
-- [Expert Support](https://expertsupport.com/?ref=writethedocs)
-- [KnowledgeOwl](https://www.knowledgeowl.com?ref=writethedocs)
-- [HelpDocs](https://www.helpdocs.io/?utm_source=writethedocs&utm_medium=sponsor&utm_campaign=wtdp26)
-- [Google](https://opensource.google/?ref=writethedocs)
-- [GitHub](https://github.com/?ref=writethedocs)
-- [Read the Docs](https://about.readthedocs.com/?ref=writethedocs)
+```{eval-rst}
+.. datatemplate::
+   :source: /_data/{{shortcode}}-{{year}}-config.yaml
+   :template: {{year}}/sponsors-simplelist.rst
+```

--- a/docs/conf/portland/2026/news/thanks-recap.md
+++ b/docs/conf/portland/2026/news/thanks-recap.md
@@ -1,0 +1,68 @@
+---
+template: {{year}}/generic.html
+og:image: /_static/conf/images/headers/2026/unconference.jpg
+banner: _static/conf/images/headers/2026/unconference.jpg
+---
+
+```{eval-rst}
+.. post:: May 19, 2026
+   :tags: {{shortcode}}-{{year}}
+```
+
+# Portland 2026 Recap - Talk Videos, Photos, Sketchnotes, CoC Report
+
+Hi everyone,
+
+Our team is slowly emerging from the post-conference recovery period, and we wanted to send out a quick message to thank everyone for helping to make Write the Docs Portland 2026 such a success. We appreciate everyone who makes the conference possible: speakers, sponsors, organizers, volunteers, and attendees alike!
+
+It was wonderful to be back at Revolution Hall in Portland for another great year of talks, conversations, and community.
+
+## Conference recap
+
+With **over 400 in-person attendees** and **over 175 virtual attendees**, we had another great turnout this year! We had the usual mix of talks on the main stage along with Q&A, lightning talks, Unconference sessions, writing day sprints, and a couple social events.
+
+We will continue to work on improving the conference experience for everyone, and we appreciate all the feedback we've received already.
+
+## Talk videos
+
+Talk videos will be available soon. This will include all conference talks with Q&A, as well as the lightning talks. We'll share the [Portland 2026 playlist](https://www.youtube.com/c/WritetheDocs) link on our YouTube channel as soon as the videos are uploaded.
+
+Thanks again to all our presenters, emcees, and folks who asked wonderful questions!
+
+## Conference photos
+
+The conference photos are almost all uploaded and edited. Our [2026 Portland Flickr album](https://www.flickr.com/photos/writethedocs/albums/72177720333452248) has the full set of photos from the conference, thanks to our wonderful photographer [Kay](https://www.instagram.com/goatladykay/)!
+
+We really love the photos each year, and you're welcome to use them for non-commercial purposes, such as conference write-ups, as per our [Creative Commons License](https://creativecommons.org/licenses/by-nc-sa/2.0/).
+
+## Talk sketchnotes
+
+Sketchnotes for the talks from the conference will be shared on our Flickr account once they're ready. Thanks to our talented sketchnote artist [Dennis](https://dennissdawson.wixsite.com/mr--dawson/portfolio) for capturing the talks in such a creative way!
+
+## Code of Conduct transparency report
+
+As with any Write the Docs event, this conference was covered by our [community Code of Conduct](https://www.writethedocs.org/code-of-conduct/). We aim to be as transparent with CoC incidents and enforcement as we can.
+
+To ensure that our CoC was visible and accessible, we took a number of specific steps:
+
+- Every participant agreed to the Code of Conduct in advance during registration.
+- The CoC, or a summary, was included on the conference website and around the venue.
+- The CoC was repeatedly mentioned in our conference introduction and announcements.
+- We specifically stressed that the CoC applies to all conference spaces, including the social event.
+- We encouraged all attendees to report any incident, even if they were not sure whether it was a violation.
+
+We are happy to report that we received no Code of Conduct incidents during the conference.
+
+Attendees can always report incidents, even after the conference, by emailing us at [conduct@writethedocs.org](mailto:conduct@writethedocs.org).
+
+## Come to our upcoming events
+
+We have another conference coming up later this year:
+
+- [Berlin 2026](http://www.writethedocs.org/conf/berlin/2026/), September 6-8, 2026, **Berlin, Germany**
+
+We hope to see you there!
+
+## Thanks again
+
+The conference is possible only because folks like you make it a great experience. Thanks for making it another wonderful year. Whether you were able to come out this time or not, we hope to see you again next year—or even sooner at one of our other events!

--- a/docs/conf/portland/2026/news/thanks-recap.md
+++ b/docs/conf/portland/2026/news/thanks-recap.md
@@ -40,6 +40,17 @@ You're welcome to use them for non-commercial purposes, such as conference write
 
 Sketchnotes for the talks are now up on our [Flickr account](https://www.flickr.com/photos/writethedocs/). Thanks to our talented sketchnote artist [Dennis](https://dennissdawson.wixsite.com/mr--dawson/portfolio) for capturing the talks in such a creative way!
 
+## Come to our upcoming events
+
+We have more conferences coming up. Keep an eye on our conference pages and newsletter for announcements and dates:
+
+- [Kenya 2026](https://www.meetup.com/wtd-kenya/events/314376384/), August 8
+- [Berlin 2026](https://www.writethedocs.org/conf/berlin/2026/), September 6-8
+- Australia 2026, December 3-4
+
+And for the first time ever, we have a date for our next Portland conference. Mark your calendars for **May 2-4, 2027** — back here at Revolution Hall.
+
+
 ## Code of Conduct transparency report
 
 As with any Write the Docs event, this conference was covered by our [community Code of Conduct](https://www.writethedocs.org/code-of-conduct/). We aim to be as transparent with CoC incidents and enforcement as we can.
@@ -56,33 +67,11 @@ We are happy to report that we received no Code of Conduct reports during the co
 
 Attendees can always report incidents, even after the conference, by emailing us at [conduct@writethedocs.org](mailto:conduct@writethedocs.org).
 
-## Join our Slack network
-
-Our Slack network is a great way to stay connected to the community beyond our conferences. We have channels for specific doc tools, meetups, career advice, and other areas of discussion.
-
-Check out the [Slack page](https://www.writethedocs.org/slack/) on our website for more information.
-
-## Join a local meetup
-
-Participating in your [local meetup](https://www.writethedocs.org/meetups/) is a great way to keep in touch with other documentarians. We have meetups in cities around the world.
-
-## Come to our upcoming events
-
-We have more conferences coming up. Keep an eye on our conference pages and newsletter for announcements and dates:
-
-- [Kenya 2026](https://www.meetup.com/wtd-kenya/events/314376384/), August 8
-- [Berlin 2026](https://www.writethedocs.org/conf/berlin/2026/), September 6-8
-- Australia 2026, December 3-4
-
-And for the first time ever, we have a date for our next Portland conference. Mark your calendars for **May 2-4, 2027** — back here at Revolution Hall.
-
 ## Thanks again
 
-The conference is possible only because folks like you make it a great experience. Thanks for making it another wonderful year. We hope to see you back again next year, or even sooner at one of our other events!
+The conference is possible only because folks like you make it a great experience. Thanks for making it another wonderful year. 
 
-## Thanks to our sponsors
-
-Thanks so much to the sponsors who supported Write the Docs Portland 2026:
+And thanks so much to the sponsors who supported us this year:
 
 ```{eval-rst}
 .. datatemplate::

--- a/docs/conf/portland/2026/news/thanks-recap.md
+++ b/docs/conf/portland/2026/news/thanks-recap.md
@@ -18,7 +18,7 @@ It was wonderful to be back at Revolution Hall in Portland for another great yea
 
 ## Conference recap
 
-With **over 400 in-person attendees** and **over 175 virtual attendees**, we had another great turnout this year! We had the usual mix of talks on the main stage along with Q&A, Lightning Talks, Unconference sessions, Writing Day sprints, and a couple social events.
+With **over 400 in-person attendees** and **over 175 virtual attendees**, we had another great turnout this year! We had the usual mix of talks on the main stage along with Q&A, Lightning Talks, Unconference sessions, Writing Day sessions, and a couple social events.
 
 We also tried a few new things this year. We took over the Martha's Coffee Shop space, giving the Unconference and Writing Day room to breathe with quieter, more focused conversations. [Promptless](https://promptless.ai/?ref=writethedocs) and [Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral) hosted sponsor sessions in that space on Monday and Tuesday mornings, and we expanded Writing Day with a new Git and GitHub workshop, resume and portfolio reviews, and pre-scheduled roundtable discussions.
 

--- a/docs/conf/portland/2026/news/thanks-recap.md
+++ b/docs/conf/portland/2026/news/thanks-recap.md
@@ -1,6 +1,7 @@
 ---
 template: {{year}}/generic.html
-banner: _static/conf/images/headers/2026/unconference.jpg
+og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
+banner: _static/conf/images/headers/2026/registration.jpg
 ---
 
 ```{eval-rst}

--- a/docs/conf/portland/2026/news/thanks-recap.md
+++ b/docs/conf/portland/2026/news/thanks-recap.md
@@ -21,19 +21,27 @@ It was wonderful to be back at Revolution Hall in Portland for another great yea
 
 With **over 400 in-person attendees** and **over 175 virtual attendees**, we had another great turnout this year! We had the usual mix of talks on the main stage along with Q&A, lightning talks, Unconference sessions, writing day sprints, and a couple social events.
 
+We also tried a few new things this year. We took over the Martha's Coffee Shop space, giving the Unconference and Writing Day room to breathe with quieter, more focused conversations. [Promptless](https://promptless.ai/?ref=writethedocs) and [Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral) hosted sponsor coffee sessions in that space on Monday and Tuesday mornings, and we expanded Writing Day with a new Git and GitHub workshop, resume and portfolio reviews, and pre-scheduled roundtable discussions.
+
 We will continue to work on improving the conference experience for everyone, and we appreciate all the feedback we've received already.
+
+## Tell us how we did
+
+**Our [short feedback survey](https://docs.google.com/forms/d/e/1FAIpQLScc0bcg3SZeeylKnprCNbrAkeOBW85L5gqy-TaEOp2a3IBDkA/viewform?usp=dialog) is quick and easy**, so please fill it out.
+
+Your feedback helps us improve our other events, and we really appreciate everyone who fills it out each year.
 
 ## Talk videos
 
-Talk videos will be available soon. This will include all conference talks with Q&A, as well as the lightning talks. We'll share the [Portland 2026 playlist](https://www.youtube.com/c/WritetheDocs) link on our YouTube channel as soon as the videos are uploaded.
+Talk videos for all conference talks, Q&A, and lightning talks are being edited and will be released over the next 1-2 weeks. We'll be uploading them to the [Portland 2026 playlist](https://www.youtube.com/playlist?list=PLZAeFn6dfHpkMzZFXFye22pKbafhhC3Cp) on our YouTube channel as they're ready.
 
 Thanks again to all our speakers, emcees, and folks who asked wonderful questions!
 
 ## Conference photos
 
-The conference photos are almost all uploaded and edited. Our [2026 Portland Flickr album](https://www.flickr.com/photos/writethedocs/albums/72177720333452248) has the full set of photos from the conference, thanks to our wonderful photographer [Kay](https://www.instagram.com/goatladykay/)!
+The initial conference photos are now available in our [Portland 2026 Flickr album](https://www.flickr.com/photos/writethedocs/albums/72177720333452248), thanks to our wonderful photographer [Kay](https://www.instagram.com/goatladykay/)! The fully edited set will be published over the next 1-2 weeks.
 
-We really love the photos each year, and you're welcome to use them for non-commercial purposes, such as conference write-ups, as per our [Creative Commons License](https://creativecommons.org/licenses/by-nc-sa/2.0/).
+You're welcome to use them for non-commercial purposes, such as conference write-ups, as per our [Creative Commons License](https://creativecommons.org/licenses/by-nc-sa/2.0/).
 
 ## Talk sketchnotes
 
@@ -55,14 +63,44 @@ We are happy to report that we received no Code of Conduct reports during the co
 
 Attendees can always report incidents, even after the conference, by emailing us at [conduct@writethedocs.org](mailto:conduct@writethedocs.org).
 
+## Join our Slack network
+
+Our Slack network is a great way to stay connected to the community beyond our conferences. We have channels for specific doc tools, meetups, career advice, and other areas of discussion.
+
+Check out the [Slack page](https://www.writethedocs.org/slack/) on our website for more information.
+
+## Join a local meetup
+
+Participating in your [local meetup](https://www.writethedocs.org/meetups/) is a great way to keep in touch with other documentarians. We have meetups in cities around the world.
+
 ## Come to our upcoming events
 
-We have another conference coming up later this year:
+We have more conferences coming up. Keep an eye on our conference pages and newsletter for announcements and dates:
 
-- [Berlin 2026](http://www.writethedocs.org/conf/berlin/2026/), September 6-8, **Berlin, Germany**
+- [Kenya 2026](https://www.meetup.com/wtd-kenya/events/314376384/), August 8
+- [Berlin 2026](https://www.writethedocs.org/conf/berlin/2026/), September 6-8
+- Australia 2026, December 3-4
 
-We hope to see you there!
+And for the first time ever, we have a date for our next Portland conference. Mark your calendars for **May 2-4, 2027** — back here at Revolution Hall.
 
 ## Thanks again
 
-The conference is possible only because folks like you make it a great experience. Thanks for making it another wonderful year. Whether you were able to come out this time or not, we hope to see you again next year—or even sooner at one of our other events!
+The conference is possible only because folks like you make it a great experience. Thanks for making it another wonderful year. We hope to see you back again next year, or even sooner at one of our other events!
+
+## Thanks to our sponsors
+
+Thanks so much to the sponsors who supported Write the Docs Portland 2026:
+
+- [Promptless](https://promptless.ai/?ref=writethedocs)
+- [Mintlify](https://mintlify.com/?utm_source=writethedocs&utm_medium=referral)
+- [ReadMe](https://readme.com/?ref=writethedocs)
+- [Stainless](https://www.stainless.com/?utm_source=write_the_docs&utm_medium=conference&utm_campaign=write_the_docs_2026)
+- [GitBook](https://www.gitbook.com/?ref=writethedocs)
+- [Fern](https://buildwithfern.com/?ref=writethedocs)
+- [MongoDB](https://www.mongodb.com/?ref=writethedocs)
+- [Expert Support](https://expertsupport.com/?ref=writethedocs)
+- [KnowledgeOwl](https://www.knowledgeowl.com?ref=writethedocs)
+- [HelpDocs](https://www.helpdocs.io/?utm_source=writethedocs&utm_medium=sponsor&utm_campaign=wtdp26)
+- [Google](https://opensource.google/?ref=writethedocs)
+- [GitHub](https://github.com/?ref=writethedocs)
+- [Read the Docs](https://about.readthedocs.com/?ref=writethedocs)

--- a/docs/conf/portland/2026/news/thanks-recap.md
+++ b/docs/conf/portland/2026/news/thanks-recap.md
@@ -38,7 +38,7 @@ You're welcome to use them for non-commercial purposes, such as conference write
 
 ## Talk sketchnotes
 
-Sketchnotes for the talks are now up on our [Flickr account](https://www.flickr.com/photos/writethedocs/). Thanks to our talented sketchnote artist [Dennis](https://dennissdawson.wixsite.com/mr--dawson/portfolio) for capturing the talks in such a creative way!
+Sketchnotes for the talks are now up in our [2026 Sketchnotes Flickr album](https://www.flickr.com/photos/writethedocs/albums/72177720333614185). Thanks to our talented sketchnote artist [Dennis](https://dennissdawson.wixsite.com/mr--dawson/portfolio) for capturing the talks in such a creative way!
 
 ## Code of Conduct transparency report
 

--- a/docs/conf/portland/2026/news/thanks-recap.md
+++ b/docs/conf/portland/2026/news/thanks-recap.md
@@ -27,7 +27,7 @@ We will continue to work on improving the conference experience for everyone, an
 
 Talk videos will be available soon. This will include all conference talks with Q&A, as well as the lightning talks. We'll share the [Portland 2026 playlist](https://www.youtube.com/c/WritetheDocs) link on our YouTube channel as soon as the videos are uploaded.
 
-Thanks again to all our presenters, emcees, and folks who asked wonderful questions!
+Thanks again to all our speakers, emcees, and folks who asked wonderful questions!
 
 ## Conference photos
 
@@ -51,7 +51,7 @@ To ensure that our CoC was visible and accessible, we took a number of specific 
 - We specifically stressed that the CoC applies to all conference spaces, including the social event.
 - We encouraged all attendees to report any incident, even if they were not sure whether it was a violation.
 
-We are happy to report that we received no Code of Conduct incidents during the conference.
+We are happy to report that we received no Code of Conduct reports during the conference.
 
 Attendees can always report incidents, even after the conference, by emailing us at [conduct@writethedocs.org](mailto:conduct@writethedocs.org).
 
@@ -59,7 +59,7 @@ Attendees can always report incidents, even after the conference, by emailing us
 
 We have another conference coming up later this year:
 
-- [Berlin 2026](http://www.writethedocs.org/conf/berlin/2026/), September 6-8, 2026, **Berlin, Germany**
+- [Berlin 2026](http://www.writethedocs.org/conf/berlin/2026/), September 6-8, **Berlin, Germany**
 
 We hope to see you there!
 

--- a/docs/conf/portland/2026/news/thanks-recap.md
+++ b/docs/conf/portland/2026/news/thanks-recap.md
@@ -1,6 +1,5 @@
 ---
 template: {{year}}/generic.html
-og:image: /_static/conf/images/headers/2026/unconference.jpg
 banner: _static/conf/images/headers/2026/unconference.jpg
 ---
 

--- a/docs/conf/portland/2026/news/thanks-recap.md
+++ b/docs/conf/portland/2026/news/thanks-recap.md
@@ -53,7 +53,7 @@ To ensure that our CoC was visible and accessible, we took a number of specific 
 - We specifically stressed that the CoC applies to all conference spaces, including the social event.
 - We encouraged all attendees to report any incident, even if they were not sure whether it was a violation.
 
-We are happy to report that we received no Code of Conduct reports during the conference.
+We are happy to say that we received no Code of Conduct reports during the conference.
 
 Attendees can always report incidents, even after the conference, by emailing us at [conduct@writethedocs.org](mailto:conduct@writethedocs.org).
 

--- a/docs/conf/portland/2026/news/thanks-recap.md
+++ b/docs/conf/portland/2026/news/thanks-recap.md
@@ -75,7 +75,7 @@ We have more conferences coming up. Keep an eye on our conference pages and news
 - [Berlin 2026](https://www.writethedocs.org/conf/berlin/2026/), September 6-8
 - Australia 2026, December 3-4
 
-And for the first time ever, we have a date for our next Portland conference. Mark your calendars for **May 2-4, 2027** — back here at Revolution Hall.
+And for the first time ever, we already have a date for our next Portland conference in this year's recap. Mark your calendars for **May 2-4, 2027** — back here at Revolution Hall.
 
 ## Thanks again
 


### PR DESCRIPTION
Adds the post-conference recap blog post for Portland 2026.

- 400+ in-person, 175+ virtual attendees
- Photos from Kay (linked to the new Flickr album)
- Sketchnotes from Dennis (album link to be added once published)
- No CoC incidents reported
- Upcoming events list trimmed to Berlin 2026

Banner currently uses an existing 2026 header image; swap to a `pics/2026/recap-2026.jpg` once that's added. Talk videos section is phrased as "coming soon" — update with the playlist URL when uploaded.

Pairs with #2685 (post-conf flag flip).

---
*Generated by AI*


<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2686.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->