### PR TITLE
Add Berlin 2026 LT/unconf signup links

### DIFF
--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -163,8 +163,11 @@ cfp:
   preview: "https://writethedocs-www--2726.org.readthedocs.build/conf/berlin/2026/schedule/"                                  # Preview URL TODO
 
 unconf:
-  url: ""
+  url: "https://docs.google.com/spreadsheets/d/1g300ZMOfZ0SRrg37v0MvYTVRy2W1Lcs8rlQ7unnWOZM/edit?usp=sharing"
   date: "All day, Monday, September 7 and Tuesday, September 8"
+
+lightning_talks:
+  signup_url: "https://docs.google.com/forms/d/e/1FAIpQLSduOPKqF2wIZM79cGL4ZttjnRXVX2f_tz3YfiR_HhOnhBMLoA/viewform"
 
 writing_day:
   url: "https://docs.google.com/forms/d/e/1FAIpQLSf5dN0o3HkPMY5UTVzyhO6nq7T07OL6awFHv9fkfX_jdV98iQ/viewform"

--- a/docs/conf/berlin/2026/lightning-talks.md
+++ b/docs/conf/berlin/2026/lightning-talks.md
@@ -28,6 +28,12 @@ Lightning Talks can be submitted through an online form only.
 - One week prior to the conference (Monday submissions only)
 - During the conference from Sunday to Tuesday morning, until the end of the last morning break
 
+{% if lightning_talks.signup_url %}
+```{button-link} {{ lightning_talks.signup_url }}
+Submit a Lightning Talk
+```
+{% endif %}
+
 **Speaker selection and announcements:**
 
 The coordinator, with staff support, selects the speakers. The speakers are announced onstage after the final morning talk and before lunch on Monday and Tuesday. You do not have to be present to be selected, but it is helpful. The coordinator also contacts the speakers by phone to confirm their acceptance. 

--- a/docs/conf/berlin/2026/unconference.md
+++ b/docs/conf/berlin/2026/unconference.md
@@ -35,6 +35,12 @@ Everyone!
 
 Exact times to be posted on our [Schedule](/conf/{{shortcode}}/{{year}}/schedule) page.
 
+{% if unconf.url %}
+```{button-link} {{ unconf.url }}
+See the Unconference sessions or lead a session
+```
+{% endif %}
+
 ## Leading a Session
 
 Sessions take place at tables and focus on small group interaction. There is no stage at an Unconference session.


### PR DESCRIPTION


<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2747.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->