### PR TITLE
templates: stack 2026 sponsors vertically in footer

### DIFF
--- a/docs/_templates/2026/sponsors-in-kind.html
+++ b/docs/_templates/2026/sponsors-in-kind.html
@@ -3,7 +3,7 @@
 
   <div class="community-sponsors">
     {% for sponsor in sponsors.in_kind %}
-    <div class="uk-width-1-2@s">
+    <div class="uk-width-1-1 uk-width-1-1@s">
       <a href="{{ sponsor.link }}">
         <img src={{ sponsor.name|sponsor_photo }} style="max-width: {{ sponsor.width|default("150px", true) }};" />
       </a>

--- a/docs/_templates/2026/sponsors-media.html
+++ b/docs/_templates/2026/sponsors-media.html
@@ -2,7 +2,7 @@
 <div class="sponsors">
   <div class="community-sponsors">
     {% for sponsor in sponsors.media %}
-    <div class="uk-width-1-2@s">
+    <div class="uk-width-1-1 uk-width-1-1@s">
       <a href="{{ sponsor.link }}">
         <img src={{ sponsor.name|sponsor_photo }} style="max-width: {{ sponsor.width|default("150px", true) }};" />
       </a>

--- a/docs/_templates/2026/sponsors.html
+++ b/docs/_templates/2026/sponsors.html
@@ -65,11 +65,7 @@
   {% if sponsors.second %}
   <div class="bronze-sponsors">
     {% for sponsor in sponsors.second %}
-    {% if include_text %}
     <div class="uk-width-1-1 uk-width-1-1@s" id="{{ sponsor.name }}">
-      {% else %}
-    <div class="uk-width-1-1 uk-width-1-2@s" id="{{ sponsor.name }}">
-    {% endif %}
       <a href="{{ sponsor.link }}">
         <img src={{ sponsor.name|sponsor_photo }} style="width: {{ sponsor.width|default("200px", true) }};" />
       </a>
@@ -86,7 +82,7 @@
   {% if sponsors.first %}
   <div class="community-sponsors">
     {% for sponsor in sponsors.first %}
-    <div class="uk-width-1-1 uk-width-1-2@s">
+    <div class="uk-width-1-1 uk-width-1-1@s">
       <a href="{{ sponsor.link }}">
         <img src={{ sponsor.name|sponsor_photo }} style="max-width: {{ sponsor.width|default("150px", true) }};" />
       </a>


### PR DESCRIPTION
## Summary

Display all 2026 sponsor tiers as a single column in the base template footer (and on the sponsor-list includes), instead of two-up on small screens. 

🤖 Generated with AI

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2695.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->