### PR TITLE
docs: update Berlin 2026 venue page from 2025 details

### DIFF
--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -150,12 +150,9 @@ about:
   social_venue: TBC
   venue: bUm Berlin
   venue_address: Paul-Lincke-Ufer 21, 10999 Berlin, Germany
-  venue_map_url: "https://www.google.com/maps/place/bUm+-+Raum+f%C3%BCr+solidarisches+Miteinander/@52.4937094,13.4270626,17z/data=!3m2!4b1!5s0x47a84fb459055813:0x3cad2ecfcf84e633!4m6!3m5!1s0x47a84fd9cf3e7c43:0x538772e39fff3a0e!8m2!3d52.4937094!4d13.4296375!16s%2Fg%2F11h91cct20?entry=ttu&g_ep=EgoyMDI1MDgyNS4wIKXMDSoASAFQAw%3D%3D"
   photos: TBD
   mainroom: Auditorium on ground floor
   unconfroom: bUm Box on first floor
-  registration_room: Foyer on ground floor
-  catering_room: Wintergarten in basement
   projector_ratio: "16:9"
 
 cfp:

--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -149,10 +149,13 @@ about:
   attendees: 200
   social_venue: TBC
   venue: bUm Berlin
-  venue_address: Paul-Lincke-Ufer 21, 10999 Berlin
+  venue_address: Paul-Lincke-Ufer 21, 10999 Berlin, Germany
+  venue_map_url: "https://www.google.com/maps/place/bUm+-+Raum+f%C3%BCr+solidarisches+Miteinander/@52.4937094,13.4270626,17z/data=!3m2!4b1!5s0x47a84fb459055813:0x3cad2ecfcf84e633!4m6!3m5!1s0x47a84fd9cf3e7c43:0x538772e39fff3a0e!8m2!3d52.4937094!4d13.4296375!16s%2Fg%2F11h91cct20?entry=ttu&g_ep=EgoyMDI1MDgyNS4wIKXMDSoASAFQAw%3D%3D"
   photos: TBD
-  mainroom: Main stage
-  unconfroom: TBC
+  mainroom: Auditorium on ground floor
+  unconfroom: bUm Box on first floor
+  registration_room: Foyer on ground floor
+  catering_room: Wintergarten in basement
   projector_ratio: "16:9"
 
 cfp:

--- a/docs/_data/schema-config.yaml
+++ b/docs/_data/schema-config.yaml
@@ -190,8 +190,6 @@ about-details:
   attendees: any(int(), str())
   mainroom: str()
   unconfroom: str(required=False)
-  registration_room: str(required=False)
-  catering_room: str(required=False)
   job_fair_room: str(required=False)
   photos: str(required=False)
   projector_ratio: str(required=False)

--- a/docs/_data/schema-config.yaml
+++ b/docs/_data/schema-config.yaml
@@ -190,6 +190,8 @@ about-details:
   attendees: any(int(), str())
   mainroom: str()
   unconfroom: str(required=False)
+  registration_room: str(required=False)
+  catering_room: str(required=False)
   job_fair_room: str(required=False)
   photos: str(required=False)
   projector_ratio: str(required=False)

--- a/docs/conf/berlin/2026/venue.md
+++ b/docs/conf/berlin/2026/venue.md
@@ -28,26 +28,7 @@ bUm Berlin is easily accessible by public transport. The following stops are wit
 - U8: Schönleinstraße
 - U1 and U3: Görlitzer Bahnhof
 
-### From the U-Bahn
-
-The best way to get to the venue is to take the **U8 (Schönleinstraße)** or the **U7/U8 (Hermannplatz)**.
-
-From Schönleinstraße, take Bürknerstraße to the intersection at Hobrechtbrücke, cross the bridge and turn right.
-
-From Hermannplatz, you can cross Sonnenallee, turn right into Weserstraße and then take the second street on the left (Friedelstraße). This also leads to Hobrechtbrücke, which you cross and then turn right onto Paul-Lincke-Ufer.
-
-Note: the subway station closest to bUm (Schönleinstraße) does not have an elevator. The Hermannplatz subway station has elevators.
-
-### Bus
-
-You can take the M29 bus to the Ohlauer Straße stop. From here, follow Ohlauer Straße south and turn left onto Paul-Lincke-Ufer.
-
-### Car
-
-If you would like to arrive by car, there are free public parking spaces on Paul-Lincke-Ufer - although these are often full.
-
 ## Conference Layout
-
 
 ### Registration, Welcome Wagon, and Sponsors
 
@@ -58,6 +39,7 @@ Location: Foyer on ground floor
 Location: Auditorium on ground floor
 
 ### Writing Day, Unconference, and Welcome Reception
+
 Location: bUm Box on first floor
 
 ### Catering and Communal Rooms

--- a/docs/conf/berlin/2026/venue.md
+++ b/docs/conf/berlin/2026/venue.md
@@ -7,36 +7,49 @@ og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
 # Venue
 
 ## bUm Berlin
+Paul-Lincke-Ufer 21, 10999 Berlin, Germany
+[Map link](https://www.google.com/maps/place/bUm+-+Raum+f%C3%BCr+solidarisches+Miteinander/@52.4937094,13.4270626,17z/data=!3m2!4b1!5s0x47a84fb459055813:0x3cad2ecfcf84e633!4m6!3m5!1s0x47a84fd9cf3e7c43:0x538772e39fff3a0e!8m2!3d52.4937094!4d13.4296375!16s%2Fg%2F11h91cct20?entry=ttu&g_ep=EgoyMDI1MDgyNS4wIKXMDSoASAFQAw%3D%3D)
 
-Paul-Lincke-Ufer 21, 10999 Berlin
+Our conference will be held at [bUm Berlin](https://www.bum.berlin/) - Raum für solidarisches Miteinander, a space for solidarity and engagement, on the Landwehrkanal in Kreuzberg. This is a community space for events, coworking, activists, and creatives.
 
-Our conference will be held at [bUm Berlin](https://www.bum.berlin/), a community and cultural centre located on the banks of the Landwehr Canal in the heart of Kreuzberg.
+## Getting to the Venue
 
-## Getting There
+### From the U-Bahn
 
-bUm Berlin is easily accessible by public transport. The following stops are within a 15-minute walk:
+The best way to get to the venue is to take the **U8 (Schönleinstraße)** or the **U7/U8 (Hermannplatz)**. You can also take the **U1/U3 (Görlitzer Bahnhof)**.
 
-**Bus**
+From Schönleinstraße, take Bürknerstraße to the intersection at Hobrechtbrücke, cross the bridge and turn right.
 
-- Line M29: Ohlauer Str.
-- Line 194: Pflügerstr.
-- Line M41: Jahnstr.
+From Hermannplatz, you can cross Sonnenallee, turn right into Weserstraße and then take the second street on the left (Friedelstraße). This also leads to Hobrechtbrücke, which you cross and then turn right onto Paul-Lincke-Ufer.
 
-**U-Bahn**
+Note: the subway station closest to bUm (Schönleinstraße) does not have an elevator. The Hermannplatz subway station has elevators.
 
-- U8: Schönleinstraße
-- U1 and U3: Görlitzer Bahnhof
+### Bus
+
+You can take the M29 bus to the Ohlauer Straße stop. From here, follow Ohlauer Straße south and turn left onto Paul-Lincke-Ufer. The 194 (Pflügerstr.) and M41 (Jahnstr.) lines also stop within a short walk of the venue.
+
+### Car
+
+If you would like to arrive by car, there are free public parking spaces on Paul-Lincke-Ufer - although these are often full.
 
 ## Conference Layout
 
-### Registration and Welcome Wagon
 
-Located at the entrance to the venue.
+### Registration, Welcome Wagon, and Sponsors
+
+Location: Foyer on ground floor
+
+### Speaker Talks
+
+Location: Auditorium on ground floor
 
 ### Writing Day, Unconference, and Welcome Reception
+Location: bUm Box on first floor
 
-**Location:** {{ about.mainroom }}
+### Catering and Communal Rooms
 
-### Speaker Talks, Sponsor Expo, and Catering
+Location: Wintergarten in basement
 
-**Location:** {{ about.mainroom }}
+View the [Attendee Guide](/conf/{{shortcode}}/{{year}}/attendee-guide/) for more information regarding spaces inside the venue.
+</content>
+</invoke>

--- a/docs/conf/berlin/2026/venue.md
+++ b/docs/conf/berlin/2026/venue.md
@@ -6,12 +6,12 @@ og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
 
 # Venue
 
-## bUm Berlin
+## {{ about.venue }}
 
-Paul-Lincke-Ufer 21, 10999 Berlin, Germany
-[Map link](https://www.google.com/maps/place/bUm+-+Raum+f%C3%BCr+solidarisches+Miteinander/@52.4937094,13.4270626,17z/data=!3m2!4b1!5s0x47a84fb459055813:0x3cad2ecfcf84e633!4m6!3m5!1s0x47a84fd9cf3e7c43:0x538772e39fff3a0e!8m2!3d52.4937094!4d13.4296375!16s%2Fg%2F11h91cct20?entry=ttu&g_ep=EgoyMDI1MDgyNS4wIKXMDSoASAFQAw%3D%3D)
+{{ about.venue_address }}
+[Map link]({{ about.venue_map_url }})
 
-Our conference will be held at [bUm Berlin](https://www.bum.berlin/), a community and cultural centre located on the banks of the Landwehr Canal in the heart of Kreuzberg.
+Our conference will be held at [{{ about.venue }}](https://www.bum.berlin/), a community and cultural centre located on the banks of the Landwehr Canal in the heart of Kreuzberg.
 
 ## Getting There
 
@@ -32,19 +32,19 @@ bUm Berlin is easily accessible by public transport. The following stops are wit
 
 ### Registration, Welcome Wagon, and Sponsors
 
-Location: Foyer on ground floor
+Location: {{ about.registration_room }}
 
 ### Speaker Talks
 
-Location: Auditorium on ground floor
+Location: {{ about.mainroom }}
 
 ### Writing Day, Unconference, and Welcome Reception
 
-Location: bUm Box on first floor
+Location: {{ about.unconfroom }}
 
 ### Catering and Communal Rooms
 
-Location: Wintergarten in basement
+Location: {{ about.catering_room }}
 
 View the [Attendee Guide](/conf/{{shortcode}}/{{year}}/attendee-guide/) for more information regarding spaces inside the venue.
 </content>

--- a/docs/conf/berlin/2026/venue.md
+++ b/docs/conf/berlin/2026/venue.md
@@ -7,16 +7,30 @@ og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
 # Venue
 
 ## bUm Berlin
+
 Paul-Lincke-Ufer 21, 10999 Berlin, Germany
 [Map link](https://www.google.com/maps/place/bUm+-+Raum+f%C3%BCr+solidarisches+Miteinander/@52.4937094,13.4270626,17z/data=!3m2!4b1!5s0x47a84fb459055813:0x3cad2ecfcf84e633!4m6!3m5!1s0x47a84fd9cf3e7c43:0x538772e39fff3a0e!8m2!3d52.4937094!4d13.4296375!16s%2Fg%2F11h91cct20?entry=ttu&g_ep=EgoyMDI1MDgyNS4wIKXMDSoASAFQAw%3D%3D)
 
-Our conference will be held at [bUm Berlin](https://www.bum.berlin/) - Raum für solidarisches Miteinander, a space for solidarity and engagement, on the Landwehrkanal in Kreuzberg. This is a community space for events, coworking, activists, and creatives.
+Our conference will be held at [bUm Berlin](https://www.bum.berlin/), a community and cultural centre located on the banks of the Landwehr Canal in the heart of Kreuzberg.
 
-## Getting to the Venue
+## Getting There
+
+bUm Berlin is easily accessible by public transport. The following stops are within a 15-minute walk:
+
+**Bus**
+
+- Line M29: Ohlauer Str.
+- Line 194: Pflügerstr.
+- Line M41: Jahnstr.
+
+**U-Bahn**
+
+- U8: Schönleinstraße
+- U1 and U3: Görlitzer Bahnhof
 
 ### From the U-Bahn
 
-The best way to get to the venue is to take the **U8 (Schönleinstraße)** or the **U7/U8 (Hermannplatz)**. You can also take the **U1/U3 (Görlitzer Bahnhof)**.
+The best way to get to the venue is to take the **U8 (Schönleinstraße)** or the **U7/U8 (Hermannplatz)**.
 
 From Schönleinstraße, take Bürknerstraße to the intersection at Hobrechtbrücke, cross the bridge and turn right.
 
@@ -26,7 +40,7 @@ Note: the subway station closest to bUm (Schönleinstraße) does not have an ele
 
 ### Bus
 
-You can take the M29 bus to the Ohlauer Straße stop. From here, follow Ohlauer Straße south and turn left onto Paul-Lincke-Ufer. The 194 (Pflügerstr.) and M41 (Jahnstr.) lines also stop within a short walk of the venue.
+You can take the M29 bus to the Ohlauer Straße stop. From here, follow Ohlauer Straße south and turn left onto Paul-Lincke-Ufer.
 
 ### Car
 

--- a/docs/conf/berlin/2026/venue.md
+++ b/docs/conf/berlin/2026/venue.md
@@ -6,12 +6,12 @@ og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
 
 # Venue
 
-## {{ about.venue }}
+## bUm Berlin
 
-{{ about.venue_address }}
-[Map link]({{ about.venue_map_url }})
+Paul-Lincke-Ufer 21, 10999 Berlin, Germany
+[Map link](https://www.google.com/maps/place/bUm+-+Raum+f%C3%BCr+solidarisches+Miteinander/@52.4937094,13.4270626,17z/data=!3m2!4b1!5s0x47a84fb459055813:0x3cad2ecfcf84e633!4m6!3m5!1s0x47a84fd9cf3e7c43:0x538772e39fff3a0e!8m2!3d52.4937094!4d13.4296375!16s%2Fg%2F11h91cct20?entry=ttu&g_ep=EgoyMDI1MDgyNS4wIKXMDSoASAFQAw%3D%3D)
 
-Our conference will be held at [{{ about.venue }}](https://www.bum.berlin/), a community and cultural centre located on the banks of the Landwehr Canal in the heart of Kreuzberg.
+Our conference will be held at [bUm Berlin](https://www.bum.berlin/), a community and cultural centre located on the banks of the Landwehr Canal in the heart of Kreuzberg.
 
 ## Getting There
 
@@ -32,20 +32,18 @@ bUm Berlin is easily accessible by public transport. The following stops are wit
 
 ### Registration, Welcome Wagon, and Sponsors
 
-Location: {{ about.registration_room }}
+Location: Foyer on ground floor
 
 ### Speaker Talks
 
-Location: {{ about.mainroom }}
+Location: Auditorium on ground floor
 
 ### Writing Day, Unconference, and Welcome Reception
 
-Location: {{ about.unconfroom }}
+Location: bUm Box on first floor
 
 ### Catering and Communal Rooms
 
-Location: {{ about.catering_room }}
+Location: Wintergarten in basement
 
 View the [Attendee Guide](/conf/{{shortcode}}/{{year}}/attendee-guide/) for more information regarding spaces inside the venue.
-</content>
-</invoke>


### PR DESCRIPTION
Fills out the Berlin 2026 venue page using details carried over from the 2025 conference, since it's the same venue (bUm Berlin) with the same spaces available. Guessed room assignments where 2026's event groupings didn't map exactly to a 2025 room (e.g. Writing Day placed with the Unconference in the bUm Box).

The original 2026 copy for the venue description and the "Getting There" transit stop lists is preserved as-is. Room names, the address, and the map link are now stored as `about.*` variables in the config rather than hardcoded in the page, so other pages (e.g. `schedule.md`, which already references `about.unconfroom`) pick them up too.

- `berlin-2026-config.yaml`: set `mainroom`, `unconfroom`; add `registration_room`, `catering_room`, `venue_map_url`; append country to `venue_address`
- `schema-config.yaml`: add optional `registration_room` and `catering_room` fields
- `venue.md`: reference the config variables

🤖 This PR was generated with the assistance of AI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9Sbg8DQ3hTdzhLDKoYNiw)_

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2718.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->