### PR TITLE
conf: Format sponsor booth location/availability as bullets

### DIFF
--- a/docs/conf/australia/2026/sponsors/information.md
+++ b/docs/conf/australia/2026/sponsors/information.md
@@ -52,8 +52,8 @@ Each sponsorship includes different opportunities to engage with our attendees. 
 
 Attendees are always looking for great products to use in their day-to-day workflows, and are curious to learn more about your company.
 
-**Location:** Main hallway, outside the auditorium
-**Availability:** {{ date.day_one.dotw }} and {{ date.day_two.dotw }}, full conference hours
+* **Location:** Main hallway, outside the auditorium
+* **Availability:** {{ date.day_one.dotw }} and {{ date.day_two.dotw }}, full conference hours
 
 #### What Write the Docs provides
 

--- a/docs/conf/berlin/2026/sponsors/information.md
+++ b/docs/conf/berlin/2026/sponsors/information.md
@@ -60,8 +60,8 @@ Each sponsorship includes different opportunities to engage with our attendees. 
 
 Attendees are always looking for great products to use in their day-to-day workflows, and are curious to learn more about your company.
 
-**Location:** Main hallway, outside the auditorium
-**Availability:** {{ date.day_three.dotw }} and {{ date.day_four.dotw }}, full conference hours
+* **Location:** Main hallway, outside the auditorium
+* **Availability:** {{ date.day_three.dotw }} and {{ date.day_four.dotw }}, full conference hours
 
 #### What Write the Docs Provides
 

--- a/docs/conf/portland/2026/sponsors/information.md
+++ b/docs/conf/portland/2026/sponsors/information.md
@@ -75,8 +75,8 @@ Each sponsorship includes different opportunities to engage with our attendees. 
 
 Sponsor booths are set up in the main hallway on {{ date.day_three.dotw }} and {{ date.day_four.dotw }} outside of the auditorium.
 
-**Location:** Main hallway, outside the auditorium
-**Availability:** {{ date.day_three.dotw }} and {{ date.day_four.dotw }}, full conference hours
+* **Location:** Main hallway, outside the auditorium
+* **Availability:** {{ date.day_three.dotw }} and {{ date.day_four.dotw }}, full conference hours
 
 #### What Write the Docs Provides
 


### PR DESCRIPTION
The **Location:** and **Availability:** lines in the 2026 sponsor information pages (Berlin, Portland, Australia) were consecutive paragraph lines, so Markdown collapsed them into a single run-together line. Formatting them as bullet list items renders them properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2732.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->