### PR TITLE
docs: add Sourcey to documentation tools

### DIFF
--- a/docs/guide/tools/index.rst
+++ b/docs/guide/tools/index.rst
@@ -27,6 +27,7 @@ While this section currently focuses on Sphinx, the Write the Docs community use
 - **Docusaurus**: React-based tool by Meta with built-in versioning and i18n
 - **Jekyll**: Ruby-based static site generator, popular for GitHub Pages
 - **Hugo**: Extremely fast Go-based generator for content sites
+- `Sourcey <https://sourcey.com/>`__: Static site generator for combining API references generated from OpenAPI, MCP, Doxygen, Go, or Rust with Markdown guides
 
 See the main :doc:`/guide/index` for broader documentation guidance applicable across tools.
 

--- a/docs/guide/tools/index.rst
+++ b/docs/guide/tools/index.rst
@@ -27,7 +27,7 @@ While this section currently focuses on Sphinx, the Write the Docs community use
 - **Docusaurus**: React-based tool by Meta with built-in versioning and i18n
 - **Jekyll**: Ruby-based static site generator, popular for GitHub Pages
 - **Hugo**: Extremely fast Go-based generator for content sites
-- `Sourcey <https://sourcey.com/>`__: Static site generator for combining API references generated from OpenAPI, MCP, Doxygen, Go, or Rust with Markdown guides
+- **Sourcey**: Open-source static site generator for combining API references generated from OpenAPI, MCP, Doxygen, Go, or Rust with Markdown guides (`website <https://sourcey.com/>`__)
 
 See the main :doc:`/guide/index` for broader documentation guidance applicable across tools.
 


### PR DESCRIPTION
Adds Sourcey to the existing list of other documentation tools, scoped to its use case: combining generated API references with Markdown guides.

Validation:
- Vale 3.4.2 (site and guide configurations): passed
- codespell: passed
- git diff --check: passed

This contribution was generated with AI assistance and reviewed before submission.

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2748.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->