### PR TITLE
sponsors: Update Berlin 2026 sponsor information for three-day format

### DIFF
--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -207,7 +207,7 @@ flagticketsonsale: True
 flagsoldout: False
 flagscheduleincomplete: True
 flagspeakersannounced: True
-flagrunofshow: False
+flagrunofshow: True
 flaghasschedule: False
 flaghasshirts: False
 flaglivestreaming: False

--- a/docs/conf/berlin/2026/sponsors/information.md
+++ b/docs/conf/berlin/2026/sponsors/information.md
@@ -40,7 +40,7 @@ Hi sponsors! We're excited to have you join us for Write the Docs {{ name }} {{ 
 
 * **{{ date.day_two.dotw | upper }}**: The conference begins with [Writing Day](/conf/{{ shortcode }}/{{ year }}/schedule/) and typically is attended by one third of our attendees. The Welcome Reception takes place in the evening and brings in an additional wave of attendees. **There are no sponsor booths this day**, but sponsors are encouraged to submit and lead a Writing Day project.
 
-* **{{ date.day_three.dotw | upper }}**: Day 1 of Speaker Talks and Unconference. Booth setup for Keystone and Patron sponsors. Attendees arrive promptly when doors open. Sponsor introductions happen after the lightning talks on the main stage for Keystone and Patron sponsors. There are seven speakers, with a short break after each talk, and the Unconference track runs in parallel. An offsite social gathering is held {{ date.day_three.dotw }} evening.
+* **{{ date.day_three.dotw | upper }}**: Day 1 of Speaker Talks and Unconference. Keystone and Patron sponsors set up their booths before doors open, and are introduced on the main stage after the lightning talks. There are seven speakers, with a short break after each talk, and the Unconference track runs in parallel. An offsite social gathering follows in the evening.
 
 * **{{ date.day_four.dotw | upper }}**: Day 2 of Speaker Talks and Unconference. There are six speakers this day, leading to an earlier wrap up so people can travel. Schedule reflects {{ date.day_three.dotw }} with slight adjustments to beginning and end times. All materials must be removed from the venue on the last day of the conference.
 
@@ -58,7 +58,7 @@ Each sponsorship includes different opportunities to engage with our attendees. 
 
 ### Sponsor Booths - Keystone and Patron
 
-Sponsor booths are set up in the main hallway on {{ date.day_three.dotw }} and {{ date.day_four.dotw }} outside of the auditorium. Attendees are always looking for great products to use in their day to day workflows, and are curious to learn more about your company.
+Attendees are always looking for great products to use in their day-to-day workflows, and are curious to learn more about your company.
 
 **Location:** Main hallway, outside the auditorium
 **Availability:** {{ date.day_three.dotw }} and {{ date.day_four.dotw }}, full conference hours
@@ -68,7 +68,6 @@ Sponsor booths are set up in the main hallway on {{ date.day_three.dotw }} and {
 - **Keystone:** a 200 × 80 cm (6.5') table with 2 chairs, a monitor, and access to power and Wi‑Fi
 - **Patron:** a 200 × 80 cm (6.5') table with 2 chairs, and access to power and Wi‑Fi
 - Monitor rental available for Patron sponsors for {{ sponsorship.monitor_rental.price }}
-- You must provide your own table linen
 
 #### What the Sponsor Provides
 
@@ -79,20 +78,20 @@ Sponsor booths are set up in the main hallway on {{ date.day_three.dotw }} and {
 
 #### Booth Logistics
 
-* **Setup:** Sponsor arrival is 08:00 on {{ date.day_three.dotw }}; the venue opens to attendees at 09:00. We recommend arriving on time to be set up for attendee arrival. Check in with the Sponsorship Coordinator for specific setup questions.
-* **Presence:** The most important times to be present at your booth are during the breaks and at the start of the lunch break. This is when attendees are most engaged and you can easily chat with them without other events happening.
+* **Setup:** Sponsor arrival is 08:00 on {{ date.day_three.dotw }}; the venue opens to attendees at 09:00. Arrive on time so your booth is ready before then. Check in with the Sponsorship Coordinator for specific setup questions.
+* **Presence:** The most important times to staff your booth are during breaks and at the start of lunch, when attendees are most engaged and free to chat.
 * **Load-out:** You are responsible for loading in and out your entire booth setup. All materials must be out of the venue by 17:30 on {{ date.day_four.dotw }}.
 * **Tips:** Engage with folks as both a sponsor and attendee. QR codes are a great way to get people to a website quickly — we recommend a service like <https://www.qr-code-generator.com/> to create these.
 
 ### Sponsor Introduction
 
-If you have a sponsorship booth, you will have time on the main stage to introduce yourself to attendees. This is a great opportunity to share what your company does and why they should come talk with you at the booth.
+If you have a sponsorship booth, you will have time on the main stage to introduce yourself to attendees — a chance to share what your company does and why they should come talk with you at the booth.
 
 **Logistics**:
 
 * Sponsor introductions happen after the lightning talks on {{ date.day_three.dotw }}.
 * Keystone sponsors have 60 seconds and Patron sponsors have 30 seconds, to ensure all sponsors have equal time.
-* You will have a slide on the stage with your company logo. Let us know if you'd like a custom slide with additional information (e.g. a QR code and additional info).
+* You will have a slide on the stage with your company logo. Let us know if you'd like a custom one with more detail, such as a QR code.
 
 ### Lightning Talk Sponsor
 
@@ -103,7 +102,7 @@ If you are sponsoring a Lightning Talk, you will be given 60 seconds to share ab
 Host a project at Writing Day. This is a place where the community gathers to get actual work done and is a great opportunity to meet with a small group and have extended interaction with attendees.
 
 * View our [Lead a Project](https://www.writethedocs.org/conf/{{ shortcode }}/{{ year }}/writing-day/#lead-a-project) for more information.
-* [Submit your Writing Day project here.](https://docs.google.com/forms/d/e/1FAIpQLSfr5-2yJOFVjYLA2jaik8nP17nxm3fKDX6GA64SAyC14uKr1Q/viewform?usp=dialog) All projects submitted by {{ writing_day.project_deadline }} will be published to our website, which encourages attendees to attend, engage with your product, and contribute to your documentation.
+* [Submit your Writing Day project here.](https://docs.google.com/forms/d/e/1FAIpQLSfr5-2yJOFVjYLA2jaik8nP17nxm3fKDX6GA64SAyC14uKr1Q/viewform?usp=dialog) All projects submitted by {{ writing_day.project_deadline }} will be published to our website, which encourages attendees to join your project, engage with your product, and contribute to your documentation.
 
 ### Host an Unconference Session
 
@@ -119,7 +118,7 @@ Host an Unconference session. This is a wonderful opportunity to lead, contribut
 
 ### How do I get the most out of my sponsorship?
 
-Come prepared to engage with our community, and to learn just as much as you teach. Engage with our event as attendees as well as other sponsors. Send technical staff who can chat with people on the interesting things your company is doing, and get value from the vast amount of insight in the room. We do have some decision makers in the room, but soft sells will work better than hard sales in the environment we strive for.
+Come prepared to engage with our community, and to learn just as much as you teach. Take part as attendees as well as sponsors. Send technical staff who can chat with people about the interesting things your company is doing, and get value from the vast amount of insight in the room. We do have some decision makers present, but soft sells will work better than hard sales in the environment we strive for.
 
 ### Who is my primary contact?
 

--- a/docs/conf/berlin/2026/sponsors/information.md
+++ b/docs/conf/berlin/2026/sponsors/information.md
@@ -17,24 +17,24 @@ Hi sponsors! We're excited to have you join us for Write the Docs {{ name }} {{ 
 
 **{{ date.day_two.dotw | upper }}, {{ date.day_two.date | upper }}**:
 
-* 10:00: Doors open
+* 09:00: Doors open
 * 10:00–18:00: Writing Day and check in
 * 17:00–19:00: Welcome reception
 
 **{{ date.day_three.dotw | upper }}, {{ date.day_three.date | upper }}**:
 
 * 08:00: Arrival and booth setup for Keystone/Patron sponsors
-* 08:30: Doors to venue/sponsor booths open
+* 09:00: Doors to venue/sponsor booths open
 * 10:00–17:00: Speaker Talks and Unconference
 * 19:00–21:00: Social event
 
 **{{ date.day_four.dotw | upper }}, {{ date.day_four.date | upper }}**:
 
-* 08:30: Keystone/Patron sponsor arrival
-* 09:00: Doors to venue/sponsor booths open
-* 10:00–17:00: Speaker Talks and Unconference
-* 17:00: Conference ends/load out
-* 18:00: Out of the venue
+* 09:00: Keystone/Patron sponsor arrival
+* 09:30: Doors to venue/sponsor booths open
+* 10:00–16:00: Speaker Talks and Unconference
+* 16:00: Conference ends/load out
+* 17:30: Out of the venue
 
 ## Conference Overview
 
@@ -79,9 +79,9 @@ Sponsor booths are set up in the main hallway on {{ date.day_three.dotw }} and {
 
 #### Booth Logistics
 
-* **Setup:** Sponsor arrival is 08:00 on {{ date.day_three.dotw }}; the venue opens to attendees at 08:30. We recommend arriving on time to be set up for attendee arrival. Check in with the Sponsorship Coordinator for specific setup questions.
+* **Setup:** Sponsor arrival is 08:00 on {{ date.day_three.dotw }}; the venue opens to attendees at 09:00. We recommend arriving on time to be set up for attendee arrival. Check in with the Sponsorship Coordinator for specific setup questions.
 * **Presence:** The most important times to be present at your booth are during the breaks and at the start of the lunch break. This is when attendees are most engaged and you can easily chat with them without other events happening.
-* **Load-out:** You are responsible for loading in and out your entire booth setup. All materials must be out of the venue by 18:00 on {{ date.day_four.dotw }}.
+* **Load-out:** You are responsible for loading in and out your entire booth setup. All materials must be out of the venue by 17:30 on {{ date.day_four.dotw }}.
 * **Tips:** Engage with folks as both a sponsor and attendee. QR codes are a great way to get people to a website quickly — we recommend a service like <https://www.qr-code-generator.com/> to create these.
 
 ### Lightning Talk Sponsor
@@ -128,6 +128,6 @@ You should have received a unique URL with a discount code for your sponsorship 
 * Sponsors are responsible for all sponsorship materials after they arrive at the venue.
 * Sponsors are responsible for mailing all materials after the conference.
 * Please print your return shipping labels prior to coming to the venue to send your materials back.
-* **All materials must be out of the venue by 18:00 on {{ date.day_four.dotw }}.**
+* **All materials must be out of the venue by 17:30 on {{ date.day_four.dotw }}.**
 
 If you have any further questions, reach out to Eric Holscher or <sponsorship@writethedocs.org>.

--- a/docs/conf/berlin/2026/sponsors/information.md
+++ b/docs/conf/berlin/2026/sponsors/information.md
@@ -1,7 +1,7 @@
 ---
 template: {{year}}/generic.html
 og:image: _static/conf/images/headers/{{ shortcode }}-{{year}}-opengraph.jpg
-banner: _static/conf/images/headers/berlin-2025-venue.jpg
+banner: _static/conf/images/headers/2026/sponsors.jpg
 ---
 
 # Sponsor Information
@@ -18,67 +18,93 @@ Hi sponsors! We're excited to have you join us for Write the Docs {{ name }} {{ 
 **{{ date.day_two.dotw | upper }}, {{ date.day_two.date | upper }}**:
 
 * 10:00: Doors open
-* 10:00-18:00: Writing Day and check in
-* 17:00-19:00: Welcome reception
+* 10:00–18:00: Writing Day and check in
+* 17:00–19:00: Welcome reception
 
 **{{ date.day_three.dotw | upper }}, {{ date.day_three.date | upper }}**:
 
 * 08:00: Arrival and booth setup for Keystone/Patron sponsors
 * 08:30: Doors to venue/sponsor booths open
-* 10:00-17:00: Speaker Talks and Unconference
-* 19:00-21:00: Social event
+* 10:00–17:00: Speaker Talks and Unconference
+* 11:35: Booth sponsor introductions on main stage
+* 19:00–21:00: Social event
 
 **{{ date.day_four.dotw | upper }}, {{ date.day_four.date | upper }}**:
 
 * 08:30: Keystone/Patron sponsor arrival
 * 09:00: Doors to venue/sponsor booths open
-* 10:00-17:00: Speaker Talks and Unconference
-* 17:30: Conference ends/load out
+* 10:00–17:00: Speaker Talks and Unconference
+* 17:00: Conference ends/load out
+* 18:00: Out of the venue
 
 ## Conference Overview
 
 * **{{ date.day_two.dotw | upper }}**: The conference begins with [Writing Day](/conf/{{ shortcode }}/{{ year }}/schedule/) and typically is attended by one third of our attendees. The Welcome Reception takes place in the evening and brings in an additional wave of attendees. **There are no sponsor booths this day**, but sponsors are encouraged to submit and lead a Writing Day project.
 
-* **{{ date.day_three.dotw | upper }}**: Day 1 of Speaker Talks and Unconference. Booth setup for Keystone and Patron sponsors. Attendees arrive promptly when doors open. Sponsor introductions are on the main stage for Keystone and Patron sponsors. The day features speaker talks with short breaks between each session, and the Unconference track runs in parallel. An offsite social gathering is held in the evening.
+* **{{ date.day_three.dotw | upper }}**: Day 1 of Speaker Talks and Unconference. Booth setup for Keystone and Patron sponsors. Attendees arrive promptly when doors open. Sponsor introductions happen after the first coffee break on the main stage for Keystone and Patron sponsors. There are seven speakers, with a short break after each talk, and the Unconference track runs in parallel. An offsite social gathering is held {{ date.day_three.dotw }} evening.
 
-* **{{ date.day_four.dotw | upper }}**: Day 2 of Speaker Talks and Unconference. Schedule reflects {{ date.day_three.dotw }} with slight adjustments to beginning and end times.
+* **{{ date.day_four.dotw | upper }}**: Day 2 of Speaker Talks and Unconference. There are six speakers this day, leading to an earlier wrap up so people can travel. Schedule reflects {{ date.day_three.dotw }} with slight adjustments to beginning and end times. All materials must be removed from the venue on the last day of the conference.
 
-The [full schedule](/conf/{{ shortcode }}/{{ year }}/schedule/) will be available here.
+The [full schedule](/conf/{{ shortcode }}/{{ year }}/schedule/) will be available around a month before the conference.
 
 ### Venue Layout
 
 Our [Venue page](/conf/{{ shortcode }}/{{ year }}/venue/) has more information about the venue, including the location of the sponsor booths, speaker talks, and other conference spaces.
 
+<!-- Media Kit is intentionally omitted for Berlin -->
+
 ## Sponsorship Benefits During the Conference
 
-Each sponsorship includes different opportunities to engage with our attendees. View further information below on specifics to sponsor booths, Writing Day, Unconference, and Lightning Talks. 
+Each sponsorship includes different opportunities to engage with our attendees. View further information below on specifics to sponsor booths, sponsor introductions, Writing Day, Unconference, and Lightning Talks.
 
 ### Sponsor Booths - Keystone and Patron
 
-Sponsor booths are set up in the main hallway on {{ date.day_two.dotw }} and {{ date.day_three.dotw }}.
+Sponsor booths are set up in the main hallway on {{ date.day_three.dotw }} and {{ date.day_four.dotw }} outside of the auditorium. Attendees are always looking for great products to use in their day to day workflows, and are curious to learn more about your company.
+
+**Location:** Main hallway, outside the auditorium
+**Availability:** {{ date.day_three.dotw }} and {{ date.day_four.dotw }}, full conference hours
+
+#### What Write the Docs Provides
+
+- **Keystone:** a 200 × 80 cm (6.5') table with 2 chairs, a monitor, and access to power and Wi‑Fi
+- **Patron:** a 200 × 80 cm (6.5') table with 2 chairs, and access to power and Wi‑Fi
+- Monitor rental available for Patron sponsors for {{ sponsorship.monitor_rental.price }}
+- You must provide your own table linen
+
+#### What the Sponsor Provides
+
+- Table linen (we encourage one with your company logo)
+- Laptop, tablet, or monitor to display your product
+- Banner (a banner frame placed behind your table works well)
+- Swag for attendees (stickers are by far the most popular item)
+
+#### Booth Logistics
+
+* **Setup:** Sponsor arrival is 08:00 on {{ date.day_three.dotw }}; the venue opens to attendees at 08:30. We recommend arriving on time to be set up for attendee arrival. Check in with the Sponsorship Coordinator for specific setup questions.
+* **Presence:** The most important times to be present at your booth are during the breaks and at the start of the lunch break. This is when attendees are most engaged and you can easily chat with them without other events happening.
+* **Load-out:** You are responsible for loading in and out your entire booth setup. All materials must be out of the venue by 18:00 on {{ date.day_four.dotw }}.
+* **Tips:** Engage with folks as both a sponsor and attendee. QR codes are a great way to get people to a website quickly — we recommend a service like <https://www.qr-code-generator.com/> to create these.
+
+### Sponsor Introduction
+
+If you have a sponsorship booth, you will have time on the main stage to introduce yourself to attendees. This is a great opportunity to share what your company does and why they should come talk with you at the booth.
 
 **Logistics**:
 
-* **WTD provides**: Each sponsor receives a table, 2 chairs, and access to power and wifi. You must provide your own linen.
-* You are responsible for loading in and loading out your entire booth setup.
-* **Sponsor provides**:
-  - Table linen
-  - Laptop/tablets/monitor to display your product
-  - Banner
-* **Arrive early for setup**: The conference venue opens to attendees at 08:30. We recommend arriving on time to be set up for attendee arrival.
-* **Be present at your booth during the breaks and at the start of lunch break.**
-* **Bring swag (especially stickers)**: Stickers are by far the most popular item for our attendees.
-* **Engage with folks as both a sponsor and attendee**: This is a great opportunity to meet folks in the community, so we recommend engaging with folks in an official capacity, but also as a regular attendee.
+* Sponsor introductions happen at the end of the first coffee break on {{ date.day_three.dotw }}.
+* Keystone sponsors have 60 seconds and Patron sponsors have 30 seconds, to ensure all sponsors have equal time.
+* You will have a slide on the stage with your company logo. Let us know if you'd like a custom slide with additional information (e.g. a QR code and additional info).
 
 ### Lightning Talk Sponsor
 
-If you are sponsoring a Lightning Talk, you will be given 60 seconds to share about your company. This will occur on {{ date.day_two.dotw }} OR {{ date.day_three.dotw }} after lunch. If you want to use a slide for your introduction, let us know. Otherwise, we will create a slide with your logo.
+If you are sponsoring a Lightning Talk, you will be given 60 seconds to share about your company. This will occur on {{ date.day_three.dotw }} OR {{ date.day_four.dotw }} after lunch. If you want to use a slide for your introduction, let us know. Otherwise, we will create a slide with your logo.
 
 ### Participate in Writing Day
 
-Host a project at Writing Day. This is a place where the community gathers to get actual work done and is a great opportunity to meet with a small group and have extended interaction with attendees. 
+Host a project at Writing Day. This is a place where the community gathers to get actual work done and is a great opportunity to meet with a small group and have extended interaction with attendees.
 
 * View our [Lead a Project](https://www.writethedocs.org/conf/{{ shortcode }}/{{ year }}/writing-day/#lead-a-project) for more information.
+* [Submit your Writing Day project here.](https://docs.google.com/forms/d/e/1FAIpQLSfr5-2yJOFVjYLA2jaik8nP17nxm3fKDX6GA64SAyC14uKr1Q/viewform?usp=dialog) All projects submitted by {{ writing_day.project_deadline }} will be published to our website, which encourages attendees to attend, engage with your product, and contribute to your documentation.
 
 ### Host an Unconference Session
 
@@ -86,7 +112,7 @@ Host an Unconference session. This is a wonderful opportunity to lead, contribut
 
 **Logistics**:
 
-* Sessions are 40 minutes in length on {{ date.day_two.dotw }} and {{ date.day_three.dotw }}.
+* Sessions are 40 minutes in length on {{ date.day_three.dotw }} and {{ date.day_four.dotw }}.
 * Let us know in advance if you plan to run an unconference session so we can confirm a suitable timeslot for you.
 * View more on how to Lead a Session on our [Unconference](/conf/{{ shortcode }}/{{ year }}/unconference/) page.
 
@@ -100,14 +126,19 @@ Come prepared to engage with our community, and to learn just as much as you tea
 
 Eric Holscher will be your primary contact, but our team is available at <sponsorship@writethedocs.org>. If you have a time sensitive inquiry, please email the entire team to ensure a timely response.
 
+If you have questions during the conference, check in with our Executive Producer Katie Janovec or our Welcome Wagon team at registration. You will find staff members there to answer any additional questions you might have.
+
 ### How do I use my sponsorship tickets?
 
 You should have received a unique URL with a discount code for your sponsorship tickets. We are happy to send it over again, just ask!
 
 ### How should I send my booth materials?
 
-* Please contact us for shipping details, as the venue doesn't accept packages directly.
-* Sponsors are responsible for all sponsorship materials after they arrive at the venue. 
+* Keystone and Patron sponsors are allowed to send 3 boxes at 61 × 46 × 46 cm (24 × 18 × 18 in) in size. Please contact us for the shipping address, as the venue doesn't accept packages directly.
+* Packages must arrive no more than 1 week before the conference.
+* Sponsors are responsible for all sponsorship materials after they arrive at the venue.
 * Sponsors are responsible for mailing all materials after the conference.
+* Please print your return shipping labels prior to coming to the venue to send your materials back.
+* **All materials must be out of the venue by 18:00 on {{ date.day_four.dotw }}.**
 
 If you have any further questions, reach out to Eric Holscher or <sponsorship@writethedocs.org>.

--- a/docs/conf/berlin/2026/sponsors/information.md
+++ b/docs/conf/berlin/2026/sponsors/information.md
@@ -15,6 +15,8 @@ Hi sponsors! We're excited to have you join us for Write the Docs {{ name }} {{ 
 
 ## Schedule
 
+Times below are approximate and not fully confirmed until the [full schedule](/conf/{{ shortcode }}/{{ year }}/schedule/) goes live.
+
 **{{ date.day_two.dotw | upper }}, {{ date.day_two.date | upper }}**:
 
 * 09:00: Doors open

--- a/docs/conf/berlin/2026/sponsors/information.md
+++ b/docs/conf/berlin/2026/sponsors/information.md
@@ -123,7 +123,7 @@ You should have received a unique URL with a discount code for your sponsorship 
 
 ### How should I send my booth materials?
 
-* Keystone and Patron sponsors are allowed to send 3 boxes at 61 × 46 × 46 cm (24 × 18 × 18 in) in size. Please contact us for the shipping address, as the venue doesn't accept packages directly.
+* Keystone and Patron sponsors are allowed to send 3 boxes at 61 × 46 × 46 cm (24 × 18 × 18 in) in size. Please contact us for the shipping address.
 * Packages must arrive no more than 1 week before the conference.
 * Sponsors are responsible for all sponsorship materials after they arrive at the venue.
 * Sponsors are responsible for mailing all materials after the conference.

--- a/docs/conf/berlin/2026/sponsors/information.md
+++ b/docs/conf/berlin/2026/sponsors/information.md
@@ -26,7 +26,6 @@ Hi sponsors! We're excited to have you join us for Write the Docs {{ name }} {{ 
 * 08:00: Arrival and booth setup for Keystone/Patron sponsors
 * 08:30: Doors to venue/sponsor booths open
 * 10:00–17:00: Speaker Talks and Unconference
-* 11:35: Booth sponsor introductions on main stage
 * 19:00–21:00: Social event
 
 **{{ date.day_four.dotw | upper }}, {{ date.day_four.date | upper }}**:
@@ -41,7 +40,7 @@ Hi sponsors! We're excited to have you join us for Write the Docs {{ name }} {{ 
 
 * **{{ date.day_two.dotw | upper }}**: The conference begins with [Writing Day](/conf/{{ shortcode }}/{{ year }}/schedule/) and typically is attended by one third of our attendees. The Welcome Reception takes place in the evening and brings in an additional wave of attendees. **There are no sponsor booths this day**, but sponsors are encouraged to submit and lead a Writing Day project.
 
-* **{{ date.day_three.dotw | upper }}**: Day 1 of Speaker Talks and Unconference. Booth setup for Keystone and Patron sponsors. Attendees arrive promptly when doors open. Sponsor introductions happen after the first coffee break on the main stage for Keystone and Patron sponsors. There are seven speakers, with a short break after each talk, and the Unconference track runs in parallel. An offsite social gathering is held {{ date.day_three.dotw }} evening.
+* **{{ date.day_three.dotw | upper }}**: Day 1 of Speaker Talks and Unconference. Booth setup for Keystone and Patron sponsors. Attendees arrive promptly when doors open. There are seven speakers, with a short break after each talk, and the Unconference track runs in parallel. An offsite social gathering is held {{ date.day_three.dotw }} evening.
 
 * **{{ date.day_four.dotw | upper }}**: Day 2 of Speaker Talks and Unconference. There are six speakers this day, leading to an earlier wrap up so people can travel. Schedule reflects {{ date.day_three.dotw }} with slight adjustments to beginning and end times. All materials must be removed from the venue on the last day of the conference.
 
@@ -55,7 +54,7 @@ Our [Venue page](/conf/{{ shortcode }}/{{ year }}/venue/) has more information a
 
 ## Sponsorship Benefits During the Conference
 
-Each sponsorship includes different opportunities to engage with our attendees. View further information below on specifics to sponsor booths, sponsor introductions, Writing Day, Unconference, and Lightning Talks.
+Each sponsorship includes different opportunities to engage with our attendees. View further information below on specifics to sponsor booths, Writing Day, Unconference, and Lightning Talks.
 
 ### Sponsor Booths - Keystone and Patron
 
@@ -84,16 +83,6 @@ Sponsor booths are set up in the main hallway on {{ date.day_three.dotw }} and {
 * **Presence:** The most important times to be present at your booth are during the breaks and at the start of the lunch break. This is when attendees are most engaged and you can easily chat with them without other events happening.
 * **Load-out:** You are responsible for loading in and out your entire booth setup. All materials must be out of the venue by 18:00 on {{ date.day_four.dotw }}.
 * **Tips:** Engage with folks as both a sponsor and attendee. QR codes are a great way to get people to a website quickly — we recommend a service like <https://www.qr-code-generator.com/> to create these.
-
-### Sponsor Introduction
-
-If you have a sponsorship booth, you will have time on the main stage to introduce yourself to attendees. This is a great opportunity to share what your company does and why they should come talk with you at the booth.
-
-**Logistics**:
-
-* Sponsor introductions happen at the end of the first coffee break on {{ date.day_three.dotw }}.
-* Keystone sponsors have 60 seconds and Patron sponsors have 30 seconds, to ensure all sponsors have equal time.
-* You will have a slide on the stage with your company logo. Let us know if you'd like a custom slide with additional information (e.g. a QR code and additional info).
 
 ### Lightning Talk Sponsor
 

--- a/docs/conf/berlin/2026/sponsors/information.md
+++ b/docs/conf/berlin/2026/sponsors/information.md
@@ -40,7 +40,7 @@ Hi sponsors! We're excited to have you join us for Write the Docs {{ name }} {{ 
 
 * **{{ date.day_two.dotw | upper }}**: The conference begins with [Writing Day](/conf/{{ shortcode }}/{{ year }}/schedule/) and typically is attended by one third of our attendees. The Welcome Reception takes place in the evening and brings in an additional wave of attendees. **There are no sponsor booths this day**, but sponsors are encouraged to submit and lead a Writing Day project.
 
-* **{{ date.day_three.dotw | upper }}**: Day 1 of Speaker Talks and Unconference. Booth setup for Keystone and Patron sponsors. Attendees arrive promptly when doors open. There are seven speakers, with a short break after each talk, and the Unconference track runs in parallel. An offsite social gathering is held {{ date.day_three.dotw }} evening.
+* **{{ date.day_three.dotw | upper }}**: Day 1 of Speaker Talks and Unconference. Booth setup for Keystone and Patron sponsors. Attendees arrive promptly when doors open. Sponsor introductions happen after the first coffee break on the main stage for Keystone and Patron sponsors. There are seven speakers, with a short break after each talk, and the Unconference track runs in parallel. An offsite social gathering is held {{ date.day_three.dotw }} evening.
 
 * **{{ date.day_four.dotw | upper }}**: Day 2 of Speaker Talks and Unconference. There are six speakers this day, leading to an earlier wrap up so people can travel. Schedule reflects {{ date.day_three.dotw }} with slight adjustments to beginning and end times. All materials must be removed from the venue on the last day of the conference.
 
@@ -54,7 +54,7 @@ Our [Venue page](/conf/{{ shortcode }}/{{ year }}/venue/) has more information a
 
 ## Sponsorship Benefits During the Conference
 
-Each sponsorship includes different opportunities to engage with our attendees. View further information below on specifics to sponsor booths, Writing Day, Unconference, and Lightning Talks.
+Each sponsorship includes different opportunities to engage with our attendees. View further information below on specifics to sponsor booths, sponsor introductions, Writing Day, Unconference, and Lightning Talks.
 
 ### Sponsor Booths - Keystone and Patron
 
@@ -83,6 +83,16 @@ Sponsor booths are set up in the main hallway on {{ date.day_three.dotw }} and {
 * **Presence:** The most important times to be present at your booth are during the breaks and at the start of the lunch break. This is when attendees are most engaged and you can easily chat with them without other events happening.
 * **Load-out:** You are responsible for loading in and out your entire booth setup. All materials must be out of the venue by 17:30 on {{ date.day_four.dotw }}.
 * **Tips:** Engage with folks as both a sponsor and attendee. QR codes are a great way to get people to a website quickly — we recommend a service like <https://www.qr-code-generator.com/> to create these.
+
+### Sponsor Introduction
+
+If you have a sponsorship booth, you will have time on the main stage to introduce yourself to attendees. This is a great opportunity to share what your company does and why they should come talk with you at the booth.
+
+**Logistics**:
+
+* Sponsor introductions happen at the end of the first coffee break on {{ date.day_three.dotw }}.
+* Keystone sponsors have 60 seconds and Patron sponsors have 30 seconds, to ensure all sponsors have equal time.
+* You will have a slide on the stage with your company logo. Let us know if you'd like a custom slide with additional information (e.g. a QR code and additional info).
 
 ### Lightning Talk Sponsor
 

--- a/docs/conf/berlin/2026/sponsors/information.md
+++ b/docs/conf/berlin/2026/sponsors/information.md
@@ -40,7 +40,7 @@ Hi sponsors! We're excited to have you join us for Write the Docs {{ name }} {{ 
 
 * **{{ date.day_two.dotw | upper }}**: The conference begins with [Writing Day](/conf/{{ shortcode }}/{{ year }}/schedule/) and typically is attended by one third of our attendees. The Welcome Reception takes place in the evening and brings in an additional wave of attendees. **There are no sponsor booths this day**, but sponsors are encouraged to submit and lead a Writing Day project.
 
-* **{{ date.day_three.dotw | upper }}**: Day 1 of Speaker Talks and Unconference. Booth setup for Keystone and Patron sponsors. Attendees arrive promptly when doors open. Sponsor introductions happen after the first coffee break on the main stage for Keystone and Patron sponsors. There are seven speakers, with a short break after each talk, and the Unconference track runs in parallel. An offsite social gathering is held {{ date.day_three.dotw }} evening.
+* **{{ date.day_three.dotw | upper }}**: Day 1 of Speaker Talks and Unconference. Booth setup for Keystone and Patron sponsors. Attendees arrive promptly when doors open. Sponsor introductions happen after the lightning talks on the main stage for Keystone and Patron sponsors. There are seven speakers, with a short break after each talk, and the Unconference track runs in parallel. An offsite social gathering is held {{ date.day_three.dotw }} evening.
 
 * **{{ date.day_four.dotw | upper }}**: Day 2 of Speaker Talks and Unconference. There are six speakers this day, leading to an earlier wrap up so people can travel. Schedule reflects {{ date.day_three.dotw }} with slight adjustments to beginning and end times. All materials must be removed from the venue on the last day of the conference.
 
@@ -90,7 +90,7 @@ If you have a sponsorship booth, you will have time on the main stage to introdu
 
 **Logistics**:
 
-* Sponsor introductions happen at the end of the first coffee break on {{ date.day_three.dotw }}.
+* Sponsor introductions happen after the lightning talks on {{ date.day_three.dotw }}.
 * Keystone sponsors have 60 seconds and Patron sponsors have 30 seconds, to ensure all sponsors have equal time.
 * You will have a slide on the stage with your company logo. Let us know if you'd like a custom slide with additional information (e.g. a QR code and additional info).
 

--- a/docs/conf/berlin/2026/sponsors/information.md
+++ b/docs/conf/berlin/2026/sponsors/information.md
@@ -15,7 +15,7 @@ Hi sponsors! We're excited to have you join us for Write the Docs {{ name }} {{ 
 
 ## Schedule
 
-Times below are approximate and not fully confirmed until the [full schedule](/conf/{{ shortcode }}/{{ year }}/schedule/) goes live.
+The [full schedule](/conf/{{ shortcode }}/{{ year }}/schedule/) will be available around a month before the conference. Times below are approximate and not fully confirmed until it goes live.
 
 **{{ date.day_two.dotw | upper }}, {{ date.day_two.date | upper }}**:
 
@@ -45,8 +45,6 @@ Times below are approximate and not fully confirmed until the [full schedule](/c
 * **{{ date.day_three.dotw | upper }}**: Day 1 of Speaker Talks and Unconference. Keystone and Patron sponsors set up their booths before doors open, and are introduced on the main stage after the lightning talks. There are seven speakers, with a short break after each talk, and the Unconference track runs in parallel. An offsite social gathering follows in the evening.
 
 * **{{ date.day_four.dotw | upper }}**: Day 2 of Speaker Talks and Unconference. There are six speakers this day, leading to an earlier wrap up so people can travel. Schedule reflects {{ date.day_three.dotw }} with slight adjustments to beginning and end times. All materials must be removed from the venue on the last day of the conference.
-
-The [full schedule](/conf/{{ shortcode }}/{{ year }}/schedule/) will be available around a month before the conference.
 
 ### Venue Layout
 

--- a/docs/conf/berlin/2026/sponsors/information.md
+++ b/docs/conf/berlin/2026/sponsors/information.md
@@ -102,7 +102,7 @@ If you are sponsoring a Lightning Talk, you will be given 60 seconds to share ab
 Host a project at Writing Day. This is a place where the community gathers to get actual work done and is a great opportunity to meet with a small group and have extended interaction with attendees.
 
 * View our [Lead a Project](https://www.writethedocs.org/conf/{{ shortcode }}/{{ year }}/writing-day/#lead-a-project) for more information.
-* [Submit your Writing Day project here.](https://docs.google.com/forms/d/e/1FAIpQLSfr5-2yJOFVjYLA2jaik8nP17nxm3fKDX6GA64SAyC14uKr1Q/viewform?usp=dialog) All projects submitted by {{ writing_day.project_deadline }} will be published to our website, which encourages attendees to join your project, engage with your product, and contribute to your documentation.
+* All projects submitted by {{ writing_day.project_deadline }} will be published to our website, which encourages attendees to join your project, engage with your product, and contribute to your documentation.{% if writing_day.url %} [Submit your Writing Day project here.]({{ writing_day.url }}){% endif %}
 
 ### Host an Unconference Session
 

--- a/docs/conf/berlin/2026/sponsors/information.md
+++ b/docs/conf/berlin/2026/sponsors/information.md
@@ -40,7 +40,7 @@ The [full schedule](/conf/{{ shortcode }}/{{ year }}/schedule/) will be availabl
 
 ## Conference Overview
 
-* **{{ date.day_two.dotw | upper }}**: The conference begins with [Writing Day](/conf/{{ shortcode }}/{{ year }}/schedule/) and typically is attended by one third of our attendees. The Welcome Reception takes place in the evening and brings in an additional wave of attendees. **There are no sponsor booths this day**, but sponsors are encouraged to submit and lead a Writing Day project.
+* **{{ date.day_two.dotw | upper }}**: The conference begins with [Writing Day](/conf/{{ shortcode }}/{{ year }}/writing-day/) and typically is attended by one third of our attendees. The Welcome Reception takes place in the evening and brings in an additional wave of attendees. **There are no sponsor booths this day**, but sponsors are encouraged to submit and lead a Writing Day project.
 
 * **{{ date.day_three.dotw | upper }}**: Day 1 of Speaker Talks and Unconference. Keystone and Patron sponsors set up their booths before doors open, and are introduced on the main stage after the lightning talks. There are seven speakers, with a short break after each talk, and the Unconference track runs in parallel. An offsite social gathering follows in the evening.
 

--- a/docs/conf/berlin/2026/sponsors/prospectus.md
+++ b/docs/conf/berlin/2026/sponsors/prospectus.md
@@ -10,11 +10,7 @@ banner: _static/conf/images/headers/2026/prospectus.jpg
 
 Welcome to the Write the Docs {{ city }} {{ year }} sponsorship prospectus. We’re excited to work with the organizations in our community to build the best documentation event in {{ year }}. Created in 2013 in Portland, Oregon, WTD has hosted conferences around the world in Prague, Berlin, Sydney, London, and Melbourne. We’re excited to celebrate this year with your support!
 
-{% if flagrunofshow %}
-
-If you're an existing sponsor looking for next steps, check out our [Sponsorship Information page](/conf/{{shortcode}}/{{year}}/sponsors/information/).
-
-{% endif %}
+For details on getting the most out of your sponsorship, check out our [Sponsorship Information page](/conf/{{shortcode}}/{{year}}/sponsors/information/).
 
 ## Concept
 

--- a/docs/conf/berlin/2026/sponsors/prospectus.md
+++ b/docs/conf/berlin/2026/sponsors/prospectus.md
@@ -10,7 +10,11 @@ banner: _static/conf/images/headers/2026/prospectus.jpg
 
 Welcome to the Write the Docs {{ city }} {{ year }} sponsorship prospectus. We’re excited to work with the organizations in our community to build the best documentation event in {{ year }}. Created in 2013 in Portland, Oregon, WTD has hosted conferences around the world in Prague, Berlin, Sydney, London, and Melbourne. We’re excited to celebrate this year with your support!
 
-For details on getting the most out of your sponsorship, check out our [Sponsorship Information page](/conf/{{shortcode}}/{{year}}/sponsors/information/).
+{% if flagrunofshow %}
+
+If you're an existing sponsor looking for next steps, check out our [Sponsorship Information page](/conf/{{shortcode}}/{{year}}/sponsors/information/).
+
+{% endif %}
 
 ## Concept
 


### PR DESCRIPTION
Updates the Berlin 2026 sponsor information page for the three-day conference format. The page was based on the 2025 (two-day) event, so this triangulates between Berlin 2025 and Portland 2026: Berlin 2025 as the default (24-hour times, metric measurements, region-specific shipping and booth guidance) with the new 2026 events (Writing Day, welcome reception, social event) pulled from Portland 2026 and `berlin-2026-config.yaml`.

- Add Writing Day, welcome reception, and social event to the schedule and overview, using 2026 config values; note that times are approximate until the full schedule goes live
- Berlin schedule rhythm: talks start at 10:00, last day wraps at 16:00
- Add a "Participate in Writing Day" section, with the submit link gated on `writing_day.url` (matching the writing-day page convention from #2719)
- Split booth benefits into Keystone and Patron tiers
- Sponsor introductions happen on the main stage after the Monday lightning talks (no fixed time in the schedule yet)
- Restore Berlin-specific booth logistics, metric measurements, and shipping details; drop the "venue doesn't accept packages" language while still asking sponsors to contact us for the shipping address
- Enable `flagrunofshow` so the prospectus links to the Sponsor Information page
- Fix a broken banner image reference (`berlin-2025-venue.jpg` → `2026/sponsors.jpg`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fy5XsS9QWoz7GEWT9cgeUD)_

----
📚 Documentation preview 📚: https://writethedocs-www--2717.org.readthedocs.build/
