### PR TITLE
conf: note that the Unconference runs as a second track

### DIFF
--- a/docs/conf/australia/2026/unconference.md
+++ b/docs/conf/australia/2026/unconference.md
@@ -8,6 +8,8 @@ banner: _static/conf/images/headers/2026/unconference.jpg
 
 The Unconference consists of attendee-driven sessions that provide the opportunity for anyone who is attending the conference to lead, contribute, share ideas, and discuss problems in an organized setting away from the main stage talks. Many attendees consider this one of their favorite aspects of the conference.
 
+The Unconference is a second track: sessions run at the same time as the talks, so throughout the day you can choose whichever you prefer.
+
 **Who can lead an Unconference session?**
 
 Everyone! All attendees are invited to lead a session on a topic. Sessions can be organized around a presentation, group discussion or anything in between.
@@ -22,7 +24,7 @@ Everyone!
 
 - Morning and afternoon sessions
 - Each session is 40 minutes in length
-- Sessions run at the same time as the talks, so the Unconference is a second track: at any point in the day, you can choose a talk or an Unconference session
+- Runs as a second track, alongside the talks
 
 ### Scheduling a Session
 

--- a/docs/conf/australia/2026/unconference.md
+++ b/docs/conf/australia/2026/unconference.md
@@ -22,6 +22,7 @@ Everyone!
 
 - Morning and afternoon sessions
 - Each session is 40 minutes in length
+- Sessions run at the same time as the talks, so the Unconference is a second track: at any point in the day, you can choose a talk or an Unconference session
 
 ### Scheduling a Session
 

--- a/docs/conf/berlin/2026/unconference.md
+++ b/docs/conf/berlin/2026/unconference.md
@@ -8,6 +8,8 @@ banner: _static/conf/images/headers/2026/unconference.jpg
 
 The Unconference consists of attendee-driven sessions that provide the opportunity for anyone who is attending the conference to lead, contribute, share ideas, and discuss problems in an organized setting away from the main stage talks. Many attendees consider this one of their favorite aspects of the conference.
 
+The Unconference is a second track: sessions run at the same time as the talks, so throughout the day you can choose whichever you prefer.
+
 **Who can lead an Unconference session?**
 
 Everyone! All attendees are invited to lead a session on a topic. Sessions can be organized around a presentation, group discussion or anything in between.
@@ -22,7 +24,7 @@ Everyone!
 
 - Morning and afternoon sessions
 - Each session is 40 minutes in length
-- Sessions run in the same time slots as the talks, so the Unconference is a second track: at any point in the day, you can choose a talk or an Unconference session
+- Runs as a second track, alongside the talks
 
 ### Scheduling a Session
 

--- a/docs/conf/berlin/2026/unconference.md
+++ b/docs/conf/berlin/2026/unconference.md
@@ -22,6 +22,7 @@ Everyone!
 
 - Morning and afternoon sessions
 - Each session is 40 minutes in length
+- Sessions run in the same time slots as the talks, so the Unconference is a second track: at any point in the day, you can choose a talk or an Unconference session
 
 ### Scheduling a Session
 

--- a/docs/conf/portland/2026/unconference.md
+++ b/docs/conf/portland/2026/unconference.md
@@ -8,6 +8,8 @@ banner: _static/conf/images/headers/2026/unconference.jpg
 
 The Unconference consists of attendee-driven sessions that provide the opportunity for anyone who is attending the conference to lead, contribute, share ideas, and discuss problems in an organized setting away from the main stage talks. Many attendees consider this one of their favorite aspects of the conference.
 
+The Unconference is a second track: sessions run at the same time as the talks, so throughout the day you can choose whichever you prefer.
+
 **Who can lead an Unconference session?**
 
 Everyone! All attendees are invited to lead a session on a topic. Sessions can be organized around a presentation, group discussion or anything in between.
@@ -22,6 +24,7 @@ Everyone!
 
 - Each session is 35 minutes in length
 - Sessions will be scheduled in 4-6 time slots, with multiple sessions happening at the same time
+- Runs as a second track, alongside the talks
 - Hosted in {{ about.unconfroom }}
 
 See the [Schedule](/conf/{{shortcode}}/{{year}}/schedule) page for exact times.


### PR DESCRIPTION
Attendees often don't realize that Unconference sessions are scheduled in the same time blocks as the talks, so you're choosing between the two rather than fitting both in. This makes that explicit on the 2026 Unconference pages (Berlin, Australia, Portland).

The explanation lives in the intro section, with a short bullet in the Schedule list so that list stays scannable. Portland is included so the wording carries over when the page is copied for 2027.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VmUQudjAcinDicCDjAwhNm)_

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2741.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->