### PR TITLE
Replace line feeds

### DIFF
--- a/docs/_data/2019.australia.speakers.yaml
+++ b/docs/_data/2019.australia.speakers.yaml
@@ -73,24 +73,24 @@
 - abstract: '<p>A few years ago the designers in my team started enthusiastically
     migrating over to a new design tool (Sketch). It looked like a fun tool, so I
     decided to learn it. Fast forward a few years and I couldn''t write for my app
-    without it. </p>
+    without it.</p>
 
     <p>In this talk I''ll cover three things:</p>
 
     <ul>
 
     <li>Co-design - go beyond being a service provider to being full participant in
-    the design process </li>
+    the design process</li>
 
     <li>Journeys - deliver better experiences for your users by writing in context</li>
 
     <li>Skilling up - how to leverage what you''ve learned to also create gorgeous
-    visual assets for your docs. </li>
+    visual assets for your docs.</li>
 
     </ul>
 
     <p>My experience is with Sketch, but my tips apply to most vector tools (including
-    Figma, Illustrator, etc). </p>'
+    Figma, Illustrator, etc).</p>'
   slug: supercharge-your-writing-process-with-a-designers-toolkit-rachel-robins
   speakers:
   - name: Rachel Robins

--- a/docs/_data/prague-2020-sessions.yaml
+++ b/docs/_data/prague-2020-sessions.yaml
@@ -189,7 +189,7 @@
 
     <p>Feeling inspired, hungry, or both? Let''s head to the content kitchen and create
     something spectacular.</p>'
-- title: Organizing a Confluence hoard, or, does this page spark joy?
+- title: Organizing a Confluence hoard, or, does this page spark joy?
   slug: organizing-a-confluence-hoard-or-does-this-page-spark-joy-abigail-sutherland
   series: Write the Docs Prague
   series_slug: prague
@@ -206,13 +206,13 @@
     what else would you call us?</p>
 
 
-    <p>True, you can''t just blame the current team. The average page was 3 1/2 years
-    old, and the oldest almost a teenager. A quarter of the pages had last been updated
+    <p>True, you can''t just blame the current team. The average page was 3 1/2 years
+    old, and the oldest almost a teenager. A quarter of the pages had last been updated
     by people no longer with the company, and nearly a third of them hadn''t even
     been looked at for more than a year.</p>
 
 
-    <p>But even if we''d inherited the problem, it was ours now. Or, more precisely,
+    <p>But even if we''d inherited the problem, it was ours now. Or, more precisely,
     <em>mine</em>.
 
     <p>What we needed was a Confluence space that&mdash;unlike the current installation&mdash;was:
@@ -225,7 +225,7 @@
 
     <li>Populated with relevant content</li></ul></p>
 
-    <p>Like Mari Kondo, the popular organization consultant, I''ve been bringing order
+    <p>Like Mari Kondo, the popular organization consultant, I''ve been bringing order
     to our informational hoarding house since autumn. In this talk, I''ll discuss
     the information architecture thinking behind every step of the process. Not just
     what I did, but why, what user needs I was serving, and how. I''ll discuss the

--- a/docs/_data/prague-2022-sessions.yaml
+++ b/docs/_data/prague-2022-sessions.yaml
@@ -163,7 +163,7 @@
     can tell stories, attract people, and inspire venture capitalists to invest. When
     done right, the reward is massive, and Africa is no exception. </p>
 
-    <p>But why aren''t African startups doing more of this? The African tech ecosystem is
+    <p>But why aren''t African startups doing more of this? The African tech ecosystem is
     rocketing, and venture capitalists are taking notice. Could it be a short-sighted
     view? Time constraints and money? Or is it the uniqueness of the African audience?</p>
 

--- a/docs/blog/newsletter-august-2017.rst
+++ b/docs/blog/newsletter-august-2017.rst
@@ -90,7 +90,7 @@ August 28 – Boise, ID, USA – `Networking Night! <https://www.meetup.com/Writ
 
 August 29 – Brisbane, QLD, Australia – `Content 101 + How Tech Writers Can Help Make Designs Safe <https://www.meetup.com/Write-the-Docs-Australia/events/241104250/>`_
 
-August 29 – Hamburg, Germany – `Let's talk about translations <https://www.meetup.com/Write-the-Docs-Hamburg/events/241950745/>`_
+August 29 – Hamburg, Germany – `Let's talk about translations <https://www.meetup.com/Write-the-Docs-Hamburg/events/241950745/>`_
 
 September 7 – Salt Lake City, UT, USA `Coffee Klatch
 <https://www.meetup.com/Write-the-Docs-SLC/events/242232142/>`_

--- a/docs/blog/newsletter-august-2018.rst
+++ b/docs/blog/newsletter-august-2018.rst
@@ -82,7 +82,7 @@ Featured job postings
 Upcoming community events
 -------------------------
 
-August 22 – Boise, Idaho, USA – `Lightning Talks from the Confab Conference <https://www.meetup.com/Write-the-Docs-Boise/events/253170161/>`_
+August 22 – Boise, Idaho, USA – `Lightning Talks from the Confab Conference <https://www.meetup.com/Write-the-Docs-Boise/events/253170161/>`_
 
 August 22 – Moscow, Russia – `документация и управление знаниями <https://www.meetup.com/Write-the-Docs-Moscow/events/253748999/>`_
 
@@ -94,7 +94,7 @@ August 28 – Brisbane, Australia – `From Writing to Product and Back Again <h
 
 September 7 – Bangalore, India – `First Meetup: Meet & Greet <https://www.meetup.com/Write-the-Docs-India/events/253159769/>`_
 
-September 11 – Portland, Oregon, USA – `Joint meetup with the Portland Accessibility and User Experience group <https://www.meetup.com/Write-The-Docs-PDX/events/253790717/>`_
+September 11 – Portland, Oregon, USA – `Joint meetup with the Portland Accessibility and User Experience group <https://www.meetup.com/Write-The-Docs-PDX/events/253790717/>`_
 
 September 11 – Ottawa, Ontario, Canada – `Monthly meetup at Shopify <https://www.meetup.com/Write-The-Docs-YOW-Ottawa/events/253846497/>`_
 

--- a/docs/blog/newsletter-december-2017.rst
+++ b/docs/blog/newsletter-december-2017.rst
@@ -9,7 +9,7 @@ Write the Docs Newsletter – December 2017
 Hi everybody! Kelly O. here, with our last issue of 2017! It's been a gigantic year for the Write the Docs community. Just in the last month, our members have gotten up to some amazing stuff, including:
 
 * A very successful first Australian event! To catch up on how it went, `watch the videos <https://www.youtube.com/channel/UCPhWNEFb53x6PjnpRIYf1yg/videos>`_ or `read all about it <https://ffeathers.wordpress.com/2017/11/25/doc-sprint-at-write-the-docs-day-australia/>`_.
-* A lively and informative third API the Docs event in Amsterdam – `check out the recaps! <https://pronovix.com/api-docs-amsterdam-2017>`_.
+* A lively and informative third API the Docs event in Amsterdam – `check out the recaps! <https://pronovix.com/api-docs-amsterdam-2017>`_.
 * And two new podcast episodes, `one focused on the Mozilla Developer Network's Web Docs Project <http://bit.ly/wtdpodcastepisode11>`_ and `the other featuring an interview with WTD organizers Eric Holscher and Mikey Ariel as guests  <http://podcast.writethedocs.org/2017/12/13/founding-principles-of-write-the-docs/>`_!
 
 Not only are we ending the year on a high note, but we also have a TON of great stuff coming up in 2018 as well!

--- a/docs/blog/newsletter-february-2017.rst
+++ b/docs/blog/newsletter-february-2017.rst
@@ -36,7 +36,7 @@ Getting started with API Docs
 * `Write the Docs Guide: API Docs <https://www.writethedocs.org/guide/#api-documentation>`_
 * `8 Great Examples of Developer Documentation <https://zapier.com/engineering/great-documentation-examples/>`_
 
-If API docs are already your jam, head over to the API channel – we'd love to hear about your favorite resources!
+If API docs are already your jam, head over to the API channel – we'd love to hear about your favorite resources!
 
 Pros and cons of using tabbed content for multiple audiences
 ------------------------------------------------------------

--- a/docs/blog/newsletter-february-2018.rst
+++ b/docs/blog/newsletter-february-2018.rst
@@ -6,7 +6,7 @@
 Write the Docs Newsletter – February 2018
 #########################################
 
-Hi everybody! Kelly O. here – back in the saddle after getting through the whole *OMG, it's a different year now* transition.
+Hi everybody! Kelly O. here – back in the saddle after getting through the whole *OMG, it's a different year now* transition.
 I'm excited to report that we have a TON of stuff happening in the community.
 I guess we're starting this new year off strong!
 
@@ -23,9 +23,9 @@ you might be interested in our new `Convince Your Manager <https://www.writethed
 We've knocked together an example email and some resources that you can use to make your case.
 
 And finally, in non-conference news, we're thrilled to announce that the **Write the Docs Job Board** will be launching next week.
-One of the benefits of the WTD community has always been its ability to connect documentarians with employers
+One of the benefits of the WTD community has always been its ability to connect documentarians with employers
 who understand the value of good docs. The job board will be a destination for making those connections.
-Keep an eye on Slack, Twitter, the forum, your email, etc. – we'll let you know as soon as it goes live.
+Keep an eye on Slack, Twitter, the forum, your email, etc. – we'll let you know as soon as it goes live.
 
 Whew! Told you there's a lot going on! But now, let's have a look at a few of the conversations that have been happening
 in `Slackland <https://www.writethedocs.org/slack/>`_ over the new year.

--- a/docs/blog/newsletter-july-2017.rst
+++ b/docs/blog/newsletter-july-2017.rst
@@ -79,8 +79,8 @@ Make sure you `get your tickets soon <https://www.writethedocs.org/conf/eu/2017/
 Upcoming Meetups
 ----------------
 
-* **Today!** July 11 – Portland, OR, USA – `History of the New Relic Documentation Site, Part One <https://www.meetup.com/Write-The-Docs-PDX/events/240771894/>`_
-* July 12 – Cambridge, UK – `Finding the right work to do: Lessons learnt from a year at a startup <https://www.meetup.com/Write-The-Docs-Cambridge/events/240634929/>`_
+* **Today!** July 11 – Portland, OR, USA – `History of the New Relic Documentation Site, Part One <https://www.meetup.com/Write-The-Docs-PDX/events/240771894/>`_
+* July 12 – Cambridge, UK – `Finding the right work to do: Lessons learnt from a year at a startup <https://www.meetup.com/Write-The-Docs-Cambridge/events/240634929/>`_
 * July 19 – Broomfield, CO – `Building navigation for your doc site: 5 best practices <https://www.meetup.com/Write-the-Docs-Boulder-Denver/events/241431528/>`_
 
 Thanks to all our wonderful organizers who are putting these events together!

--- a/docs/blog/newsletter-june-2018.rst
+++ b/docs/blog/newsletter-june-2018.rst
@@ -102,11 +102,11 @@ June 14 – Salt Lake City, UT, USA – `Writing the Docs for Multiple Projects 
 
 June 19 – Austin, TX, USA – `Panel Discussion: Navigating Career Paths <https://www.meetup.com/WriteTheDocs-ATX-Meetup/events/249817330/>`_
 
-June 21 – Boise, ID, USA – `Write the Docs Conference Rundown <https://www.meetup.com/Write-the-Docs-Boise/events/249633985/>`_
+June 21 – Boise, ID, USA – `Write the Docs Conference Rundown <https://www.meetup.com/Write-the-Docs-Boise/events/249633985/>`_
 
 June 26 – Ottawa, ON, Canada – `Auditing documentation | Developing Shopify's API docs style guide <https://www.meetup.com/Write-The-Docs-YOW-Ottawa/events/250880001/>`_
 
-June 26 – San Francisco, CA, USA – `The Developer Experience for APIs <https://www.meetup.com/Write-the-Docs-SF/events/251444527/>`_
+June 26 – San Francisco, CA, USA – `The Developer Experience for APIs <https://www.meetup.com/Write-the-Docs-SF/events/251444527/>`_
 
 June 27 – Brisbane, Australia – `Facebook, Dynamite, Uber, Bombs, and Tech Writers: A quick historical excursion through ethics and documentation <https://www.meetup.com/Write-the-Docs-Australia/events/250630480/>`_
 

--- a/docs/blog/newsletter-march-2018.rst
+++ b/docs/blog/newsletter-march-2018.rst
@@ -73,25 +73,25 @@ Featured job postings
 Upcoming community events
 -------------------------
 
-*New meetup* March 14 – Herzliya, Israel – `Kickoff meeting <https://www.meetup.com/Write-The-Docs-Herzliya/events/248189800/>`_
+*New meetup* March 14 – Herzliya, Israel – `Kickoff meeting <https://www.meetup.com/Write-The-Docs-Herzliya/events/248189800/>`_
 
 March 14 – Leeds, UK – `SEO Optimisation for a New Jekyll Install <https://www.meetup.com/Write-the-Docs-Leeds-Bradford/events/247184981/>`_
 
 *New meetup* March 14 – Köln, Germany – `First meetup <https://www.meetup.com/WTD-Rhineland/events/248194015/>`_
 
-March 15 – San Fransisco (East Bay), California, USA – `Hands-On Demo: How Do I Get into Open Source Projects? <https://www.meetup.com/Write-the-Docs-SF/events/248482881/>`_
+March 15 – San Fransisco (East Bay), California, USA – `Hands-On Demo: How Do I Get into Open Source Projects? <https://www.meetup.com/Write-the-Docs-SF/events/248482881/>`_
 
 March 18 – Novosibirsk, Siberia, Russia – `Confluence: От первых шагов до основного инструмента разработки документации <https://www.meetup.com/Write-the-Docs-Siberia/events/248458984/>`_
 
-March 19 – Amsterdam, Netherlands – `March Meetup <https://www.meetup.com/Write-The-Docs-Amsterdam/events/248478377/>`_
+March 19 – Amsterdam, Netherlands – `March Meetup <https://www.meetup.com/Write-The-Docs-Amsterdam/events/248478377/>`_
 
 March 19 – Berlin, Germany – `Mixing things up: Playing with form in technical writing <https://www.meetup.com/Write-The-Docs-Berlin/events/248465625/>`_
 
-March 20 – Fredericton, New Brunswick, Canada – March Lunch Meetup
+March 20 – Fredericton, New Brunswick, Canada – March Lunch Meetup
 
 March 21 – Perth, Western Australia – `Moving from Word to the Web | Contributing to open source docs <https://www.meetup.com/Write-the-Docs-Australia/events/246830725/>`_
 
-March 22 – Boise, Idaho, USA – `First meetup of 2018 <https://www.meetup.com/Write-the-Docs-Boise/events/246900941/>`_
+March 22 – Boise, Idaho, USA – `First meetup of 2018 <https://www.meetup.com/Write-the-Docs-Boise/events/246900941/>`_
 
 March 27 – Boston, Massachusetts, USA – `Moving Docs to Sphinx <https://www.meetup.com/Write-the-Docs-BOS/events/247849315/>`_
 

--- a/docs/blog/newsletter-may-2017.rst
+++ b/docs/blog/newsletter-may-2017.rst
@@ -126,7 +126,7 @@ Did we mention that `Write the Docs Prague <https://www.writethedocs.org/conf/eu
 If you see a discussion in the WTD Slack channels that you'd like to see highlighted here in the WTD newsletter, there's a new tool for that! We're now using the `Reacji Channeler <https://reacji-channeler.builtbyslack.com>`_. If you see a helpful or enjoyable discussion and think it would make a good item in the newsletter, just tag one of the messages with the `newsletter` emoji:
 
 .. image:: news.png
-    :width: 128px
+    :width: 128px
     :align: left
     :height: 128px
     :alt: emoji for tagging newsletter suggestions

--- a/docs/blog/newsletter-may-2018.rst
+++ b/docs/blog/newsletter-may-2018.rst
@@ -107,7 +107,7 @@ May 22 – Budapest, Hungary – `Github: Why it will change the world of techni
 
 May 24 – Los Angeles, CA, USA – `Documenting APIs, the Symantec way! <https://www.meetup.com/Write-the-Docs-LA/events/249946913/>`_
 
-May 28 – Amsterdam, Netherlands – `May meetup <https://www.meetup.com/Write-The-Docs-Amsterdam/events/249028095/>`_
+May 28 – Amsterdam, Netherlands – `May meetup <https://www.meetup.com/Write-The-Docs-Amsterdam/events/249028095/>`_
 
 May 31 – Brussels, Belgium – `Process first! <https://www.meetup.com/Write-The-Docs-Brussels/events/250299512/>`_
 

--- a/docs/blog/newsletter-november-2017.rst
+++ b/docs/blog/newsletter-november-2017.rst
@@ -28,7 +28,7 @@ Some other image tips that came up included:
 
 * Crop your screenshots to highlight only the specific area of interface you're documenting.
 * Keep all of your image files in a single, separate location. If possible, use version control.
-* Develop – and stick to – a standard for producing screenshots: size, tool, resolution, file type, etc.
+* Develop – and stick to – a standard for producing screenshots: size, tool, resolution, file type, etc.
 * Triage your updates. Prioritize functional UI changes over changes in button color, for example.
 
 **************************
@@ -107,10 +107,10 @@ November 15 - Los Angeles, CA, USA – `Happy Hour/Social Meetup <https://www.me
 
 November 16 – Boston, MA, USA – `Challenges in Large Doc Sets <https://www.meetup.com/Write-the-Docs-BOS/events/244174338/>`_
 
-November 24 – Melbourne, Australia – `Write the Docs Day Australia: One-day mini-conference <https://www.writethedocs.org/conf/au/2017/>`_
+November 24 – Melbourne, Australia – `Write the Docs Day Australia: One-day mini-conference <https://www.writethedocs.org/conf/au/2017/>`_
 
-November 27 – Berlin, Germany – `November Hackup <https://www.meetup.com/Write-The-Docs-Berlin/events/244348754/>`_
+November 27 – Berlin, Germany – `November Hackup <https://www.meetup.com/Write-The-Docs-Berlin/events/244348754/>`_
 
-November 29 – Leeds-Bradford, UK – `Social meetup: Burgers & Chat <https://www.meetup.com/Write-the-Docs-Leeds-Bradford/events/244243638/>`_
+November 29 – Leeds-Bradford, UK – `Social meetup: Burgers & Chat <https://www.meetup.com/Write-the-Docs-Leeds-Bradford/events/244243638/>`_
 
 December 4 – Amsterdam, Netherlands – `API The Docs mini-conference <http://apithedocs.org/>`_

--- a/docs/blog/newsletter-october-2017.rst
+++ b/docs/blog/newsletter-october-2017.rst
@@ -57,7 +57,7 @@ This month, someone asked a question which many of us have wondered about, at on
 The ensuing conversation made it clear that whether you call it developer relations (DevRel), developer evangelism, or developer advocacy, it can mean a lot of different things. But some common themes emerged:
 
 * Folks in these roles are generally expected to be the "face" of their developer community. Their work involves making their product/language/framework/etc. more visible and more approachable.
-* Often they sit at an overlap point between engineering – since they're (ideally) experts in the tool they're representing – and sales, marketing, documentation, etc.
+* Often they sit at an overlap point between engineering – since they're (ideally) experts in the tool they're representing – and sales, marketing, documentation, etc.
 * The line between "evangelist" and "advocate" gets blurry. Often, though, the evangelist side is about bringing the product out to the community, while the advocate side focuses on bringing the community's voice back to the product team.
 * Although these roles may have gotten their start in the open source community, they're becoming increasingly common across the industry.
 
@@ -73,9 +73,9 @@ We're so excited to be coming up on our first official Australian event! If you'
 * **Tomorrow!** October 10 – Portland, OR, USA – `Confluence Docs With Node.js, Intro to the PSU Tech Writing Program <https://www.meetup.com/Write-The-Docs-PDX/events/242228205/>`_
 * **Also Tomorrow!** October 10 – Seattle, WA, USA – `WTD Seattle October Meetup <https://www.meetup.com/Write-The-Docs-Seattle/events/243392623/>`_
 * October 11 – Brisbane, QLD, Australia – `Peanuts and Minimalism and Technical Writing <https://www.meetup.com/Write-the-Docs-Australia/events/243038647/>`_
-* October 12 – Leeds, UK – `Social: First Meetup <https://www.meetup.com/Write-the-Docs-Leeds-Bradford/events/242556120/>`_
+* October 12 – Leeds, UK – `Social: First Meetup <https://www.meetup.com/Write-the-Docs-Leeds-Bradford/events/242556120/>`_
 * October 12 – San Francisco, CA, USA – `Lightning Talks! <https://www.meetup.com/Write-the-Docs-SF/events/243528992/>`_
 * October 14 – Fredericton, NB, Canada – Technical Communicator Lunch Social
-* October 17 – London, UK – `Worked Examples in the Documentation of Complex Systems <https://www.meetup.com/Write-The-Docs-London/events/243010658/>`_
+* October 17 – London, UK – `Worked Examples in the Documentation of Complex Systems <https://www.meetup.com/Write-The-Docs-London/events/243010658/>`_
 * October 24 – Boston, MA, USA – `mabl Happy Hour + Lightning Talks <https://www.meetup.com/Write-the-Docs-BOS/events/242428486/>`_
 * October 25 – Austin, TX, USA – `Content strategy for your docs <https://www.meetup.com/WriteTheDocs-ATX-Meetup/events/242784674/>`_

--- a/docs/blog/newsletter-october-2018.rst
+++ b/docs/blog/newsletter-october-2018.rst
@@ -106,7 +106,7 @@ Featured job postings
 Upcoming community events
 -------------------------
 
-October 09 – Ottawa, Alberta, Canada – `Structured Writing with Mark Baker <https://www.meetup.com/Write-The-Docs-YOW-Ottawa/events/xtcbgqyxnbmb/>`_
+October 09 – Ottawa, Alberta, Canada – `Structured Writing with Mark Baker <https://www.meetup.com/Write-The-Docs-YOW-Ottawa/events/xtcbgqyxnbmb/>`_
 
 October 14 – Moscow, Russia – `Second Meetup <https://www.meetup.com/Write-the-Docs-Moscow/events/255163318/>`_
 
@@ -120,7 +120,7 @@ October 16 – Portland, Oregon, USA – `Joint Meetup with PSU & Support Driven
 
 October 17 – Bradford, West Yorkshire, UK – `Hacktoberfest! Join us in a basement in Bradford! <https://www.meetup.com/Write-the-Docs-North/events/254988997/>`_
 
-October 24 – Austin, Texas, USA – `Engineering/Developer-focused Content: Stories and Tools for Practitioners <https://www.meetup.com/WriteTheDocs-ATX-Meetup/events/255188139/>`_
+October 24 – Austin, Texas, USA – `Engineering/Developer-focused Content: Stories and Tools for Practitioners <https://www.meetup.com/WriteTheDocs-ATX-Meetup/events/255188139/>`_
 
 October 25 – Remote (Australia time) – `Remote: Teaching engineers about content strategy <https://www.meetup.com/Write-the-Docs-Australia/events/253769102/>`_
 

--- a/docs/books.rst
+++ b/docs/books.rst
@@ -24,7 +24,7 @@ Technical communication
 E-Learning
 -----------
 
-* `e-Learning and the Science of Instruction <https://onlinelibrary.wiley.com/doi/book/10.1002/9781119239086>`_, by Ruth Colvin Clark, Richard E. Mayer
+* `e-Learning and the Science of Instruction <https://onlinelibrary.wiley.com/doi/book/10.1002/9781119239086>`_, by Ruth Colvin Clark, Richard E. Mayer
 
 Content strategy
 ------------------

--- a/docs/conf/atlantic/2023/cfp.rst
+++ b/docs/conf/atlantic/2023/cfp.rst
@@ -66,7 +66,7 @@ If you're a WTD conference organizer, please only submit talks to conferences yo
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 
@@ -125,8 +125,8 @@ Don't worry too much about whether we will accept your talk proposal, just submi
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/atlantic/2023/convince-your-manager.rst
+++ b/docs/conf/atlantic/2023/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/atlantic/2023/news/thank-you-recap.rst
+++ b/docs/conf/atlantic/2023/news/thank-you-recap.rst
@@ -115,5 +115,5 @@ Thanks so much to the following companies for supporting the Portland conference
    :source: /_data/{{shortcode}}-{{year}}-config.yaml
    :template: {{year}}/sponsors-simplelist.rst
 
-We're so grateful to our sponsors, speakers, volunteers, and attendees for making this conference possible. Whether you were able to come out this time or not, we hope to see you again next year – or
+We're so grateful to our sponsors, speakers, volunteers, and attendees for making this conference possible. Whether you were able to come out this time or not, we hope to see you again next year – or
 even sooner at one of our other events!

--- a/docs/conf/atlantic/2024/cfp.rst
+++ b/docs/conf/atlantic/2024/cfp.rst
@@ -57,7 +57,7 @@ If you're a WTD conference organizer, please only submit talks to conferences yo
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 
@@ -121,8 +121,8 @@ Don't worry too much about whether we will accept your talk proposal, just submi
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/atlantic/2024/convince-your-manager.rst
+++ b/docs/conf/atlantic/2024/convince-your-manager.rst
@@ -6,7 +6,7 @@ Convince Your Organization
 Convince Your Manager
 ---------------------
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/atlantic/2024/news/thank-you-recap.rst
+++ b/docs/conf/atlantic/2024/news/thank-you-recap.rst
@@ -118,5 +118,5 @@ Thanks so much to the following companies for supporting the Portland conference
    :source: /_data/{{shortcode}}-{{year}}-config.yaml
    :template: {{year}}/sponsors-simplelist.rst
 
-We're so grateful to our sponsors, speakers, volunteers, and attendees for making this conference possible. Whether you were able to come out this time or not, we hope to see you again next year – or
+We're so grateful to our sponsors, speakers, volunteers, and attendees for making this conference possible. Whether you were able to come out this time or not, we hope to see you again next year – or
 even sooner at one of our other events!

--- a/docs/conf/australia/2018/cfp.rst
+++ b/docs/conf/australia/2018/cfp.rst
@@ -32,7 +32,7 @@ What we’re looking for
 **Mix of topics and perspectives**
 
 The focus of Write the Docs is software documentation, but we actively seek talks that address a wide range of related subjects,
-at various levels of expertise. Documentation perspectives from other fields are welcome! Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+at various levels of expertise. Documentation perspectives from other fields are welcome! Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse group of speakers**
 
@@ -64,8 +64,8 @@ Need help?
 
 If you need a hand preparing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 
 Presentation format

--- a/docs/conf/australia/2018/convince-your-manager.rst
+++ b/docs/conf/australia/2018/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/australia/2018/news/au-2018-announcing-speakers.rst
+++ b/docs/conf/australia/2018/news/au-2018-announcing-speakers.rst
@@ -9,14 +9,14 @@ Announcing speakers and talks
 G'day folks!
 
 We're excited to announce that we've finalised our list of speakers and talks for the event!
-The selection process was tough as we had a strong batch of submissions. Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
+The selection process was tough as we had a strong batch of submissions. Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
 
 We also have some info about ticket purchasing (now's the time!), trip planning (Melbourne beckons!), opportunities to volunteer and of course our generous sponsors (want to `join them <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/sponsors/prospectus/>`_?). Read on for more details!
 
 Speakers and talks
 -------------------
 
-This year, we hope to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure. We're really excited about the presentations we've got this year – we hope you are too!
+This year, we hope to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure. We're really excited about the presentations we've got this year – we hope you are too!
 
 .. datatemplate::
    :source: /_data/{{year}}.{{shortcode}}.speakers.yaml

--- a/docs/conf/australia/2018/news/thanks-recap.rst
+++ b/docs/conf/australia/2018/news/thanks-recap.rst
@@ -91,4 +91,4 @@ Thanks again
 ============
 
 We're so grateful to our speakers, sponsors, volunteers, and attendees for making this conference possible.
-We hope to see you back next year – or even sooner at one of our other local events!
+We hope to see you back next year – or even sooner at one of our other local events!

--- a/docs/conf/australia/2019/cfp.rst
+++ b/docs/conf/australia/2019/cfp.rst
@@ -32,7 +32,7 @@ What we’re looking for
 **Mix of topics and perspectives**
 
 The focus of Write the Docs is software documentation, but we actively seek talks that address a wide range of related subjects,
-at various levels of expertise. Documentation perspectives from other fields are welcome! Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+at various levels of expertise. Documentation perspectives from other fields are welcome! Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse group of speakers**
 
@@ -64,8 +64,8 @@ Need help?
 
 If you need a hand preparing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 
 Presentation format

--- a/docs/conf/australia/2019/convince-your-manager.rst
+++ b/docs/conf/australia/2019/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/australia/2019/news/announcing-speakers.rst
+++ b/docs/conf/australia/2019/news/announcing-speakers.rst
@@ -18,7 +18,7 @@ We also have some info about ticket purchasing (now’s the time!), call for vol
 Full speaker line-up
 --------------------
 
-Every year, we look to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure. We're really excited about the presentations we've got this year – we hope you are too!
+Every year, we look to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure. We're really excited about the presentations we've got this year – we hope you are too!
 
 .. datatemplate::
    :source: /_data/{{year}}.{{shortcode}}.speakers.yaml

--- a/docs/conf/australia/2020/cfp.rst
+++ b/docs/conf/australia/2020/cfp.rst
@@ -51,7 +51,7 @@ If you're a WTD conference organizer, please only submit talks to conferences yo
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 
@@ -112,8 +112,8 @@ Don't worry too much about whether we will accept your talk proposal, just submi
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/australia/2020/convince-your-manager.rst
+++ b/docs/conf/australia/2020/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/australia/2020/news/announcing-speakers.rst
+++ b/docs/conf/australia/2020/news/announcing-speakers.rst
@@ -10,13 +10,13 @@ Hello! We are here with an update on the online Australia and India conference!
 
 To start off, we're delighted to announce that we've finalised our speakers for the event!
 Every year, talk selection gets more and more difficult as we get a larger, stronger batch of submissions.
-A big thank you to everyone who took the time to send us a proposal – we literally wouldn't have an event without you!
+A big thank you to everyone who took the time to send us a proposal – we literally wouldn't have an event without you!
 
 Full speaker line-up
 --------------------
 
 Every year, we look to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure.
-We're really excited about the presentations we've got this year – we hope you are too!
+We're really excited about the presentations we've got this year – we hope you are too!
 
 .. datatemplate::
    :source: /_data/{{shortcode}}-{{year}}-sessions.yaml

--- a/docs/conf/australia/2020/news/thank-you-recap.rst
+++ b/docs/conf/australia/2020/news/thank-you-recap.rst
@@ -80,4 +80,4 @@ Thanks again
 ============
 
 We're so grateful to our sponsors, speakers, volunteers, and attendees for making this conference possible.
-Whether you were able to come out this time or not, we hope to see you again next year – or even sooner at one of our other events!
+Whether you were able to come out this time or not, we hope to see you again next year – or even sooner at one of our other events!

--- a/docs/conf/australia/2021/cfp.rst
+++ b/docs/conf/australia/2021/cfp.rst
@@ -67,7 +67,7 @@ If you're a WTD conference organizer, please only submit talks to conferences yo
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 
@@ -127,8 +127,8 @@ Don't worry too much about whether we will accept your talk proposal, just submi
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/australia/2021/convince-your-manager.rst
+++ b/docs/conf/australia/2021/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/australia/2021/news/cancel-announcement.rst
+++ b/docs/conf/australia/2021/news/cancel-announcement.rst
@@ -17,7 +17,7 @@ Here's what we will do instead.
 Super meetup
 ------------
 
-In place of a full 2-day conference, we will select 4 talks (from the CFP process, pending confirmation from the speakers) and invite these documentarians to present their talks at a super 2-hour meetup (date **TBA**). 
+In place of a full 2-day conference, we will select 4 talks (from the CFP process, pending confirmation from the speakers) and invite these documentarians to present their talks at a super 2-hour meetup (date **TBA**).
 We value the time and effort our documentarians put in to submit talk proposals and wanted to use this time to share their experience and knowledge.
 
 * This meetup event will be a free and open event without prior registration, so you can join in from anywhere. We will try and keep this in a timezone convenient for both our WTD Australia and India communities.

--- a/docs/conf/australia/2022/cfp.rst
+++ b/docs/conf/australia/2022/cfp.rst
@@ -67,7 +67,7 @@ If you're a WTD conference organizer, please only submit talks to conferences yo
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 

--- a/docs/conf/australia/2022/convince-your-manager.rst
+++ b/docs/conf/australia/2022/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/australia/2022/news/thank-you-recap.rst
+++ b/docs/conf/australia/2022/news/thank-you-recap.rst
@@ -84,4 +84,4 @@ Thanks again
 ============
 
 We're so grateful to our sponsors, speakers, volunteers, and attendees for making this conference possible.
-Whether you were able to come out this time or not, we hope to see you again next year – or even sooner at one of our other events!
+Whether you were able to come out this time or not, we hope to see you again next year – or even sooner at one of our other events!

--- a/docs/conf/australia/2023/cfp.rst
+++ b/docs/conf/australia/2023/cfp.rst
@@ -69,7 +69,7 @@ If you're a WTD conference organizer, please only submit talks to conferences yo
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 

--- a/docs/conf/australia/2023/convince-your-manager.rst
+++ b/docs/conf/australia/2023/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/australia/2023/news/thanks-recap.rst
+++ b/docs/conf/australia/2023/news/thanks-recap.rst
@@ -118,6 +118,6 @@ Thanks again
 ============
 
 We're so grateful to our sponsor, speakers, volunteers, and attendees for making this conference possible.
-Whether you were able to come out this time or not, we hope to see you again next year – or even sooner at one of our other events!
+Whether you were able to come out this time or not, we hope to see you again next year – or even sooner at one of our other events!
 
 The Write the Docs Australia team

--- a/docs/conf/australia/2024/cfp.rst
+++ b/docs/conf/australia/2024/cfp.rst
@@ -67,7 +67,7 @@ If you're a WTD conference organizer, please only submit talks to conferences yo
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 

--- a/docs/conf/australia/2024/convince-your-manager.rst
+++ b/docs/conf/australia/2024/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/australia/2024/news/thanks-recap.rst
+++ b/docs/conf/australia/2024/news/thanks-recap.rst
@@ -126,6 +126,6 @@ Thanks again
 ============
 
 We're so grateful to our sponsor, speakers, volunteers, and attendees for making this conference possible.
-Whether you were able to come out this time or not, we hope to see you again next year – or even sooner at one of our other events!
+Whether you were able to come out this time or not, we hope to see you again next year – or even sooner at one of our other events!
 
 The Write the Docs Australia team

--- a/docs/conf/australia/2025/cfp.rst
+++ b/docs/conf/australia/2025/cfp.rst
@@ -67,7 +67,7 @@ If you're a WTD conference organizer, please only submit talks to conferences yo
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 

--- a/docs/conf/australia/2025/convince-your-manager.rst
+++ b/docs/conf/australia/2025/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/berlin/2025/cfp.rst
+++ b/docs/conf/berlin/2025/cfp.rst
@@ -130,8 +130,8 @@ Don't worry too much about whether we will accept your talk proposal. We encoura
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/berlin/2026/cfp.md
+++ b/docs/conf/berlin/2026/cfp.md
@@ -123,8 +123,8 @@ Don't worry too much about whether we will accept your talk proposal. We encoura
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-- **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
-- **Meetup brainstorming** – For some in-person workshopping, check in on your [local meetup group](https://www.writethedocs.org/meetups/) and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+- **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+- **Meetup brainstorming** – For some in-person workshopping, check in on your [local meetup group](https://www.writethedocs.org/meetups/) and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 - **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at <https://www.writethedocs.org/slack/>.)
 
 ## Selection process

--- a/docs/conf/cincinnati/2018/cfp.rst
+++ b/docs/conf/cincinnati/2018/cfp.rst
@@ -32,7 +32,7 @@ What we’re looking for
 **Mix of topics and perspectives**
 
 The focus of Write the Docs is software documentation, but we actively seek talks that address a wide range of related subjects,
-at various levels of expertise. Documentation perspectives from other fields are welcome! Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+at various levels of expertise. Documentation perspectives from other fields are welcome! Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse group of speakers**
 
@@ -64,8 +64,8 @@ Need help?
 
 If you need a hand preparing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 
 Presentation format

--- a/docs/conf/cincinnati/2018/news/announcing-speakers.rst
+++ b/docs/conf/cincinnati/2018/news/announcing-speakers.rst
@@ -8,14 +8,14 @@ Announcing speakers and talks
 
 Hello everyone!
 
-We're excited to announce that we've finalized our list of speakers for the Cincinnati event! Thank you to everyone who took the time to send us a proposal – we are grateful for your interest and could not have an event without you.
+We're excited to announce that we've finalized our list of speakers for the Cincinnati event! Thank you to everyone who took the time to send us a proposal – we are grateful for your interest and could not have an event without you.
 
 We also have some info about ticket purchasing (now's the time!), trip planning, and `sponsorship <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/sponsors/prospectus/>`_. Read on for details!
 
 Speakers and talks
 ------------------
 
-We look to bring a wide range of voices to the Write the Docs stage with a mix of practical, philosophical, and technical topics. Our partnership with Open Help means we were especially interested in talks with an open source angle, and fortunately we had a number of strong proposals related to documentation for open source projects. We're so excited about the presentations we've got for this inaugural event – we hope you are too!
+We look to bring a wide range of voices to the Write the Docs stage with a mix of practical, philosophical, and technical topics. Our partnership with Open Help means we were especially interested in talks with an open source angle, and fortunately we had a number of strong proposals related to documentation for open source projects. We're so excited about the presentations we've got for this inaugural event – we hope you are too!
 
 .. datatemplate::
    :source: /_data/{{year}}.{{shortcode}}.speakers.yaml

--- a/docs/conf/portland/2018/cfp.rst
+++ b/docs/conf/portland/2018/cfp.rst
@@ -30,7 +30,7 @@ What we’re looking for
 **Mix of topics and perspectives**
 
 The focus of Write the Docs is software documentation, but we actively seek talks that address a wide range of related subjects,
-at various levels of expertise. Documentation perspectives from other fields are welcome! Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+at various levels of expertise. Documentation perspectives from other fields are welcome! Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse group of speakers**
 
@@ -61,8 +61,8 @@ Need help?
 
 If you need a hand preparing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 
 Presentation format

--- a/docs/conf/portland/2018/convince-your-manager.rst
+++ b/docs/conf/portland/2018/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/portland/2018/news/announcing-schedule.rst
+++ b/docs/conf/portland/2018/news/announcing-schedule.rst
@@ -8,7 +8,7 @@ Announcing Full Schedule & Last Chance For Tickets
 
 Hello everyone!
 We're about a month out from the Portland conference and we couldn't be more stoked!
-We're writing today to a) announce the full speaker schedule, b) get the ball rolling for Writing Day sprints, and c) encourage you – if you haven't already – to buy your tickets.
+We're writing today to a) announce the full speaker schedule, b) get the ball rolling for Writing Day sprints, and c) encourage you – if you haven't already – to buy your tickets.
 We're likely to sell out **in the next day or two**, so `now's your chance <https://www.writethedocs.org/conf/portland/2018/tickets/>`_!
 
 In the meantime, if it's your first Write the Docs, now's a great time to check out `the Welcome Wagon page <https://www.writethedocs.org/conf/portland/2018/welcome-wagon/>`_, which is chockfull of info to help you get oriented.

--- a/docs/conf/portland/2018/news/announcing-speakers.rst
+++ b/docs/conf/portland/2018/news/announcing-speakers.rst
@@ -7,14 +7,14 @@ Happy Tuesday everybody!
 
 We're writing today with an update on the fast-approaching Portland conference!
 
-First off, we're delighted to announce that we've finalized our speakers for the event! Every year talk selection gets more and more difficult as we get a larger, stronger batch of submissions. Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
+First off, we're delighted to announce that we've finalized our speakers for the event! Every year talk selection gets more and more difficult as we get a larger, stronger batch of submissions. Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
 
 We also have some info about ticket purchasing (now's the time!), trip planning (Portland's cool!), and our generous sponsors (want to join them?). Read on for more details!
 
 Full speaker line-up
 --------------------
 
-Every year, we look to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure. We're really excited about the presentations we're going hear this year – we hope you are too!
+Every year, we look to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure. We're really excited about the presentations we're going hear this year – we hope you are too!
 
 * Ashleigh Rentz – `The Facts About FAQs <https://www.writethedocs.org/conf/portland/2018/speakers/#speaker-ashleigh-rentz>`_
 * Beth Aitman – `Who Writes the Docs? <https://www.writethedocs.org/conf/portland/2018/speakers/#speaker-beth-aitman>`_
@@ -48,7 +48,7 @@ Planning your trip
 
 In the next few weeks, we’ll be announcing more details about the conference events, including the full schedule, annual hike on Saturday afternoon, writing day and reception on Sunday, and official party on Monday evening. But on top of that, there's ALL SORTS of stuff to do in Portland.
 
-We've got a couple of excellent volunteers – Mo Nishiyama and Alicia Duncan – who are heading up our Explore Portland committee. They're already hard at work putting together resources to help you plan your visit! Check out the `Visit Portland <https://www.writethedocs.org/conf/portland/2018/visiting/>`_ page on the conference website, or pop into the `#wtd-conferences <https://writethedocs.slack.com/messages/wtd-conferences>`_ channel on Slack to ask a question.
+We've got a couple of excellent volunteers – Mo Nishiyama and Alicia Duncan – who are heading up our Explore Portland committee. They're already hard at work putting together resources to help you plan your visit! Check out the `Visit Portland <https://www.writethedocs.org/conf/portland/2018/visiting/>`_ page on the conference website, or pop into the `#wtd-conferences <https://writethedocs.slack.com/messages/wtd-conferences>`_ channel on Slack to ask a question.
 
 Thanks to our sponsors
 ----------------------

--- a/docs/conf/portland/2018/news/cfp-reminder.rst
+++ b/docs/conf/portland/2018/news/cfp-reminder.rst
@@ -9,7 +9,7 @@ CFP Reminder & Ticket Sales Open
 
 Happy New Year, fellow documentarians!
 
-Now that we've crossed the threshold into 2018, the Portland Write the Docs conference is suddenly feeling *much* closer! Our `call for proposals closes next Wednesday <https://www.writethedocs.org/conf/portland/2018/cfp/>`_, and `tickets for the conference are officially on sale <https://www.writethedocs.org/conf/portland/2018/tickets/>`_. Read on for more details on both!
+Now that we've crossed the threshold into 2018, the Portland Write the Docs conference is suddenly feeling *much* closer! Our `call for proposals closes next Wednesday <https://www.writethedocs.org/conf/portland/2018/cfp/>`_, and `tickets for the conference are officially on sale <https://www.writethedocs.org/conf/portland/2018/tickets/>`_. Read on for more details on both!
 
 Submit your talk by Wednesday
 ------------------------------------------------------------

--- a/docs/conf/portland/2018/news/thanks-recap.rst
+++ b/docs/conf/portland/2018/news/thanks-recap.rst
@@ -95,5 +95,5 @@ Thanks again
 
 We're so grateful to our sponsors, speakers, volunteers, and attendees
 for making this conference possible. Whether you were able to come out
-this time or not, we hope to see you back in Portland next year – or
+this time or not, we hope to see you back in Portland next year – or
 even sooner at one of our other events!

--- a/docs/conf/portland/2018/writing-day.rst
+++ b/docs/conf/portland/2018/writing-day.rst
@@ -27,7 +27,7 @@ Kubernetes Documentation
 
 If you’re looking to contribute to open source documentation on GitHub, consider helping improve the Kubernetes docs. Issues and projects this year include improving the user journeys that provide the landing page for the docs, helping develop a custom Kubernetes dictionary for common spellcheckers, and more.
 
-Kubernetes is an open source system that manages containerized applications across different infrastructures. No previous product experience is needed to help with the docs. Docs are published at `kubernetes.io <https://kubernetes.io/docs/home/>`_ and they're pulled directly from `Github
+Kubernetes is an open source system that manages containerized applications across different infrastructures. No previous product experience is needed to help with the docs. Docs are published at `kubernetes.io <https://kubernetes.io/docs/home/>`_ and they're pulled directly from `Github
 <https://github.com/kubernetes/website>`_. So you’ll need a GitHub account, and some familiarity with Markdown. You can also take a look at our contributor guidelines, and if you haven’t contributed before, it’ll save time if you sign the contributor license agreement before you arrive at Writing Day.
 
 `Detailed information, including how to sign the CLA <https://docs.google.com/document/d/1-mlmb9yHgdLsTqR8t52MegAWlUgXsZeko247hUMJaVU/edit?usp=sharing>`_

--- a/docs/conf/portland/2019/cfp.rst
+++ b/docs/conf/portland/2019/cfp.rst
@@ -47,7 +47,7 @@ We especially welcome talks from underrepresented groups within the tech communi
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 
@@ -106,8 +106,8 @@ Don't worry too much about whether we will accept your talk proposal, just submi
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/portland/2019/convince-your-manager.rst
+++ b/docs/conf/portland/2019/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/portland/2019/news/announcing-speakers.rst
+++ b/docs/conf/portland/2019/news/announcing-speakers.rst
@@ -8,14 +8,14 @@ Announcing speakers and talks
 
 We're writing today with an update on the fast-approaching Portland conference!
 
-First off, we're delighted to announce that we've finalized our speakers for the event! Every year talk selection gets more and more difficult as we get a larger, stronger batch of submissions. Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
+First off, we're delighted to announce that we've finalized our speakers for the event! Every year talk selection gets more and more difficult as we get a larger, stronger batch of submissions. Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
 
 We also have some info about ticket purchasing (now's the time!), trip planning (Portland's cool!), and our generous sponsors (want to join them?). Read on for more details!
 
 Full speaker line-up
 --------------------
 
-Every year, we look to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure. We're really excited about the presentations we've got this year – we hope you are too!
+Every year, we look to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure. We're really excited about the presentations we've got this year – we hope you are too!
 
 .. datatemplate::
    :source: /_data/{{year}}.{{shortcode}}.speakers.yaml
@@ -35,7 +35,7 @@ Planning your trip
 
 In the next few weeks, we’ll be announcing more details about the conference events, including the full schedule, annual hike on Saturday afternoon, writing day and reception on Sunday, and official party on Monday evening. But on top of that, there's ALL SORTS of stuff to do in Portland.
 
-We've got a couple of excellent volunteers – Mo Nishiyama and Alicia Duncan – who are heading up our Explore Portland committee. They're already hard at work putting together resources to help you plan your visit! Check out the `Visit Portland <https://www.writethedocs.org/conf/portland/2019/visiting/>`_ page on the conference website, or pop into the `#wtd-conferences <https://writethedocs.slack.com/messages/wtd-conferences>`_ channel on Slack to ask a question.
+We've got a couple of excellent volunteers – Mo Nishiyama and Alicia Duncan – who are heading up our Explore Portland committee. They're already hard at work putting together resources to help you plan your visit! Check out the `Visit Portland <https://www.writethedocs.org/conf/portland/2019/visiting/>`_ page on the conference website, or pop into the `#wtd-conferences <https://writethedocs.slack.com/messages/wtd-conferences>`_ channel on Slack to ask a question.
 
 Thanks to our sponsors
 ----------------------

--- a/docs/conf/portland/2019/news/thanks-recap.rst
+++ b/docs/conf/portland/2019/news/thanks-recap.rst
@@ -90,5 +90,5 @@ Thanks again
 
 We're so grateful to our sponsors, speakers, volunteers, and attendees
 for making this conference possible. Whether you were able to come out
-this time or not, we hope to see you back in Portland next year – or
+this time or not, we hope to see you back in Portland next year – or
 even sooner at one of our other events!

--- a/docs/conf/portland/2020/cfp.rst
+++ b/docs/conf/portland/2020/cfp.rst
@@ -47,7 +47,7 @@ If you're a WTD conference organizer, please only submit talks to conferences yo
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 
@@ -106,8 +106,8 @@ Don't worry too much about whether we will accept your talk proposal, just submi
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/portland/2020/convince-your-manager.rst
+++ b/docs/conf/portland/2020/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/portland/2020/news/announcing-speakers.rst
+++ b/docs/conf/portland/2020/news/announcing-speakers.rst
@@ -10,7 +10,7 @@ We're writing today with an update on the fast-approaching Portland conference!
 
 First off, we're delighted to announce that we've finalized our speakers for the event!
 Every year talk selection gets more and more difficult as we get a larger, stronger batch of submissions.
-Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
+Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
 
 Second, we're super excited to announce our new opportunity grant program to support folks who would not otherwise be able to make it the conference.
 
@@ -21,7 +21,7 @@ Full speaker line-up
 --------------------
 
 Every year, we look to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure.
-We're really excited about the presentations we've got this year – we hope you are too!
+We're really excited about the presentations we've got this year – we hope you are too!
 
 .. datatemplate::
    :source: /_data/{{shortcode}}-{{year}}-sessions.yaml
@@ -49,7 +49,7 @@ Planning your trip
 
 In the next few weeks, we’ll be announcing more details about the conference events, including the full schedule, annual hike on Saturday afternoon, writing day and reception on Sunday. But on top of that, there's ALL SORTS of stuff to do in Portland.
 
-We've got a couple of excellent volunteers – Christy and Mo – who are heading up our Explore Portland committee.
+We've got a couple of excellent volunteers – Christy and Mo – who are heading up our Explore Portland committee.
 They're already hard at work updating the the `Visit Portland <https://www.writethedocs.org/conf/portland/2020/visiting/>`_.
 Pop into the `#wtd-conferences <https://writethedocs.slack.com/messages/wtd-conferences>`_ channel on Slack if you have any question.
 

--- a/docs/conf/portland/2020/news/thanks-recap.rst
+++ b/docs/conf/portland/2020/news/thanks-recap.rst
@@ -77,5 +77,5 @@ Thanks again
 
 We're so grateful to our sponsors, speakers, volunteers, and attendees
 for making this conference possible. Whether you were able to come out
-this time or not, we hope to see you again next year – or
+this time or not, we hope to see you again next year – or
 even sooner at one of our other events!

--- a/docs/conf/portland/2021/cfp.rst
+++ b/docs/conf/portland/2021/cfp.rst
@@ -62,7 +62,7 @@ If you're a WTD conference organizer, please only submit talks to conferences yo
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 
@@ -121,8 +121,8 @@ Don't worry too much about whether we will accept your talk proposal, just submi
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/portland/2021/convince-your-manager.rst
+++ b/docs/conf/portland/2021/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/portland/2021/news/announcing-speakers.rst
+++ b/docs/conf/portland/2021/news/announcing-speakers.rst
@@ -9,13 +9,13 @@ Announcing speakers and sessions
 We're writing today with an update on the fast-approaching Portland conference.
 
 We're delighted to announce that we've finalized our speakers for the event, and have updated t-shirts on sale.
-Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
+Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
 
 Full speaker line-up
 --------------------
 
 Every year, we look to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure.
-We're really excited about the presentations we've got this year – we hope you are too!
+We're really excited about the presentations we've got this year – we hope you are too!
 
 .. datatemplate::
    :source: /_data/{{shortcode}}-{{year}}-sessions.yaml

--- a/docs/conf/portland/2021/news/thanks-recap.rst
+++ b/docs/conf/portland/2021/news/thanks-recap.rst
@@ -105,5 +105,5 @@ Thanks so much to the following companies for supporting the Portland conference
 
 We're so grateful to our sponsors, speakers, volunteers, and attendees
 for making this conference possible. Whether you were able to come out
-this time or not, we hope to see you again next year – or
+this time or not, we hope to see you again next year – or
 even sooner at one of our other events!

--- a/docs/conf/portland/2022/cfp.rst
+++ b/docs/conf/portland/2022/cfp.rst
@@ -66,7 +66,7 @@ If you're a WTD conference organizer, please only submit talks to conferences yo
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 
@@ -125,8 +125,8 @@ Don't worry too much about whether we will accept your talk proposal, just submi
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/portland/2022/convince-your-manager.rst
+++ b/docs/conf/portland/2022/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/portland/2022/news/thanks-recap.rst
+++ b/docs/conf/portland/2022/news/thanks-recap.rst
@@ -139,5 +139,5 @@ Thanks so much to the following companies for supporting the Portland conference
 
 We're so grateful to our sponsors, speakers, volunteers, and attendees
 for making this conference possible. Whether you were able to come out
-this time or not, we hope to see you again next year – or
+this time or not, we hope to see you again next year – or
 even sooner at one of our other events!

--- a/docs/conf/portland/2023/cfp.rst
+++ b/docs/conf/portland/2023/cfp.rst
@@ -130,8 +130,8 @@ Don't worry too much about whether we will accept your talk proposal, just submi
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/portland/2023/convince-your-manager.rst
+++ b/docs/conf/portland/2023/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/portland/2024/cfp.rst
+++ b/docs/conf/portland/2024/cfp.rst
@@ -130,8 +130,8 @@ Don't worry too much about whether we will accept your talk proposal, just submi
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/portland/2024/convince-your-manager.rst
+++ b/docs/conf/portland/2024/convince-your-manager.rst
@@ -8,7 +8,7 @@ Convince Your Organization
 Convince Your Manager
 ---------------------
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/portland/2025/cfp.rst
+++ b/docs/conf/portland/2025/cfp.rst
@@ -130,8 +130,8 @@ Don't worry too much about whether we will accept your talk proposal. We encoura
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/portland/2026/cfp.md
+++ b/docs/conf/portland/2026/cfp.md
@@ -117,8 +117,8 @@ Don't worry too much about whether we will accept your talk proposal. We encoura
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-- **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
-- **Meetup brainstorming** – For some in-person workshopping, check in on your [local meetup group](https://www.writethedocs.org/meetups/) and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+- **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+- **Meetup brainstorming** – For some in-person workshopping, check in on your [local meetup group](https://www.writethedocs.org/meetups/) and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 - **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at <https://www.writethedocs.org/slack/>.)
 
 ## Selection process

--- a/docs/conf/prague/2018/cfp.rst
+++ b/docs/conf/prague/2018/cfp.rst
@@ -32,7 +32,7 @@ What we’re looking for
 **Mix of topics and perspectives**
 
 The focus of Write the Docs is software documentation, but we actively seek talks that address a wide range of related subjects,
-at various levels of expertise. Documentation perspectives from other fields are welcome! Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+at various levels of expertise. Documentation perspectives from other fields are welcome! Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse group of speakers**
 
@@ -64,8 +64,8 @@ Need help?
 
 If you need a hand preparing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 
 Presentation format

--- a/docs/conf/prague/2018/convince-your-manager.rst
+++ b/docs/conf/prague/2018/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/prague/2018/news/announcing-speakers.rst
+++ b/docs/conf/prague/2018/news/announcing-speakers.rst
@@ -8,14 +8,14 @@ Announcing speakers and talks
 
 Hello folks!
 
-First off, we're excited to announce that we've finalized our list of speakers for the event! Every year talk selection gets more and more difficult as we get a larger, stronger batch of submissions. Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
+First off, we're excited to announce that we've finalized our list of speakers for the event! Every year talk selection gets more and more difficult as we get a larger, stronger batch of submissions. Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
 
 We also have some info about ticket purchasing (now's the time!), trip planning (Prague beckons!), conference shirts (now printed on demand) and of course our generous sponsors (want to `join them <https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/sponsors/prospectus/>`_?). Read on for more details!
 
 Speakers and talks
 ------------------
 
-Every year, we look to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure. We're really excited about the presentations we've got this year – we hope you are too!
+Every year, we look to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure. We're really excited about the presentations we've got this year – we hope you are too!
 
 .. datatemplate::
    :source: /_data/{{year}}.{{shortcode}}.speakers.yaml

--- a/docs/conf/prague/2018/news/thanks-recap.rst
+++ b/docs/conf/prague/2018/news/thanks-recap.rst
@@ -66,4 +66,4 @@ Thanks again
 ============
 
 We're so grateful to our speakers, sponsors, volunteers, and attendees for making this conference possible.
-Whether you were able to join us this time or not, we hope to see you back in Prague next year – or even sooner at one of our other events!
+Whether you were able to join us this time or not, we hope to see you back in Prague next year – or even sooner at one of our other events!

--- a/docs/conf/prague/2019/cfp.rst
+++ b/docs/conf/prague/2019/cfp.rst
@@ -45,7 +45,7 @@ We especially welcome talks from underrepresented groups within the tech communi
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 
@@ -104,8 +104,8 @@ Don't worry too much about whether we will accept your talk proposal, just submi
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/prague/2019/convince-your-manager.rst
+++ b/docs/conf/prague/2019/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/prague/2019/news/talks-volunteers-tickets-shirts.rst
+++ b/docs/conf/prague/2019/news/talks-volunteers-tickets-shirts.rst
@@ -10,14 +10,14 @@ Hello to our documentarians in Europe and beyond!
 
 We're happy to write to you with the latest news about our upcoming Prague conference, there's lots to share and with the conference less than three months away, we hope you're all getting excited!
 
-Firstly, we've finalized our speakers for the event! Every year talk selection gets more and more difficult as we get a larger, stronger batch of submissions. Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
+Firstly, we've finalized our speakers for the event! Every year talk selection gets more and more difficult as we get a larger, stronger batch of submissions. Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
 
 We also have some info about ticket purchasing (now's the time!), call for volunteers, diversity tickets reminder, and our now-traditional pop-up t-shirt shop.
 
 Full speaker line-up
 --------------------
 
-Every year, we look to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure. We're really excited about the presentations we've got this year – we hope you are too!
+Every year, we look to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure. We're really excited about the presentations we've got this year – we hope you are too!
 
 .. datatemplate::
    :source: /_data/{{year}}.{{shortcode}}.speakers.yaml

--- a/docs/conf/prague/2019/news/thank-you-recap.rst
+++ b/docs/conf/prague/2019/news/thank-you-recap.rst
@@ -65,4 +65,4 @@ Thanks again
 ============
 
 We're so grateful to our speakers, sponsors, volunteers, and attendees for making this conference possible.
-Whether you were able to join us this time or not, we hope to see you back in Prague next year – or even sooner at one of our other events!
+Whether you were able to join us this time or not, we hope to see you back in Prague next year – or even sooner at one of our other events!

--- a/docs/conf/prague/2020/cfp.rst
+++ b/docs/conf/prague/2020/cfp.rst
@@ -51,7 +51,7 @@ If you're a WTD conference organizer, please only submit talks to conferences yo
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 
@@ -110,8 +110,8 @@ Don't worry too much about whether we will accept your talk proposal, just submi
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/prague/2020/convince-your-manager.rst
+++ b/docs/conf/prague/2020/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/prague/2020/news/announcing-speakers.rst
+++ b/docs/conf/prague/2020/news/announcing-speakers.rst
@@ -10,13 +10,13 @@ We're writing today with an update on the first online Prague conference!
 
 First off, we're delighted to announce that we've finalized our speakers for the event!
 Every year talk selection gets more and more difficult as we get a larger, stronger batch of submissions.
-Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
+Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
 
 Full speaker line-up
 --------------------
 
 Every year, we look to bring a wide range of voices to the Write the Docs stage. Because the role of "documentarian" looks so different to each of us, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure.
-We're really excited about the presentations we've got this year – we hope you are too!
+We're really excited about the presentations we've got this year – we hope you are too!
 
 .. datatemplate::
    :source: /_data/{{shortcode}}-{{year}}-sessions.yaml

--- a/docs/conf/prague/2020/news/thank-you-recap.rst
+++ b/docs/conf/prague/2020/news/thank-you-recap.rst
@@ -73,4 +73,4 @@ Thanks again
 ============
 
 We're so grateful to our sponsors, speakers, volunteers, and attendees for making this conference possible. 
-Whether you were able to come out this time or not, we hope to see you again next year – or even sooner at one of our other events!
+Whether you were able to come out this time or not, we hope to see you again next year – or even sooner at one of our other events!

--- a/docs/conf/prague/2021/cfp.rst
+++ b/docs/conf/prague/2021/cfp.rst
@@ -66,7 +66,7 @@ If you're a WTD conference organizer, please only submit talks to conferences yo
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 
@@ -125,8 +125,8 @@ Don't worry too much about whether we will accept your talk proposal, just submi
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/prague/2021/convince-your-manager.rst
+++ b/docs/conf/prague/2021/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/prague/2021/news/announcing-speakers.rst
+++ b/docs/conf/prague/2021/news/announcing-speakers.rst
@@ -9,14 +9,14 @@ Announcing speakers
 Hello, documentarians! Today we're happy to announce the full list of talks and speakers for the 2021 Prague virtual conference. 
 
 Every year talk selection gets more and more difficult as we get a larger, stronger batch of submissions.
-Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
+Thank you so much to everyone who took the time to send us a pitch – we literally wouldn't have an event without you!
 
 Full speaker line-up
 --------------------
 
 Every year, we look to bring a wide range of voices to the Write the Docs stage. Because being a documentarian can mean different things to different people, we aim for a line-up that spans a good mix of practical, philosophical, and technical topics – with the odd whimsical one thrown in for good measure.
 
-We're really excited about the presentations we've got this year – we hope you are too!
+We're really excited about the presentations we've got this year – we hope you are too!
 
 .. datatemplate::
    :source: /_data/{{shortcode}}-{{year}}-sessions.yaml

--- a/docs/conf/prague/2022/cfp.rst
+++ b/docs/conf/prague/2022/cfp.rst
@@ -66,7 +66,7 @@ If you're a WTD conference organizer, please only submit talks to conferences yo
 
 **Mix of roles and perspectives**
 
-Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse audience**
 
@@ -125,8 +125,8 @@ Don't worry too much about whether we will accept your talk proposal, just submi
 
 If you need a hand preparing or honing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know at {{ shortcode }}@writethedocs.org!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 * **Twitter hivemind** – If Twitter is more your speed, `#writethedocs <https://twitter.com/hashtag/writethedocs>`__ will get you there.
 

--- a/docs/conf/prague/2022/convince-your-manager.rst
+++ b/docs/conf/prague/2022/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/prague/2022/news/thank-you-recap.rst
+++ b/docs/conf/prague/2022/news/thank-you-recap.rst
@@ -118,5 +118,5 @@ Thanks so much to the following companies for supporting the Portland conference
    :source: /_data/{{shortcode}}-{{year}}-config.yaml
    :template: {{year}}/sponsors-simplelist.rst
 
-We're so grateful to our sponsors, speakers, volunteers, and attendees for making this conference possible. Whether you were able to come out this time or not, we hope to see you again next year – or
+We're so grateful to our sponsors, speakers, volunteers, and attendees for making this conference possible. Whether you were able to come out this time or not, we hope to see you again next year – or
 even sooner at one of our other events!

--- a/docs/conf/vilnius/2019/cfp.rst
+++ b/docs/conf/vilnius/2019/cfp.rst
@@ -30,7 +30,7 @@ What we’re looking for
 **Mix of topics and perspectives**
 
 The focus of Write the Docs is software documentation, but we actively seek talks that address a wide range of related subjects,
-at various levels of expertise. Documentation perspectives from other fields are welcome! Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
+at various levels of expertise. Documentation perspectives from other fields are welcome! Talks from the scientific community, fiction writers, system administrators, and support staff – in addition to technical writers and software developers – are all valuable to our attendees.
 
 **Diverse group of speakers**
 
@@ -62,8 +62,8 @@ Need help?
 
 If you need a hand preparing your talk proposal, there are lots of good places to start:
 
-* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
-* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
+* **Community mentorship** – We have an ever-growing pool of previous Write the Docs speakers, many of whom are happy to be a second pair of eyes on talk proposals. If you're interested in working with a past speaker, let us know!
+* **Meetup brainstorming** – For some in-person workshopping, check in on your `local meetup group <https://www.writethedocs.org/meetups/>`_ and see if they have a talk brainstorming session on their calendar. If they don't... ask if they're planning one!
 * **Slack hivemind** – You can also hit up the hivemind directly on the Write the Docs Slack, any time of day! (If you're not registered yet, you can at `https://www.writethedocs.org/slack/ <https://www.writethedocs.org/slack/>`_.)
 
 Presentation format

--- a/docs/conf/vilnius/2019/convince-your-manager.rst
+++ b/docs/conf/vilnius/2019/convince-your-manager.rst
@@ -3,7 +3,7 @@
 Convince Your Manager
 =====================
 
-Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
+Do you need help justifying why your employer should send you to Write the Docs? Don't worry – you're not alone.
 Based on the experiences of some of our previous attendees, we've put together a sample email and list of resources below.
 Feel free to adapt and share with your manager to show them the many benefits of attending!
 

--- a/docs/conf/vilnius/2019/news/announcing-talks.rst
+++ b/docs/conf/vilnius/2019/news/announcing-talks.rst
@@ -8,7 +8,7 @@ Announcing Speakers and Talks
 
 Greetings, fellow documentarians! We're writing today with an update on the fast-approaching Vilnius event, and we're very excited to announce the speakers and talks for the event.
 
-Thank you so much to everyone who took the time to send us a proposal – we literally wouldn't have an event without you!
+Thank you so much to everyone who took the time to send us a proposal – we literally wouldn't have an event without you!
 
 We also have some info about ticket purchasing (now's the time!), trip planning (Vilnius is beautiful!), and Writing Day (start thinking about projects!).
 

--- a/docs/include/conf/portland/speaking-tips.rst
+++ b/docs/include/conf/portland/speaking-tips.rst
@@ -52,7 +52,7 @@ Good resources on this include:
 - `The Responsible Communication Style Guide <https://rcstyleguide.com/>`__
 - `GDS design principles <https://www.gov.uk/guidance/government-design-principles#this-is-for-everyone>`__
 
-Also, we know there's a ton of nuance and complexity here – 
+Also, we know there's a ton of nuance and complexity here –
 just do your best to be aware of and sensitive about your language choices!
 If you have any doubts about any of your language, feel free to ask us in advance.
 

--- a/docs/include/conf/speaking-tips.rst
+++ b/docs/include/conf/speaking-tips.rst
@@ -55,7 +55,7 @@ Good resources on this include:
 - `The Responsible Communication Style Guide <https://rcstyleguide.com/>`__
 - `GDS design principles <https://www.gov.uk/guidance/government-design-principles#this-is-for-everyone>`__
 
-Also, we know there's a ton of nuance and complexity here – 
+Also, we know there's a ton of nuance and complexity here –
 just do your best to be aware of and sensitive about your language choices!
 
 Slide display details

--- a/docs/include/conf/virtual/speaking-tips.rst
+++ b/docs/include/conf/virtual/speaking-tips.rst
@@ -50,7 +50,7 @@ Good resources on this include:
 - `The Responsible Communication Style Guide <https://rcstyleguide.com/>`__
 - `GDS design principles <https://www.gov.uk/guidance/government-design-principles#this-is-for-everyone>`__
 
-Also, we know there's a ton of nuance and complexity here – 
+Also, we know there's a ton of nuance and complexity here –
 just do your best to be aware of and sensitive about your language choices!
 
 Slide display details

--- a/docs/origin-story.rst
+++ b/docs/origin-story.rst
@@ -40,7 +40,7 @@ Living in Portland, I'm lucky to be surrounded by some amazing people.
 If you wander down to the `food
 carts <http://www.foodcartsportland.com/>`__ on any given weekday at
 lunch time, you're likely to run into any number of luminary 'people
-from the internet' hanging around.
+from the internet' hanging around.
 
 One of those people might be `Eric
 Holscher <http://twitter.com/ericholscher>`__. I've known Eric since
@@ -52,7 +52,7 @@ developer <http://ericholscher.com/blog/2009/nov/10/what-they-didnt-teach-me-col
 I was vaguely aware of his side-project, `Read The
 Docs <https://readthedocs.org/>`__, which, `since
 2010 <http://ericholscher.com/blog/2010/aug/16/announcing-read-docs/>`__
-has been a vital resource to the Python open source community.
+has been a vital resource to the Python open source community.
 
 As a developer, I have always cared about documentation, but I'm not
 sure I ever thought about it *deeply* until I got to know Eric Holscher
@@ -62,7 +62,7 @@ Urban Airship <http://ericholscher.com/blog/2013/jan/10/walk-woods/>`__
 and was able to work on Read the Docs full time. This was going well,
 but he was concerned about the future of the project. There didn't seem
 to be a sense of community around documentation. Was documentation ever
-going to be given the focus it needed?
+going to be given the focus it needed?
 
 At the same time, I looked around me and realized that here in Portland,
 I was surrounded by some amazing people working with documentation;
@@ -72,30 +72,30 @@ Hawthorn <http://hawthornlandings.org/>`__, `Adron
 Hall <https://twitter.com/adron>`__, `Joe
 Moon <https://twitter.com/joebadmo>`__, `Eric
 Redmond <https://twitter.com/coderoshi>`__. I saw a community that
-didn't see itself.
+didn't see itself.
 
 Eric Redmond was the first person I'd met with the (self-appointed) job
-title "documentarian".
+title "documentarian".
 
-Building a Community of Documentarians
+Building a Community of Documentarians
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 I have a `habit <http://nodepdx.org/>`__ of
 `starting <http://jsconf.cn/>`__
 `conferences <http://conf.writethedocs.org>`__, as well as local
 meetups, and creating terrible inside-joke-esque slang. I really enjoy
-helping people organize to create the things they want to see happen.
+helping people organize to create the things they want to see happen.
 
 Naturally, my first reaction to Eric Holscher's `existential
 angst <https://twitter.com/ericholscher/status/287998770011074560>`__
 about docs was, "Let's have a conference". I called up Eric Redmond and
 we had our first meeting of documentarians (I refer to them collectively
-as "the Erics").
+as "the Erics").
 
     There exists a group of documentarians in the world. Up until this
     point, they haven’t had a central place to meet each other, and
     coalesce into a community. We are providing the space to allow this
-    to happen, both in person and online.
+    to happen, both in person and online.
 
 The headline quote above is from a doc, then titled :doc:`/guide/about/vision/`, written
 that night. The Erics almost laughed the idea off at first; no one would
@@ -103,9 +103,9 @@ come, no one would sponsor it. I said "no really, it's not that hard,
 let's see what could happen" and bought another round of beer. So, we
 created a landing page with minimal details, included a call to action
 and a mailing list signup form, then `posted the link to
-Hacker News <https://news.ycombinator.com/item?id=5129425>`__.
+Hacker News <https://news.ycombinator.com/item?id=5129425>`__.
 
-It seems we touched a nerve.
+It seems we touched a nerve.
 
 Originally, `we were discussing a 50-100 person
 conference <https://twitter.com/thoward37/status/288797696939151360>`__,
@@ -116,7 +116,7 @@ variety of disciplines; technical writing industry groups, designers,
 typographers, literate programmers, API driven startups, and more. We
 quickly found a new venue, and sold out a 250 person conference. The
 `experience <https://andrewnhem.com/content-strategy/a-wonderful-time-at-write-the-docs-2013/>`__
-was amazing. We'd found our people, and they'd found us.
+was amazing. We'd found our people, and they'd found us.
 
 Now, we're ramping up for year two, with conferences both `in
 Portland <http://conf.writethedocs.org/na/2014/>`__ and `in
@@ -125,7 +125,7 @@ spring. We've seen local meetups spring up in `San
 Francisco <http://www.meetup.com/Write-the-Docs/>`__,
 `Boston <https://www.meetup.com/write-the-docs-bos/>`__, and `New
 York <http://www.meetup.com/Write-The-Docs-NY/>`__. We're working on
-building more.
+building more.
 
 ----------
 

--- a/docs/surveys/salary-survey/2019.rst
+++ b/docs/surveys/salary-survey/2019.rst
@@ -303,7 +303,7 @@ This figure is not very representative as it does not take into account
 the socio-economic situation in the countries of the very highest
 earners (out of the top 10 salary values, 9 were from the US and one
 from the UK) and the very lowest (the bottom 10 salary values were from
- India, Asia, and Eastern Europe).
+India, Asia, and Eastern Europe).
 
 Figures grouped into regions make a more useful baseline from which to
 determine what constitutes a “fair” salary.
@@ -619,7 +619,7 @@ Note: 3 respondents skipped this question
 The two largest age groups (26-35 year olds and 36-45 year olds)
 combined formed 67.5% of the total respondents. Only 4.6% of respondents
 fell into the youngest age group, and there were no respondents in the
-66+ age bracket.  
+66+ age bracket. 
 
 .. figure:: images/2019/12.svg
    :alt: Figure: Age

--- a/docs/surveys/salary-survey/2019.rst
+++ b/docs/surveys/salary-survey/2019.rst
@@ -296,7 +296,7 @@ Note: as 97% (632) of respondents reporting working between 30 and 60
 hours per week - a “full time” role - the 3% reporting fewer than 30
 hours have been omitted from the figures in this section.
 
-The median salary across all regions, before tax and any additional benefits, was $74,500 (meaning half of the
+The median salary across all regions, before tax and any additional benefits, was $74,500 (meaning half of the
 respondents earned more, and half earned less).
 
 This figure is not very representative as it does not take into account
@@ -479,7 +479,7 @@ unsatisfied.
 Reasons for dissatisfaction
 ---------------------------
 
-Note: 56% of respondents did not answer this question. Although the
+Note: 56% of respondents did not answer this question. Although the
 wording suggested that only those who indicated that they were
 unsatisfied should answer this question, 16 of those that rated
 themselves as “very satisfied” and 104 of those who rated themselves as

--- a/docs/surveys/salary-survey/2020.rst
+++ b/docs/surveys/salary-survey/2020.rst
@@ -423,7 +423,7 @@ Proportion of role officially related to documentation
 
    .. rubric:: What we asked
                                                                          
-    7. Documentation is:                                                 
+   7. Documentation is:                                                  
                                                                          
    -  the whole of my official job description                           
    -  part of my official job description                                
@@ -703,7 +703,7 @@ about the situation.
 Similarly, no negativity was reported from the 16 respondents in this
 group who worked on-site. Half of the on-site workers felt “very
 positive” and the other half were split between “positive” and
- “neutral”. In fact, only 1 respondent - from the “partially remote,
+“neutral”. In fact, only 1 respondent - from the “partially remote,
 partially onsite” segment - reported feeling “negative” about their work
 location, and no one reported feeling “very negative”.
 
@@ -762,13 +762,13 @@ Other Changes Due to COVID-19
    -  Social distancing measures have been introduced in my workplace    
       (masks, distance between desks, maximum people in a room, online   
       meetings only etc)                                                 
-   -   My hours have changed                                             
-   -   I was furloughed                                                  
-   -   I was laid off                                                    
-   -   I changed roles (within the same organization)                    
-   -   I changed roles (started work with a different organization)      
-   -   Other (please specify)                                            
-   -   None of the above                                                 
+   -  My hours have changed                                              
+   -  I was furloughed                                                   
+   -  I was laid off                                                     
+   -  I changed roles (within the same organization)                     
+   -  I changed roles (started work with a different organization)       
+   -  Other (please specify)                                             
+   -  None of the above                                                  
 
 .. _h.thwzeueyahop:
 
@@ -1117,19 +1117,19 @@ Additional Benefits - Employees
    -  Health insurance (in excess of government-mandated minimums)       
    -  Pension, superannuation, or retirement fund (in excess of any      
       government-mandated minimums)                                      
-   -   Stocks, shares, stock options, or equity                          
-   -   Commission payments                                               
-   -   Bonus payments                                                    
-   -   Professional development / ongoing education / conference budget  
-   -   Meals, meal vouchers, or food-related benefits                    
-   -   Gym, fitness, sport, or other wellness-related benefits           
-   -   Other types of insurance e.g. life insurance, accident insurance, 
+   -  Stocks, shares, stock options, or equity                           
+   -  Commission payments                                                
+   -  Bonus payments                                                     
+   -  Professional development / ongoing education / conference budget   
+   -  Meals, meal vouchers, or food-related benefits                     
+   -  Gym, fitness, sport, or other wellness-related benefits            
+   -  Other types of insurance e.g. life insurance, accident insurance,  
       income protection insurance                                        
-   -   Paid parental leave (in excess of government-mandated minimum)    
-   -   Time off or bonuses for community-related activities              
-   -   Unlimited PTO (paid/personal time off)                            
-   -   None of the above                                                 
-   -   Other (please specify)                                            
+   -  Paid parental leave (in excess of government-mandated minimum)     
+   -  Time off or bonuses for community-related activities               
+   -  Unlimited PTO (paid/personal time off)                             
+   -  None of the above                                                  
+   -  Other (please specify)                                             
 
 .. _h.ury4804ee83n:
 

--- a/docs/surveys/salary-survey/2020.rst
+++ b/docs/surveys/salary-survey/2020.rst
@@ -56,12 +56,12 @@ Section 1: Employment Parameters
 ---------------------------------
 
 In this section, we asked about the parameters of the respondent’s
-employment: 
+employment:
 
 -  whether they were employees, self-employed, or had been employed or
-   self-employed but were currently not working, 
+   self-employed but were currently not working,
 -  the number of hours they worked and the length of time they had held
-   the same position, 
+   the same position,
 -  whether they worked solo or as part of a team and how they classified
    their role, and
 -  how focused their role was on tasks related to documentation.
@@ -195,7 +195,7 @@ valid job title.
 
 The most common job title entered was “Technical Writer”, making up 33%
 of all respondents - but nearly double that (63% of respondents) entered
-job titles that included that phrase.    
+job titles that included that phrase.
 
 .. table::  Top Job Titles (including “technical writer”)
    :width: 80%
@@ -342,7 +342,7 @@ a manager or team leader.
 
 4 respondents selected “Other” and entered more information: 3 of these
 were special cases but essentially each worked as part of a team or
-multiple teams, while the final case indicated a solo role.    
+multiple teams, while the final case indicated a solo role.
 
 .. figure:: images/2020/team-breakdown.svg
    :alt: Figure: Team Breakdown
@@ -403,7 +403,7 @@ than 10 years,
 -  61% reported between 11 and 15 years,
 -  10 individual respondents indicated 20 years or more -  7 of these
    had clocked up either 20 or 21 years, and
--  single respondents each reported 23 years, 27 years, and 28 years.  
+-  single respondents each reported 23 years, 27 years, and 28 years. 
 
 .. figure:: images/2020/years-in-current-role.svg
    :alt: Figure: Years in Current Role
@@ -1228,7 +1228,7 @@ Salary Satisfaction - Employees
 On the whole, most employee respondents were satisfied (40.27%) or very
 satisfied (31.87%) with their salary and benefits. Those with neutral
 feelings made up 17.2% of employees, with those that were unsatisfied
-(8.8%) or very unsatisfied (1.87%) in the minority.  
+(8.8%) or very unsatisfied (1.87%) in the minority. 
 
 .. figure:: images/2020/salary-satisfaction-employees.svg
    :alt: Figure: Salary Satisfaction (Employees)

--- a/docs/surveys/salary-survey/2020.rst
+++ b/docs/surveys/salary-survey/2020.rst
@@ -31,7 +31,7 @@ expanded the scope to better cater for independent contractors, people
 who were currently out of work, and multiple currencies, and also added
 a section about the impact of the COVID-19 pandemic.
 
-805 people completed the survey in 2020, an increase of 24% over 2019.
+805 people completed the survey in 2020, an increase of 24% over 2019.
 
 This year, while our respondents specified the currency they were paid
 in, all numbers in this report have been converted to US dollars for
@@ -63,7 +63,7 @@ employment:
 -  the number of hours they worked and the length of time they had held
    the same position,
 -  whether they worked solo or as part of a team and how they classified
-   their role, and
+   their role, and
 -  how focused their role was on tasks related to documentation.
 
 .. _h.1rxh4j1e0028:
@@ -150,7 +150,7 @@ As in 2019, most respondents worked “full-time” hours:
 Of the 4.5% working part-time:
 
 -  1.6% worked up to 20 hours, and
--  2.9% worked between 21 and 30 hours.
+-  2.9% worked between 21 and 30 hours.
 
 3 respondents reported working over 60 hours per week: the highest
 entered value was a staggering 80 hours. In contrast, the highest
@@ -401,7 +401,7 @@ Of those respondents who had been with their current employer for more
 than 10 years,
 
 -  61% reported between 11 and 15 years,
--  10 individual respondents indicated 20 years or more -  7 of these
+-  10 individual respondents indicated 20 years or more -  7 of these
    had clocked up either 20 or 21 years, and
 -  single respondents each reported 23 years, 27 years, and 28 years. 
 
@@ -498,7 +498,7 @@ Proportion of role actually related to documentation
 Section 2: Work Location and COVID-19
 -------------------------------------
 
-In 2019, we included one question about work location: whether the
+In 2019, we included one question about work location: whether the
 respondent worked on site, remotely, or a combination of the two; the
 possible responses were arranged to also show if the work location was
 stipulated by the employer or the individual’s own choice.
@@ -714,11 +714,11 @@ location, and no one reported feeling “very negative”.
 
 .. _h.ynoi7l698d10:
 
-Overall Work Location
+Overall Work Location
 '''''''''''''''''''''
 
 Combining the results for respondents whose work location has changed
-with those whose location has not gives a snapshot of the work location
+with those whose location has not gives a snapshot of the work location
 of the whole community, both before the pandemic started and in the
 latter half of 2020.
 
@@ -934,7 +934,7 @@ and half earned less).
 
 This figure does not take into account the socio-economic situation in
 the countries of the very highest earners (the top 10 salaries were all
-from the United States) and the very lowest (the bottom 10 salaries were
+from the United States) and the very lowest (the bottom 10 salaries were
 from Asia and South America) - as well as the difference between the
 country of the employee and the country of the employer. Figures grouped
 into regions make a more useful baseline from which to determine what
@@ -1792,7 +1792,7 @@ had 5-10 years under their belts.
 
 The largest group was those with over 10 years of experience, just under
 40% of respondents. Of these, 198 reported between 10 and 20 years, 100
-reported between 20 and 30 years, and 23 reported over 30 years -  7 of
+reported between 20 and 30 years, and 23 reported over 30 years -  7 of
 which were veterans of over 40 years. The highest reported value was 44
 years (1 respondent).
 
@@ -1839,15 +1839,15 @@ The majority of respondents - 93.3% had completed a college or university gradua
 qualification or higher - 54% had a graduate qualification (Certificate,
 Diploma, Associate Degree, or Bachelor's Degree) and 39% had completed a
 post-graduate qualification (Master's Degree, Post-Graduate Diploma or
-Certificate, or Doctorate). Those completing technical college or
+Certificate, or Doctorate). Those completing technical college or
 equivalent numbered 2.2%, and those completing high school only
 (including those who did some tertiary education but did not achieve a
 formal qualification) accounted for 4% of respondents, and technical
 college 2.2%.
 
 The responses entered for “Other” resulted in a new category being added
-for those that are still currently studying: 2 respondents indicated
-that they are currently working towards a degree.
+for those that are still currently studying: 2 respondents indicated
+that they are currently working towards a degree.
 
 2 respondents chose not to answer this question. 
 


### PR DESCRIPTION
For some reason, this repository has a number of line feed ([LF](https://www.fileformat.info/info/unicode/char/0a/index.htm)) characters where space ([SP](https://www.fileformat.info/info/unicode/char/20/index.htm)) characters seem more appropriate.

As changing them alone is a fairly large item, I'm splitting them out from a content change.

Note that I haven't stripped _all_ trailing space (SP) characters, but in some instances I did drop the run (I've used distinct commits for different replacements).

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2696.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->