### PR TITLE
docs: Add command palette for page navigation

### DIFF
--- a/docs/_static/css/command-palette.css
+++ b/docs/_static/css/command-palette.css
@@ -1,0 +1,145 @@
+/* Command palette (Cmd+K / Ctrl+K) */
+
+.wtd-cmdk-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(20, 24, 30, 0.55);
+    z-index: 9999;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 10vh 16px 16px;
+}
+
+.wtd-cmdk-overlay[hidden] {
+    display: none;
+}
+
+html.wtd-cmdk-open {
+    overflow: hidden;
+}
+
+.wtd-cmdk-panel {
+    width: 100%;
+    max-width: 640px;
+    background: #fff;
+    border-radius: 8px;
+    box-shadow: 0 24px 64px rgba(0, 0, 0, 0.35);
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+    max-height: 70vh;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+.wtd-cmdk-input {
+    border: 0;
+    outline: 0;
+    padding: 16px 18px;
+    font-size: 16px;
+    width: 100%;
+    box-sizing: border-box;
+    border-bottom: 1px solid #e5e7eb;
+    background: #fff;
+    color: #111827;
+}
+
+.wtd-cmdk-input::placeholder {
+    color: #9ca3af;
+}
+
+.wtd-cmdk-list {
+    list-style: none;
+    margin: 0;
+    padding: 6px 0;
+    overflow-y: auto;
+    flex: 1 1 auto;
+}
+
+.wtd-cmdk-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 8px 16px;
+    cursor: pointer;
+    color: #1f2937;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.wtd-cmdk-item.is-active {
+    background: #eef2ff;
+    color: #1e3a8a;
+}
+
+.wtd-cmdk-level {
+    flex: 0 0 auto;
+    font-size: 10px;
+    font-weight: 600;
+    color: #6b7280;
+    background: #f3f4f6;
+    border-radius: 3px;
+    padding: 2px 6px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    min-width: 26px;
+    text-align: center;
+}
+
+.wtd-cmdk-item.is-active .wtd-cmdk-level {
+    background: #c7d2fe;
+    color: #1e3a8a;
+}
+
+.wtd-cmdk-label {
+    flex: 1 1 auto;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.wtd-cmdk-level-2 .wtd-cmdk-label { padding-left: 4px; }
+.wtd-cmdk-level-3 .wtd-cmdk-label { padding-left: 18px; }
+.wtd-cmdk-level-4 .wtd-cmdk-label { padding-left: 32px; }
+.wtd-cmdk-level-5 .wtd-cmdk-label { padding-left: 46px; }
+.wtd-cmdk-level-6 .wtd-cmdk-label { padding-left: 60px; }
+
+.wtd-cmdk-empty {
+    padding: 16px;
+    color: #6b7280;
+    text-align: center;
+    font-size: 14px;
+}
+
+.wtd-cmdk-hint {
+    display: flex;
+    gap: 14px;
+    flex-wrap: wrap;
+    padding: 8px 16px;
+    border-top: 1px solid #e5e7eb;
+    background: #f9fafb;
+    font-size: 12px;
+    color: #6b7280;
+}
+
+.wtd-cmdk-hint kbd {
+    display: inline-block;
+    background: #fff;
+    border: 1px solid #d1d5db;
+    border-bottom-width: 2px;
+    border-radius: 3px;
+    padding: 1px 5px;
+    margin: 0 2px;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 11px;
+    color: #374151;
+}
+
+@media (max-width: 600px) {
+    .wtd-cmdk-overlay {
+        padding: 6vh 8px 8px;
+    }
+    .wtd-cmdk-panel {
+        max-height: 85vh;
+    }
+}

--- a/docs/_static/js/command-palette.js
+++ b/docs/_static/js/command-palette.js
@@ -1,0 +1,261 @@
+// Command palette: Cmd+K / Ctrl+K opens a modal listing the current page's
+// headings so visitors can jump straight to a section.
+(function () {
+    "use strict";
+
+    var overlay = null;
+    var input = null;
+    var list = null;
+    var items = [];      // {el, text, level, id, anchorText}
+    var matches = [];    // currently visible matches
+    var activeIndex = 0;
+
+    function collectHeadings() {
+        var headings = document.querySelectorAll(
+            ".body h1[id], .body h2[id], .body h3[id], .body h4[id], .body h5[id], .body h6[id]"
+        );
+        var collected = [];
+        for (var i = 0; i < headings.length; i++) {
+            var h = headings[i];
+            // Strip Sphinx's pilcrow permalink so the heading text is clean.
+            var clone = h.cloneNode(true);
+            var perma = clone.querySelector("a.headerlink");
+            if (perma) {
+                perma.parentNode.removeChild(perma);
+            }
+            var text = clone.textContent.replace(/\s+/g, " ").trim();
+            if (!text) continue;
+            collected.push({
+                el: h,
+                text: text,
+                level: parseInt(h.tagName.substring(1), 10),
+                id: h.id
+            });
+        }
+        return collected;
+    }
+
+    function buildOverlay() {
+        overlay = document.createElement("div");
+        overlay.className = "wtd-cmdk-overlay";
+        overlay.setAttribute("role", "dialog");
+        overlay.setAttribute("aria-modal", "true");
+        overlay.setAttribute("aria-label", "Jump to section");
+        overlay.hidden = true;
+
+        var panel = document.createElement("div");
+        panel.className = "wtd-cmdk-panel";
+
+        input = document.createElement("input");
+        input.type = "text";
+        input.className = "wtd-cmdk-input";
+        input.setAttribute("placeholder", "Jump to a section on this page…");
+        input.setAttribute("aria-label", "Filter headings");
+        input.setAttribute("autocomplete", "off");
+        input.setAttribute("spellcheck", "false");
+
+        list = document.createElement("ul");
+        list.className = "wtd-cmdk-list";
+        list.setAttribute("role", "listbox");
+
+        var hint = document.createElement("div");
+        hint.className = "wtd-cmdk-hint";
+        hint.innerHTML =
+            '<span><kbd>↑</kbd><kbd>↓</kbd> navigate</span>' +
+            '<span><kbd>↵</kbd> jump</span>' +
+            '<span><kbd>Esc</kbd> close</span>';
+
+        panel.appendChild(input);
+        panel.appendChild(list);
+        panel.appendChild(hint);
+        overlay.appendChild(panel);
+
+        overlay.addEventListener("click", function (e) {
+            if (e.target === overlay) close();
+        });
+
+        input.addEventListener("input", function () {
+            render(input.value);
+        });
+
+        input.addEventListener("keydown", function (e) {
+            if (e.key === "ArrowDown") {
+                e.preventDefault();
+                move(1);
+            } else if (e.key === "ArrowUp") {
+                e.preventDefault();
+                move(-1);
+            } else if (e.key === "Enter") {
+                e.preventDefault();
+                select(activeIndex);
+            } else if (e.key === "Escape") {
+                e.preventDefault();
+                close();
+            }
+        });
+
+        document.body.appendChild(overlay);
+    }
+
+    function matchScore(text, query) {
+        // Returns -1 for no match, otherwise a lower score = better match.
+        // Prefer prefix matches, then word-start matches, then substring.
+        var lower = text.toLowerCase();
+        var q = query.toLowerCase();
+        if (!q) return 0;
+        if (lower.indexOf(q) === 0) return 0;
+        if (lower.indexOf(" " + q) !== -1) return 1;
+        var idx = lower.indexOf(q);
+        if (idx !== -1) return 2 + idx / 100;
+        // Loose subsequence match for fuzzy typing.
+        var ti = 0;
+        for (var i = 0; i < q.length; i++) {
+            ti = lower.indexOf(q.charAt(i), ti);
+            if (ti === -1) return -1;
+            ti++;
+        }
+        return 100;
+    }
+
+    function render(query) {
+        list.innerHTML = "";
+        query = (query || "").trim();
+        var scored = [];
+        for (var i = 0; i < items.length; i++) {
+            var s = matchScore(items[i].text, query);
+            if (s !== -1) scored.push({ item: items[i], score: s });
+        }
+        if (query) {
+            scored.sort(function (a, b) { return a.score - b.score; });
+        }
+        matches = scored.map(function (x) { return x.item; });
+        activeIndex = 0;
+
+        if (matches.length === 0) {
+            var empty = document.createElement("li");
+            empty.className = "wtd-cmdk-empty";
+            empty.textContent = "No headings match.";
+            list.appendChild(empty);
+            return;
+        }
+
+        for (var j = 0; j < matches.length; j++) {
+            var m = matches[j];
+            var li = document.createElement("li");
+            li.className = "wtd-cmdk-item wtd-cmdk-level-" + m.level;
+            li.setAttribute("role", "option");
+            li.dataset.index = String(j);
+
+            var level = document.createElement("span");
+            level.className = "wtd-cmdk-level";
+            level.textContent = "H" + m.level;
+
+            var label = document.createElement("span");
+            label.className = "wtd-cmdk-label";
+            label.textContent = m.text;
+
+            li.appendChild(level);
+            li.appendChild(label);
+
+            li.addEventListener("mouseenter", function (e) {
+                setActive(parseInt(e.currentTarget.dataset.index, 10));
+            });
+            li.addEventListener("click", function (e) {
+                select(parseInt(e.currentTarget.dataset.index, 10));
+            });
+            list.appendChild(li);
+        }
+        setActive(0);
+    }
+
+    function setActive(idx) {
+        if (matches.length === 0) return;
+        if (idx < 0) idx = matches.length - 1;
+        if (idx >= matches.length) idx = 0;
+        activeIndex = idx;
+        var children = list.querySelectorAll(".wtd-cmdk-item");
+        for (var i = 0; i < children.length; i++) {
+            if (i === idx) {
+                children[i].classList.add("is-active");
+                children[i].setAttribute("aria-selected", "true");
+                scrollIntoViewIfNeeded(children[i]);
+            } else {
+                children[i].classList.remove("is-active");
+                children[i].setAttribute("aria-selected", "false");
+            }
+        }
+    }
+
+    function scrollIntoViewIfNeeded(el) {
+        var parent = el.parentNode;
+        var top = el.offsetTop;
+        var bottom = top + el.offsetHeight;
+        if (top < parent.scrollTop) {
+            parent.scrollTop = top;
+        } else if (bottom > parent.scrollTop + parent.clientHeight) {
+            parent.scrollTop = bottom - parent.clientHeight;
+        }
+    }
+
+    function move(delta) {
+        setActive(activeIndex + delta);
+    }
+
+    function select(idx) {
+        var target = matches[idx];
+        if (!target) return;
+        close();
+        // Update the URL and scroll to the heading.
+        history.pushState(null, "", "#" + target.id);
+        target.el.scrollIntoView({ behavior: "smooth", block: "start" });
+        // Briefly focus the heading for screen readers.
+        var prevTabIndex = target.el.getAttribute("tabindex");
+        target.el.setAttribute("tabindex", "-1");
+        target.el.focus({ preventScroll: true });
+        if (prevTabIndex === null) {
+            setTimeout(function () { target.el.removeAttribute("tabindex"); }, 1000);
+        }
+    }
+
+    function open() {
+        if (!overlay) buildOverlay();
+        items = collectHeadings();
+        if (items.length === 0) return;
+        overlay.hidden = false;
+        document.documentElement.classList.add("wtd-cmdk-open");
+        input.value = "";
+        render("");
+        // Focus on the next tick so the keystroke that opened us isn't typed in.
+        setTimeout(function () { input.focus(); }, 0);
+    }
+
+    function close() {
+        if (!overlay || overlay.hidden) return;
+        overlay.hidden = true;
+        document.documentElement.classList.remove("wtd-cmdk-open");
+    }
+
+    function isTypingTarget(el) {
+        if (!el) return false;
+        var tag = el.tagName;
+        return tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT" || el.isContentEditable;
+    }
+
+    document.addEventListener("keydown", function (e) {
+        if ((e.key === "k" || e.key === "K") && (e.metaKey || e.ctrlKey)) {
+            // Don't hijack browser search or other text inputs.
+            e.preventDefault();
+            if (overlay && !overlay.hidden) {
+                close();
+            } else {
+                open();
+            }
+            return;
+        }
+        if (e.key === "/" && !isTypingTarget(document.activeElement)) {
+            // Slash is a common shortcut on doc sites — bind it too.
+            e.preventDefault();
+            open();
+        }
+    });
+})();

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -284,5 +284,7 @@ def setup(app):
     app.add_directive('button-link', ButtonLink)
     app.add_css_file('css/global-customizations.css')
     app.add_css_file('css/survey.css')
+    app.add_css_file('css/command-palette.css')
+    app.add_js_file('js/command-palette.js')
 
     app.config.wtd_cache = {}


### PR DESCRIPTION
Adds a command palette feature that allows visitors to quickly jump to sections on a page using Cmd+K / Ctrl+K (or / on non-input elements).

## Changes

- **New JavaScript module** (`docs/_static/js/command-palette.js`): Implements a modal dialog that collects all headings from the current page and provides fuzzy search filtering. Users can navigate with arrow keys, select with Enter, and close with Escape. The palette intelligently scores matches (preferring prefix matches, then word-start matches, then substrings, with loose subsequence matching for fuzzy typing).

- **New stylesheet** (`docs/_static/css/command-palette.css`): Styles the command palette overlay, panel, input field, list items, and hint text. Includes responsive design for mobile devices and visual feedback for active/hovered items. Heading levels are visually indicated with indentation.

- **Configuration update** (`docs/conf.py`): Registers the new CSS and JavaScript files to be included in all documentation pages.

## Implementation Details

- The palette collects headings with IDs from the `.body` element, stripping Sphinx's pilcrow permalinks for clean display
- Smooth scrolling to selected headings with URL history updates
- Accessibility features: ARIA labels, listbox role, screen reader focus management
- Keyboard shortcuts: Cmd+K / Ctrl+K to toggle, / to open (when not in a text input)
- Responsive design with adjusted viewport padding and max-height on mobile

---
*Generated by AI*

https://claude.ai/code/session_01FTYJJRrNVWdABkVp4UUwkT

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2694.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->