### PR TITLE
berlin: fill in missing 2026 content from the three-day format change

### DIFF
--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -204,7 +204,7 @@ sponsors:
 # Things that change over time, listed in order of change
 flaglanding: False
 flaghassponsors: True
-flagcfp: True
+flagcfp: False
 flagticketsonsale: True
 flagsoldout: False
 flagscheduleincomplete: True
@@ -227,4 +227,4 @@ flaghassponsorexpo: True
 flaghasboat: False
 flaghasvisiting: False
 flaghasteam: False
-flaghasattendeeguide: False
+flaghasattendeeguide: True

--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -202,7 +202,7 @@ sponsors:
 # Things that change over time, listed in order of change
 flaglanding: False
 flaghassponsors: True
-flagcfp: False
+flagcfp: True
 flagticketsonsale: True
 flagsoldout: False
 flagscheduleincomplete: True
@@ -225,4 +225,4 @@ flaghassponsorexpo: True
 flaghasboat: False
 flaghasvisiting: False
 flaghasteam: False
-flaghasattendeeguide: True
+flaghasattendeeguide: False

--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -132,7 +132,6 @@ date: # how do we handle these? human readable would be nice.
     summary: This is the main event! Hear from lots of interesting folks about all things documentation. We will have talks all day, and unconference sessions running in parallel.
     dotw: Monday
     talk_time: 10:00-17:00
-    unconference_time: 10:45-17:00
     social_time: 19:00-21:00
     icon: conference
   day_four:
@@ -141,7 +140,6 @@ date: # how do we handle these? human readable would be nice.
     summary: And the conference goes on! More talks and unconference today!
     dotw: Tuesday
     talk_time: 10:00-17:00
-    unconference_time: 13:00-17:00
     icon: conversation
   total_talk_days: 2
 

--- a/docs/conf/berlin/2026/attendee-guide.md
+++ b/docs/conf/berlin/2026/attendee-guide.md
@@ -124,7 +124,7 @@ The [Unconference](/conf/{{shortcode}}/{{year}}/unconference/) consists of atten
 - Sign up to give a talk at the Registration table. Selections are announced on Monday and Tuesday before the lunch breaks.
 
 ### Sponsor Expo:
-[Sponsor Expo](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/sponsors/) will include companies sharing products and others hiring. They'll be in the foyer both days.
+[Sponsor Expo](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/sponsors/) will include companies sharing products and others hiring. They'll be in the foyer on both talk days, Monday and Tuesday.
 
 ### Monday Conference Party:
 This is our main social event of the conference. Drinks and snacks provided by us. It is a time to connect with other attendees outside of the scheduled programming. Come for an hour or stay the entire time!

--- a/docs/conf/berlin/2026/cfp.md
+++ b/docs/conf/berlin/2026/cfp.md
@@ -6,7 +6,7 @@ banner: _static/conf/images/headers/2026/lightning-talks.jpg
 
 # Call for Proposals
 
-It's that time of year again: We're now accepting talk proposals for our next **in-person** {{ city }} conference, on {{date.main}}. Like last year, we're also accepting a few pre-recorded talks by remote speakers.
+{% if flagcfp %}It's that time of year again: We're now accepting talk proposals for our next **in-person** {{ city }} conference, on {{date.main}}. Like last year, we're also accepting a few pre-recorded talks by remote speakers.{% elif flagspeakersannounced %}The Call for Proposals for our {{ city }} conference, on {{date.main}}, is now closed. Thanks to everyone who submitted a proposal — check out [this year's speakers](/conf/{{shortcode}}/{{year}}/speakers/)!{% else %}We're planning our next **in-person** {{ city }} conference, on {{date.main}}. Like last year, we're also accepting a few pre-recorded talks by remote speakers.{% endif %}
 
 Every year, Write the Docs invites people from all across our community to come up on stage to share their insights and experience. Whether you've worked on documentation for decades or you've just started this year, we want to hear from you! Read on to learn more about the goals of the conference and what we look for in talk proposals.
 
@@ -17,7 +17,7 @@ In the meantime, mark your calendars:
 - **Deadline: {{cfp.ends}} at 11:59 PM {{tz}}**
 - **Acceptance emails: by {{cfp.notification}}**
 
-{% else %} We will announce the CFP dates soon. {% endif %}
+{% elif not flagspeakersannounced %} We will announce the CFP dates soon. {% endif %}
 
 {% if flagcfp %}
 

--- a/docs/conf/berlin/2026/cfp.md
+++ b/docs/conf/berlin/2026/cfp.md
@@ -6,7 +6,7 @@ banner: _static/conf/images/headers/2026/lightning-talks.jpg
 
 # Call for Proposals
 
-{% if flagcfp %}It's that time of year again: We're now accepting talk proposals for our next **in-person** {{ city }} conference, on {{date.main}}. Like last year, we're also accepting a few pre-recorded talks by remote speakers.{% elif flagspeakersannounced %}The Call for Proposals for our {{ city }} conference, on {{date.main}}, is now closed. Thanks to everyone who submitted a proposal — check out [this year's speakers](/conf/{{shortcode}}/{{year}}/speakers/)!{% else %}We're planning our next **in-person** {{ city }} conference, on {{date.main}}. Like last year, we're also accepting a few pre-recorded talks by remote speakers.{% endif %}
+It's that time of year again: We're now accepting talk proposals for our next **in-person** {{ city }} conference, on {{date.main}}. Like last year, we're also accepting a few pre-recorded talks by remote speakers.
 
 Every year, Write the Docs invites people from all across our community to come up on stage to share their insights and experience. Whether you've worked on documentation for decades or you've just started this year, we want to hear from you! Read on to learn more about the goals of the conference and what we look for in talk proposals.
 
@@ -17,7 +17,7 @@ In the meantime, mark your calendars:
 - **Deadline: {{cfp.ends}} at 11:59 PM {{tz}}**
 - **Acceptance emails: by {{cfp.notification}}**
 
-{% elif not flagspeakersannounced %} We will announce the CFP dates soon. {% endif %}
+{% else %} We will announce the CFP dates soon. {% endif %}
 
 {% if flagcfp %}
 

--- a/docs/conf/berlin/2026/convince-your-manager.md
+++ b/docs/conf/berlin/2026/convince-your-manager.md
@@ -74,7 +74,7 @@ Remember to change the things in [brackets]!
 *Writing Day Benefits:*
 
 - *Introduce our project and community to a new audience and demographic in our industry*
-- *Get highlighted as a project in the conference blog and announcements (must submit online by April 17, 2026)*
+- *Get highlighted as a project in the conference blog and announcements (must submit online by {{ writing_day.project_deadline }})*
 - *Onboard documentation enthusiasts to increase the likelihood of post-conference contributions*
 - *Strategically tackle documentation tickets and requests*
 - *Update existing documentation
@@ -94,7 +94,7 @@ Peer review new and existing documentation*
 
 When discussing how to pitch Writing Day, a few helpful tips emerged:
 
-- Highlight specific projects from a previous [Writing Day project list.](https://www.writethedocs.org/conf/portland/{{year-1}}/writing-day/#project-list)
+- Highlight specific projects from a previous [Writing Day project list.](https://www.writethedocs.org/conf/portland/{{year}}/writing-day/#project-list)
 - If your community is looking for regular documentation contributions, this is a great place to onboard potential contributors and editors.
 - Attending raises the visibility of your company in the community. 
 - Establishes your team's reputation for caring about their docs.

--- a/docs/conf/berlin/2026/lightning-talks.md
+++ b/docs/conf/berlin/2026/lightning-talks.md
@@ -19,7 +19,7 @@ Our goal is to have a balance between first-time and experienced speakers.
 
 ## Schedule and Logistics
 
-**Date: {{date.day_two.dotw}}, {{date.day_two.date}} and {{date.day_three.dotw}}, {{date.day_three.date}} after lunch**
+**Date: {{date.day_three.dotw}}, {{date.day_three.date}} and {{date.day_four.dotw}}, {{date.day_four.date}} after lunch**
 
 Lightning Talks can be submitted through an online form only. 
 

--- a/docs/conf/berlin/2026/schedule-virtual.md
+++ b/docs/conf/berlin/2026/schedule-virtual.md
@@ -37,7 +37,7 @@ A detailed schedule will be announced soon.
 
 ### Conference Talks
 
-Talks are around 30 minutes, with moderated 10 minute Q&A.
+Talks are around 30 minutes, with moderated 5 minute Q&A.
 
 - **Where**: Venueless virtual platform
 {% if not flaghasschedule %}
@@ -64,7 +64,7 @@ A detailed schedule will be announced soon.
 
 ### Conference Talks
 
-Talks are around 30 minutes, with moderated 10 minute Q&A.
+Talks are around 30 minutes, with moderated 5 minute Q&A.
 
 - **Where**: Venueless virtual platform
 {% if not flaghasschedule %}

--- a/docs/conf/berlin/2026/social-events.md
+++ b/docs/conf/berlin/2026/social-events.md
@@ -11,4 +11,23 @@ which means a big part of the experience is meeting and getting to know other do
 Along with the talks and Unconference sessions,
 we will have social events planned to help you connect with other attendees.
 
-Details of social events are still to be confirmed, and we will announce them closer to the conference.
+## Welcome Reception
+
+We encourage everyone to drop by on {{date.day_two.dotw}} evening for the Welcome Reception, right after Writing Day.
+This is a great chance to meet other attendees,
+and make sure you know your way around the conference venue.
+
+**Where**: {{about.venue}}
+
+**When**: {{date.day_two.dotw}}, {{date.day_two.reception_time}}
+
+## {{date.day_three.dotw}} Social
+
+Join us for our {{date.day_three.dotw}} night social event! This is a great chance to meet more of your fellow documentarians
+and chat about the conference in a relaxed atmosphere.
+
+**Where**: {{about.social_venue}}
+
+**When**: {{date.day_three.dotw}}, {{date.day_three.social_time}}
+
+More details of the social events will be announced closer to the conference.

--- a/docs/conf/berlin/2026/team.md
+++ b/docs/conf/berlin/2026/team.md
@@ -40,7 +40,7 @@ Eric is one of the co-founders of Write the Docs, and also one of the co-founder
 
 ![](/_static/img/2024/team/katie.jpg)
 
-Katie Janovec is an Event Producer and Project Manager based in Portland, Oregon. She enjoys organizing a variety of events, including conferences, galas, block parties, dance and music events, motorcycle shows, and more. Katie enjoys organizing events as it fosters community connection, growth, and joy. Katie is excited to be a part of her first Berlin conference and fourth Write the Docs conference.
+Katie Janovec is an Event Producer and Project Manager based in Portland, Oregon. She enjoys organizing a variety of events, including conferences, galas, block parties, dance and music events, motorcycle shows, and more. Katie enjoys organizing events as it fosters community connection, growth, and joy. Katie is excited to be back for her second Berlin conference.
 
 ### Andrea Kao (she/her)
 

--- a/docs/conf/berlin/2026/tickets.md
+++ b/docs/conf/berlin/2026/tickets.md
@@ -100,6 +100,24 @@ If you need to cancel your ticket because of fear of traveling internationally o
   {% endif %}
 </div>
 
+<div class="ticket">
+  <h2>
+    <strong>Corporate Concierge</strong>: <em>{{tickets.concierge.price}}</em> per ticket
+  </h2>
+  <p>
+    We offer a corporate concierge service if your company is unable to follow our regular ticket sales process through the website.
+    We can offer payment by invoice, process purchase orders, bank transfers, fill in supplier registration forms, and offer other support.
+    Your tickets will be issued after we have received payment. The minimum purchase is three tickets.
+  </p>
+  {% if flagticketsonsale %}
+  <ul>
+    <li>
+      <a href="mailto:{{email}}">Contact us at {{email}} for this service</a>
+    </li>
+  </ul>
+  {% endif %}
+</div>
+
 {% if shirts and flaghasshirts %}
 
 <div class="ticket">

--- a/docs/conf/berlin/2026/writing-day.md
+++ b/docs/conf/berlin/2026/writing-day.md
@@ -13,7 +13,7 @@ Writing Day is modeled after the concept of [code sprints](https://en.wikipedia.
 
 Attendees can lead a Writing Day project or join and contribute to someone else's project. Projects can run for a half-day or full-day.
 
-More details are below. No additional sign up is required, and the full schedule will be released in the coming months. Ready to submit a Writing Day project? Click the link below.
+More details are below. No additional sign up is required, and the full schedule will be released in the coming months.{% if writing_day.url %} Ready to submit a Writing Day project? Click the link below.{% endif %}
 
 {% if writing_day.url %}
 <div class="announcement" style="background-color:white;">
@@ -95,6 +95,7 @@ Writing Day is the perfect opportunity to participate and learn about new projec
 ## Project List
 
 If you are planning to contribute, review the project list before the conference.
+Incoming project information, check back here for updates closer to the conference.
 
 ### Examples of projects you might see at the conference
 
@@ -107,11 +108,7 @@ If you are planning to contribute, review the project list before the conference
 - Love letters
 - The Documentarian Manifesto
 
-Find specific examples on the [Portland Writing Day {{year-1}} project list](https://www.writethedocs.org/conf/portland/{{year-1}}/writing-day/#project-list).
-
-## Project list
-
-Incoming project information, check back here for updates closer to the conference.
+Find specific examples on the [Portland Writing Day {{year}} project list](https://www.writethedocs.org/conf/portland/{{year}}/writing-day/#project-list).
 
 ## Contact us
 


### PR DESCRIPTION
Berlin 2026 moved from the 2025 two-day format to three days (Writing Day plus two talk days), and several pages copied from Berlin 2025 or Portland 2026 still described the old format, carried Portland-specific values, or were missing content the config already confirms: lightning talks pointed at Writing Day instead of the two talk days, Convince Your Manager used Portland's hardcoded project deadline, the social events page didn't mention the Welcome Reception or Monday social, and the Corporate Concierge ticket from 2025 was missing despite being priced in the 2026 config.

Follow-ups from review: removed the per-day unconference times since the unconference runs all day, and matched the virtual schedule's Q&A length to the 5 minutes used in Portland and on the Berlin speaker info page. No feature flags are changed.

Complements the other open Berlin 2026 PRs: #2716 (visiting), #2717 (sponsor info), #2718 (venue).

🤖 This PR was generated by AI.

https://claude.ai/code/session_013mbCsieFH6KoNw7NaKrr1k

----
📚 Documentation preview 📚: https://writethedocs-www--2719.org.readthedocs.build/