### PR TITLE
Add Writing Day mailing/schedule

### DIFF
--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -168,6 +168,7 @@ unconf:
 
 writing_day:
   url: "https://docs.google.com/forms/d/e/1FAIpQLSf5dN0o3HkPMY5UTVzyhO6nq7T07OL6awFHv9fkfX_jdV98iQ/viewform"
+  git_signup_url: "https://ti.to/writethedocs/write-the-docs-berlin-2026/with/qyxd-bvuzc"
   date: Sunday, September 6, 9:30-17:00 CEST
   project_deadline: "August 17, 2026"
 

--- a/docs/_data/berlin-2026-schedule.yaml
+++ b/docs/_data/berlin-2026-schedule.yaml
@@ -1,29 +1,24 @@
 writing_day:
   - time: '08:30'
-    duration: '1:00'
     title: Doors open
-  - duration: '0:30'
-    title: Morning introduction - Introduction to Sprints & Project Introductions
-  - duration: '0:00'
-    title: 'Projects team up and start <a href="../writing-day">writing</a>'
+  - time: '09:30'
+    title: Welcome and overview
+  - time: '10:00'
+    title: 'Project announcements: Leads give a 2 minute summary and projects begin'
+  - time: '10:00'
+    title: New to Git workshop and Write the Docs Orientation
   - time: '12:00'
-    duration: '0:00'
     title: '<a href="../attendee-guide/#welcome-wagon-tour">Welcome Wagon</a> conference introduction and venue tour'
-  - time: '12:15'
+  - time: '12:30'
     title: Lunch Break
   - time: '14:00'
-    duration: '0:15'
-    title: Afternoon session - all-day groups reconvene and new group introductions
-  - duration: '0:00'
-    title: 'Projects team up and continue <a href="../writing-day">writing</a>'
-  - time: '14:30'
-    duration: '2:00'
-    title: '<a href="../writing-day/#roundtable-discussions">Roundtable Discussions</a>'
+    title: 'Afternoon sessions: Leads give a 2 minute summary, starting with the afternoon-only projects, and projects reconvene'
+  - title: '<a href="../writing-day/#roundtable-discussions">Roundtable Discussions</a>'
+  - title: Salary Survey
+  - title: Resume writing session and portfolio review
   - time: '16:30'
-    duration: '0:00'
     title: '<a href="../attendee-guide/#welcome-wagon-tour">Welcome Wagon</a> conference introduction and venue tour'
   - time: '17:00'
-    duration: '0:00'
     title: End of Writing Day
   - time: '17:00'
     title: '<b><a href="../social-events/#welcome-reception">Welcome Reception</a> starts</b>'

--- a/docs/_data/berlin-2026-schedule.yaml
+++ b/docs/_data/berlin-2026-schedule.yaml
@@ -6,7 +6,9 @@ writing_day:
   - time: '10:00'
     title: 'Project announcements: Leads give a 2 minute summary and projects begin'
   - time: '10:00'
-    title: New to Git workshop and Write the Docs Orientation
+    title: New to Git workshop
+  - time: '11:00'
+    title: Write the Docs Orientation
   - time: '12:00'
     title: '<a href="../attendee-guide/#welcome-wagon-tour">Welcome Wagon</a> conference introduction and venue tour'
   - time: '12:30'

--- a/docs/_data/berlin-2026-schedule.yaml
+++ b/docs/_data/berlin-2026-schedule.yaml
@@ -15,7 +15,10 @@ writing_day:
     title: Lunch Break
   - time: '14:00'
     title: 'Afternoon sessions: Leads give a 2 minute summary, starting with the afternoon-only projects, and projects reconvene'
-  - title: '<a href="../writing-day/#roundtable-discussions">Roundtable Discussions</a>'
+  - time: '14:30'
+    title: 'AI and Docs - <a href="../writing-day/#roundtable-discussions">Roundtable discussion</a>'
+  - time: '15:30'
+    title: 'API docs - <a href="../writing-day/#roundtable-discussions">Roundtable discussion</a>'
   - title: Salary Survey
   - title: Resume writing session and portfolio review
   - time: '16:30'

--- a/docs/_data/schema-config.yaml
+++ b/docs/_data/schema-config.yaml
@@ -222,6 +222,7 @@ unconf-details:
 
 writing_day-details:
   url: str(required=False)
+  git_signup_url: str(required=False)
   date: str(required=True)
   project_deadline: str(required=False)
 

--- a/docs/conf/berlin/2026/news/writing-day-schedule.md
+++ b/docs/conf/berlin/2026/news/writing-day-schedule.md
@@ -8,7 +8,7 @@ og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
 :tags: {{shortcode}}-{{year}}, writing-day
 ```
 
-# Your Writing Day Schedule
+# What's happening on Writing Day, and how to sign up
 
 Writing Day is back and kicks off Write the Docs {{ city }} on {{ date.day_two.dotw }}, {{ date.day_two.date }}. Alongside the Writing Day projects, we're running several sessions throughout the day. Here's what to expect, and how to participate!
 

--- a/docs/conf/berlin/2026/news/writing-day-schedule.md
+++ b/docs/conf/berlin/2026/news/writing-day-schedule.md
@@ -19,7 +19,7 @@ Writing Day is back and kicks off Write the Docs {{ city }} on {{ date.day_two.d
 - **Afternoon**
   - **Resume writing session and portfolio review**
   - **Salary Survey**
-  - A pre-scheduled, facilitated **roundtable discussion track**
+  - A pre-scheduled, facilitated **roundtable discussion track**, with sessions on AI and Docs, and on API docs
 
 For the New to Git session, **[advance signup is required]({{ writing_day.git_signup_url }})**. For other sessions, you can show up and attend. As always, you are more than welcome to bring a project the day of and announce it during Writing Day.
 

--- a/docs/conf/berlin/2026/news/writing-day-schedule.md
+++ b/docs/conf/berlin/2026/news/writing-day-schedule.md
@@ -34,6 +34,15 @@ Two of the best ways to take part in the conference are the Unconference and Lig
 - **[Unconference](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/unconference/):** attendee-driven sessions where anyone can lead a discussion, show and tell, or short talk.
 - **[Lightning Talks](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/lightning-talks/):** brief, up-to-five-minute talks on anything you're passionate about. A great format for first-time speakers. Online submissions open Monday, and stay open in person through the last morning break. Need inspiration? Watch [last year's Berlin Lightning Talks](https://www.youtube.com/watch?v=lgBbeUFoSic&list=PLZAeFn6dfHpkP1wAM5OIqAMH4guScopET).
 
+## Register soon
+
+Space is limited, so don't wait to grab your ticket.
+Register by **Sunday, August 30**, and we'll have your name badge printed and ready. After that, you'll write your own at the door.
+
+```{button-link} https://ti.to/writethedocs/write-the-docs-{{shortcode}}-{{year}}
+Register for Write the Docs {{ city }}
+```
+
 ## See you soon
 
 Questions? Email us at {{ email }}. See you in {{ date.month }}!

--- a/docs/conf/berlin/2026/news/writing-day-schedule.md
+++ b/docs/conf/berlin/2026/news/writing-day-schedule.md
@@ -31,7 +31,7 @@ Writing Day entry requires a conference ticket.
 Two of the best ways to take part in the conference are the Unconference and Lightning Talks, and online signups open on **Monday, August 31**, one week before the conference.
 
 - **[Unconference](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/unconference/):** attendee-driven sessions where anyone can lead a discussion, show and tell, or short talk.
-- **[Lightning Talks](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/lightning-talks/):** brief, up-to-five-minute talks on anything you're passionate about. A great format for first-time speakers. Online submissions open Monday, and stay open in person through the last morning break. Need inspiration? Watch [last year's Berlin Lightning Talks](https://www.youtube.com/playlist?list=PLZAeFn6dfHpkP1wAM5OIqAMH4guScopET).
+- **[Lightning Talks](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/lightning-talks/):** brief, up-to-five-minute talks on anything you're passionate about. A great format for first-time speakers. Online submissions open Monday, and stay open in person through the last morning break. Need inspiration? Watch <a href="https://www.youtube.com/watch?v=lgBbeUFoSic&amp;list=PLZAeFn6dfHpkP1wAM5OIqAMH4guScopET&amp;index=14">last year's Berlin Lightning Talks</a>.
 
 ## Register soon
 

--- a/docs/conf/berlin/2026/news/writing-day-schedule.md
+++ b/docs/conf/berlin/2026/news/writing-day-schedule.md
@@ -1,0 +1,39 @@
+---
+template: {{year}}/generic.html
+banner: _static/conf/images/headers/2026/writing-day.jpg
+og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
+---
+
+```{post} August 20, 2026
+:tags: {{shortcode}}-{{year}}, writing-day
+```
+
+# Your Writing Day schedule, and how to sign up
+
+Writing Day kicks off Write the Docs {{ city }} on {{ date.day_two.dotw }}, {{ date.day_two.date }}. Here's what to expect, and how to get involved.
+
+## The Writing Day schedule
+
+Alongside the Writing Day projects, we're running several sessions throughout the day:
+
+- **Intro to Git** in the morning, if you'd like a gentle start with the tools many projects use.
+- **First Timer meetup** to meet other new people, and a **resume and portfolio review with Janine**.
+- **Roundtable discussions** in the afternoon: pre-scheduled, facilitated conversations on focused topics.
+- **Lightning Talk workshop** in the afternoon, to help you brainstorm and perhaps get a Lightning Talk ready for the main conference days.
+
+For the Intro to Git, **advance signup is required**. For other sessions, you can just attend.
+To pitch your own project, be there at the start of the day.
+
+See the full run of the day, including start times, on the [Writing Day page](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/writing-day/#writing-day-schedule).
+Writing Day entry requires a conference ticket.
+
+## Unconference and Lightning Talk signups open Monday
+
+Two of the best ways to take part in the conference are the Unconference and Lightning Talks, and online signups open on **Monday, August 31**, one week before the conference.
+
+- **[Unconference](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/unconference/):** attendee-driven sessions where anyone can lead a discussion, show and tell, or short talk.
+- **[Lightning Talks](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/lightning-talks/):** brief, up-to-five-minute talks on anything you're passionate about. A great format for first-time speakers. Online submissions open Monday, and stay open in person through the last morning break. Need inspiration? Watch [last year's Berlin Lightning Talks](https://www.youtube.com/watch?v=lgBbeUFoSic&list=PLZAeFn6dfHpkP1wAM5OIqAMH4guScopET).
+
+## See you soon
+
+Questions? Email us at {{ email }}. See you in {{ date.month }}!

--- a/docs/conf/berlin/2026/news/writing-day-schedule.md
+++ b/docs/conf/berlin/2026/news/writing-day-schedule.md
@@ -31,7 +31,7 @@ Writing Day entry requires a conference ticket.
 Two of the best ways to take part in the conference are the Unconference and Lightning Talks, and online signups open on **Monday, August 31**, one week before the conference.
 
 - **[Unconference](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/unconference/):** attendee-driven sessions where anyone can lead a discussion, show and tell, or short talk.
-- **[Lightning Talks](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/lightning-talks/):** brief, up-to-five-minute talks on anything you're passionate about. A great format for first-time speakers. Online submissions open Monday, and stay open in person through the last morning break. Need inspiration? Watch [last year's Berlin Lightning Talks](https://www.youtube.com/watch?v=lgBbeUFoSic&list=PLZAeFn6dfHpkP1wAM5OIqAMH4guScopET).
+- **[Lightning Talks](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/lightning-talks/):** brief, up-to-five-minute talks on anything you're passionate about. A great format for first-time speakers. Online submissions open Monday, and stay open in person through the last morning break. Need inspiration? Watch [last year's Berlin Lightning Talks](https://www.youtube.com/playlist?list=PLZAeFn6dfHpkP1wAM5OIqAMH4guScopET).
 
 ## Register soon
 

--- a/docs/conf/berlin/2026/news/writing-day-schedule.md
+++ b/docs/conf/berlin/2026/news/writing-day-schedule.md
@@ -8,23 +8,22 @@ og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
 :tags: {{shortcode}}-{{year}}, writing-day
 ```
 
-# Your Writing Day schedule, and how to sign up
+# Your Writing Day Schedule
 
-Writing Day kicks off Write the Docs {{ city }} on {{ date.day_two.dotw }}, {{ date.day_two.date }}. Here's what to expect, and how to get involved.
+Writing Day is back and kicks off Write the Docs {{ city }} on {{ date.day_two.dotw }}, {{ date.day_two.date }}. Alongside the Writing Day projects, we're running several sessions throughout the day. Here's what to expect, and how to participate!
 
-## The Writing Day schedule
+- **Writing Day project** (half-day or full-day): attendees can lead a project or join and contribute to a project.
+- **Morning**
+  - **New to Git** ([sign up here]({{ writing_day.git_signup_url }}))
+  - **Write the Docs Orientation** for folks who want tips and tricks for navigating the conference, led by the Welcome Wagon team.
+- **Afternoon**
+  - **Resume writing session and portfolio review**
+  - **Salary Survey**
+  - A pre-scheduled, facilitated **roundtable discussion track**
 
-Alongside the Writing Day projects, we're running several sessions throughout the day:
+For the New to Git session, **advance signup is required**. For other sessions, you can show up and attend. As always, you are more than welcome to bring a project the day of and announce it during Writing Day.
 
-- **Intro to Git** in the morning, if you'd like a gentle start with the tools many projects use.
-- **First Timer meetup** to meet other new people, and a **resume and portfolio review with Janine**.
-- **Roundtable discussions** in the afternoon: pre-scheduled, facilitated conversations on focused topics.
-- **Lightning Talk workshop** in the afternoon, to help you brainstorm and perhaps get a Lightning Talk ready for the main conference days.
-
-For the Intro to Git, **advance signup is required**. For other sessions, you can just attend.
-To pitch your own project, be there at the start of the day.
-
-See the full run of the day, including start times, on the [Writing Day page](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/writing-day/#writing-day-schedule).
+See the full run of the day on the [Writing Day page](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/writing-day/#writing-day-schedule).
 Writing Day entry requires a conference ticket.
 
 ## Unconference and Lightning Talk signups open Monday

--- a/docs/conf/berlin/2026/news/writing-day-schedule.md
+++ b/docs/conf/berlin/2026/news/writing-day-schedule.md
@@ -4,7 +4,7 @@ banner: _static/conf/images/headers/2026/writing-day.jpg
 og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
 ---
 
-```{post} August 20, 2026
+```{post} August 26, 2026
 :tags: {{shortcode}}-{{year}}, writing-day
 ```
 

--- a/docs/conf/berlin/2026/news/writing-day-schedule.md
+++ b/docs/conf/berlin/2026/news/writing-day-schedule.md
@@ -8,7 +8,7 @@ og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
 :tags: {{shortcode}}-{{year}}, writing-day
 ```
 
-# What's happening on Writing Day, and how to sign up
+# Making the most of Writing Day
 
 Writing Day is back and kicks off Write the Docs {{ city }} on {{ date.day_two.dotw }}, {{ date.day_two.date }}. Alongside the Writing Day projects, we're running several sessions throughout the day. Here's what to expect, and how to participate!
 

--- a/docs/conf/berlin/2026/news/writing-day-schedule.md
+++ b/docs/conf/berlin/2026/news/writing-day-schedule.md
@@ -21,7 +21,7 @@ Writing Day is back and kicks off Write the Docs {{ city }} on {{ date.day_two.d
   - **Salary Survey**
   - A pre-scheduled, facilitated **roundtable discussion track**
 
-For the New to Git session, **advance signup is required**. For other sessions, you can show up and attend. As always, you are more than welcome to bring a project the day of and announce it during Writing Day.
+For the New to Git session, **[advance signup is required]({{ writing_day.git_signup_url }})**. For other sessions, you can show up and attend. As always, you are more than welcome to bring a project the day of and announce it during Writing Day.
 
 See the full run of the day on the [Writing Day page](https://www.writethedocs.org/conf/{{shortcode}}/{{year}}/writing-day/#writing-day-schedule).
 Writing Day entry requires a conference ticket.

--- a/docs/conf/berlin/2026/writing-day.md
+++ b/docs/conf/berlin/2026/writing-day.md
@@ -35,7 +35,8 @@ We may make changes to the structure closer to the conference.
 - **8:30** - Doors open
 - **9:30** - Welcome and overview
 - **10:00** - Project announcements: Leads give a 2 minute summary and projects begin
-  - New to Git workshop ([sign up required]({{ writing_day.git_signup_url }})) and Write the Docs Orientation
+  - **10:00** - New to Git workshop ([sign up required]({{ writing_day.git_signup_url }}))
+  - **11:00** - Write the Docs Orientation
 - **12:30-14:00** - Lunch break
 - **14:00-17:00** - Afternoon sessions: Leads give a 2 minute summary, starting with the afternoon-only projects, and projects reconvene
   - Roundtable discussions

--- a/docs/conf/berlin/2026/writing-day.md
+++ b/docs/conf/berlin/2026/writing-day.md
@@ -9,6 +9,8 @@ Held on Sunday, Writing Day marks the official start of the conference.
 
 Writing Day is modeled after the concept of [code sprints](https://en.wikipedia.org/wiki/Sprint_%28software_development%29) or hackathons, which are common in open-source (OSS) conferences. The goal is to bring together documentarians to collaborate on interesting projects — whether that's open-source documentation, community content, or other documentation-related work.
 
+To create more ways for attendees to take part on Sunday, we are expanding Writing Day to include additional, shorter-format options such as workshops and discussions.
+
 ## How to Participate in Writing Day in 2026
 
 Attendees can lead a Writing Day project or join and contribute to someone else's project. Projects can run for a half-day or full-day.
@@ -33,14 +35,12 @@ We may make changes to the structure closer to the conference.
 - **8:30** - Doors open
 - **9:30** - Welcome and overview
 - **10:00** - Project announcements: Leads give a 2 minute summary and projects begin
-  - **10:00** - Intro to Git ([sign up required](https://www.writethedocs.org/))
-  - **11:00** - First Timer meetup: Meet other people
-  - **11:00** - Resume and portfolio review
+  - New to Git workshop ([sign up required]({{ writing_day.git_signup_url }})) and Write the Docs Orientation
 - **12:30-14:00** - Lunch break
 - **14:00-17:00** - Afternoon sessions: Leads give a 2 minute summary, starting with the afternoon-only projects, and projects reconvene
-  - **14:30** - Roundtable discussion
-  - **15:30** - Roundtable discussion
-  - **15:30** - Lightning Talk workshop
+  - Roundtable discussions
+  - Salary Survey
+  - Resume writing session and portfolio review
 - **17:00-19:00** - Welcome reception
 
 ## How to Prepare

--- a/docs/conf/berlin/2026/writing-day.md
+++ b/docs/conf/berlin/2026/writing-day.md
@@ -39,7 +39,8 @@ We may make changes to the structure closer to the conference.
   - **11:00** - Write the Docs Orientation
 - **12:30-14:00** - Lunch break
 - **14:00-17:00** - Afternoon sessions: Leads give a 2 minute summary, starting with the afternoon-only projects, and projects reconvene
-  - Roundtable discussions
+  - **14:30** - AI and Docs - Roundtable discussion
+  - **15:30** - API docs - Roundtable discussion
   - Salary Survey
   - Resume writing session and portfolio review
 - **17:00-19:00** - Welcome reception
@@ -115,7 +116,7 @@ Find specific examples on the [Portland Writing Day {{year}} project list](https
 
 ## Roundtable Discussions
 
-Roundtable discussions are pre-scheduled, facilitated conversations held in the afternoon. Topics might include AI in documentation and API docs. We are keeping the topics focused this year as an experiment, and if it goes well might expand to a full-day discussion track in the future.
+Roundtable discussions are pre-scheduled, facilitated conversations held in the afternoon. This year's topics are AI in documentation and API docs. We are keeping the topics focused this year as an experiment, and if it goes well might expand to a full-day discussion track in the future.
 
 ## Contact us
 

--- a/docs/conf/berlin/2026/writing-day.md
+++ b/docs/conf/berlin/2026/writing-day.md
@@ -33,8 +33,14 @@ We may make changes to the structure closer to the conference.
 - **8:30** - Doors open
 - **9:30** - Welcome and overview
 - **10:00** - Project announcements: Leads give a 2 minute summary and projects begin
+  - **10:00** - Intro to Git ([sign up required](https://www.writethedocs.org/))
+  - **11:00** - First Timer meetup: Meet other people
+  - **11:00** - Resume and portfolio review
 - **12:30-14:00** - Lunch break
 - **14:00-17:00** - Afternoon sessions: Leads give a 2 minute summary, starting with the afternoon-only projects, and projects reconvene
+  - **14:30** - Roundtable discussion
+  - **15:30** - Roundtable discussion
+  - **15:30** - Lightning Talk workshop
 - **17:00-19:00** - Welcome reception
 
 ## How to Prepare


### PR DESCRIPTION
This is a draft pending some decisions, planned for sending Wed, Aug 26.

Open:

- [ ] Git workshop signups, if required in advance, a tito URL
- [ ] Finalise the schedule
- [ ] Update post date just before publishing

I left a kind of first timer meetup in there for now, but we might drop it. Some of the timing isn't final either.

https://writethedocs-www--2738.org.readthedocs.build/conf/berlin/2026/news/writing-day-schedule/

https://writethedocs-www--2738.org.readthedocs.build/conf/berlin/2026/writing-day/#writing-day-schedule