### PR TITLE
australia: fix venue address, unconf link, and conf list typos for AU 2026

### DIFF
--- a/docs/_data/australia-2026-config.yaml
+++ b/docs/_data/australia-2026-config.yaml
@@ -129,7 +129,7 @@ about:
   attendees: 200
   social_venue: TBC
   venue: Treasury Theatre, Melbourne
-  venue_address: Lower Plaza, 1 Macarthur Stream
+  venue_address: Lower Plaza, 1 Macarthur Street
   photos: TBD
   mainroom: Theatre
   unconfroom: Breakout
@@ -145,7 +145,7 @@ cfp:
   preview: "TBD"
 
 unconf:
-  url: https://bit.ly/wtd-au-20256
+  url: https://bit.ly/wtd-au-2026
   date: "Thursday and Friday after the morning tea break"
 
 

--- a/docs/include/conf/current.rst
+++ b/docs/include/conf/current.rst
@@ -9,5 +9,5 @@ Current Conferences
 - :doc:`Portland 2026 </conf/portland/2026/index>`, May 3-5, **Portland, Oregon**
 - `Kenya 2026 <https://www.meetup.com/Write-the-Docs-Kenya/events/314376384/>`__, August 8, **Nairobi, Kenya**
 - :doc:`Berlin 2026 </conf/berlin/2026/index>`, September 6-8, **Berlin, Germany**
-- :doc:`Australia 2026 </conf/australia/2026/index>`, December 3-4, , **Melbourne, Australia**
+- :doc:`Australia 2026 </conf/australia/2026/index>`, December 3-4, **Melbourne, Australia**
 - Portland 2027, May 2-4, **Portland, Oregon**


### PR DESCRIPTION
A few small, obvious fixes spotted while reviewing #2699. Targeted at that PR's branch so it can be folded in.

- **Venue address:** `Lower Plaza, 1 Macarthur Stream` → `Macarthur Street`. The Treasury Theatre is at 1 Macarthur Street, East Melbourne — "Stream" is a typo.
- **Unconference short link:** `https://bit.ly/wtd-au-20256` → `https://bit.ly/wtd-au-2026`. Follows the established `wtd-au-<year>` pattern (2025 used `wtd-au-2025`); `20256` is a stray digit.
- **Current conferences list:** removed a stray double comma in the Australia 2026 entry (`December 3-4, , **Melbourne...**`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014hCAkw3YQAPMFo6EvHoKf2)_

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2713.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->