### PR TITLE
sponsorship: add pricing table and CTA buttons

### DIFF
--- a/docs/_static/css/global-customizations.css
+++ b/docs/_static/css/global-customizations.css
@@ -270,12 +270,9 @@ div.body {
   }
 }
 
-/** Sponsorship CTA buttons **/
+/** Sponsorship CTA button, using the existing newsletter button colors **/
 
 .cta-group {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
     margin: 1.5em 0;
 }
 
@@ -285,33 +282,19 @@ div.body a.cta-button:visited {
     display: inline-block;
     padding: 12px 28px;
     background-color: #2ECC71;
-    border: 1px solid #27AE60;
+    border: 1px solid #4a4a4a;
     border-radius: 5px;
     color: #FFFFFF;
     font-family: Helvetica, Arial, sans-serif;
     font-size: 16px;
     font-weight: bold;
-    line-height: 150%;
     text-decoration: none;
 }
 
 div.body a.cta-button:hover {
-    background-color: #27AE60;
+    filter: brightness(0.95);
     color: #FFFFFF;
     text-decoration: none;
-}
-
-div.body a.cta-button.cta-secondary,
-div.body a.cta-button.cta-secondary:link,
-div.body a.cta-button.cta-secondary:visited {
-    background-color: #FFFFFF;
-    border: 1px solid #27AE60;
-    color: #27AE60;
-}
-
-div.body a.cta-button.cta-secondary:hover {
-    background-color: #EAFAF1;
-    color: #1E8449;
 }
 
 table.sponsorship-pricing {

--- a/docs/_static/css/global-customizations.css
+++ b/docs/_static/css/global-customizations.css
@@ -270,6 +270,58 @@ div.body {
   }
 }
 
+/** Sponsorship CTA buttons **/
+
+.cta-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin: 1.5em 0;
+}
+
+div.body a.cta-button,
+div.body a.cta-button:link,
+div.body a.cta-button:visited {
+    display: inline-block;
+    padding: 12px 28px;
+    background-color: #2ECC71;
+    border: 1px solid #27AE60;
+    border-radius: 5px;
+    color: #FFFFFF;
+    font-family: Helvetica, Arial, sans-serif;
+    font-size: 16px;
+    font-weight: bold;
+    line-height: 150%;
+    text-decoration: none;
+}
+
+div.body a.cta-button:hover {
+    background-color: #27AE60;
+    color: #FFFFFF;
+    text-decoration: none;
+}
+
+div.body a.cta-button.cta-secondary,
+div.body a.cta-button.cta-secondary:link,
+div.body a.cta-button.cta-secondary:visited {
+    background-color: #FFFFFF;
+    border: 1px solid #27AE60;
+    color: #27AE60;
+}
+
+div.body a.cta-button.cta-secondary:hover {
+    background-color: #EAFAF1;
+    color: #1E8449;
+}
+
+table.sponsorship-pricing {
+    width: 100%;
+}
+
+table.sponsorship-pricing td, table.sponsorship-pricing th {
+    padding: 8px 12px;
+}
+
 .announcement-banner {
     background-color: #3399ff;
     color: #fff;

--- a/docs/_static/css/global-customizations.css
+++ b/docs/_static/css/global-customizations.css
@@ -299,10 +299,22 @@ div.body a.cta-button:hover {
 
 table.sponsorship-pricing {
     width: 100%;
+    border-collapse: collapse;
 }
 
 table.sponsorship-pricing td, table.sponsorship-pricing th {
-    padding: 8px 12px;
+    border: none;
+    border-bottom: 1px solid #DDD;
+    padding: 10px 12px;
+    text-align: left;
+}
+
+table.sponsorship-pricing thead th {
+    border-bottom: 2px solid #4a4a4a;
+}
+
+table.sponsorship-pricing td:last-child {
+    white-space: nowrap;
 }
 
 .announcement-banner {

--- a/docs/sponsorship/index.rst
+++ b/docs/sponsorship/index.rst
@@ -1,31 +1,8 @@
-Sponsor Write the Docs
-======================
+Community Sponsorship
+=====================
 
-Write the Docs is a global community of people who care about documentation:
-technical writers, developers, developer advocates, support folks, and the people who lead them.
-Sponsorship puts your company in front of this audience,
-and keeps the community sustainable.
-
-Our community includes:
-
-* A Slack network with over {{ slack_members }} members
-* A monthly newsletter with over {{ newsletter_subs }} subscribers
-* A website with {{ website_visits }}+ visits a month
-* Yearly conferences on four continents, with video archives from all conference years
-* Meetup groups in over {{ meetup_cities }} cities
-
-.. raw:: html
-
-   <div class="cta-group">
-      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Sponsoring%20Write%20the%20Docs">Email our sponsorship team</a>
-      <a class="cta-button cta-secondary" href="#options-and-pricing">See options and pricing</a>
-   </div>
-
-Options and pricing
--------------------
-
-Every program has a fixed price and a simple format,
-so you can get started with a single email to `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org>`__.
+We support our community in a variety of ways, and you can choose to focus
+your sponsorship on any one of them, at a level that suits you:
 
 .. list-table::
    :class: sponsorship-pricing
@@ -53,37 +30,40 @@ so you can get started with a single email to `sponsorship@writethedocs.org <mai
 
 We accept payment online by card, or we can issue an invoice — whichever works best for your company.
 
-Conference sponsorship
-----------------------
-
-Our conferences are the best way to meet the community in person,
-with packages for organizations of every size.
-Each conference has its own sponsorship prospectus:
+Our conferences each have their own sponsorship prospectus:
 
 * Our hybrid :doc:`Berlin 2026 conference </conf/berlin/2026/sponsors/prospectus>` (September 6-8, 2026)
 * Our :doc:`Australia 2026 conference </conf/australia/2026/sponsors/prospectus>` (December 3-4, 2026)
-
-How to sponsor
---------------
-
-#. **Pick a program** from the options above — or tell us your goals and we'll recommend one.
-#. **Email us** at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?subject=Sponsoring%20Write%20the%20Docs>`__ with the program and month you'd like.
-#. **Pay and send your assets.** We'll confirm availability, send a payment link or invoice, and walk you through the asset requirements.
 
 In addition to these existing programs,
 we're always interested in working together with organizations in our community to build new approaches to sponsorship.
 We believe we have one of the most skilled and forward-looking communities in the software industry,
 and look forward to working together to keep it sustainable.
 
+You can `reach out to us`_ directly if you have any questions or ideas for sponsorship.
+
+.. _reach out to us: mailto:sponsorship@writethedocs.org
+
+.. raw:: html
+
+   <div class="cta-group">
+      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Sponsoring%20Write%20the%20Docs">Email our sponsorship team</a>
+   </div>
+
 What your money supports
 ------------------------
 
 Write the Docs was founded in 2013 to build a community for documentarians. There are many communities for particular technologies, or particular areas of writing. Write the Docs is quite unique in including everyone who cares about communication, documentation, and their users. That includes programmers, tech writers, developer advocates, customer support, marketers, and anyone else who wants people to have great experiences with software.
 
-We also run other activities, such as our annual salary survey, and are currently exploring even more ways to support the community and help our community stay connected.
+Over the years, we have grown to a community that includes:
 
-Your sponsorship directly covers the cost of running these programs,
-and keeps them available to everyone in the community.
+* A Slack network with over {{ slack_members }} members.
+* Yearly conferences on four continents, and video archives from all conference years.
+* Meetup groups in over {{ meetup_cities }} cities.
+* A monthly newsletter with over {{ newsletter_subs }} subscribers.
+* An extensive documentation guide.
+
+We also run other activities, such as our annual salary survey, and are currently exploring even more ways to support the community and help our community stay connected.
 
 .. raw:: html
 

--- a/docs/sponsorship/index.rst
+++ b/docs/sponsorship/index.rst
@@ -1,40 +1,95 @@
-Community Sponsorship
-=====================
+Sponsor Write the Docs
+======================
 
-We support our community in a variety of ways, and you can choose to focus 
-your sponsorship on any one of them, at a level that suits you:
+Write the Docs is a global community of people who care about documentation:
+technical writers, developers, developer advocates, support folks, and the people who lead them.
+Sponsorship puts your company in front of this audience,
+and keeps the community sustainable.
 
-* Our conferences each have their own sponsorship prospectus
-    - Our hybrid :doc:`Berlin 2026 conference </conf/berlin/2026/sponsors/prospectus>` (September 6-8, 2026)
-    - Our :doc:`Australia 2026 conference </conf/australia/2026/sponsors/prospectus>` (December 3-4, 2026)
-* Our :doc:`/sponsorship/newsletter` with over {{ newsletter_subs }} subscribers
-* Our :doc:`/sponsorship/slack` allows you to get in front of our Slack network
-* Our :doc:`/sponsorship/jobs` gets your job posting in front of our community
-* Our :doc:`/sponsorship/website` offers a sidebar ad on our website
+Our community includes:
+
+* A Slack network with over {{ slack_members }} members
+* A monthly newsletter with over {{ newsletter_subs }} subscribers
+* A website with {{ website_visits }}+ visits a month
+* Yearly conferences on four continents, with video archives from all conference years
+* Meetup groups in over {{ meetup_cities }} cities
+
+.. raw:: html
+
+   <div class="cta-group">
+      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Sponsoring%20Write%20the%20Docs">Email our sponsorship team</a>
+      <a class="cta-button cta-secondary" href="#options-and-pricing">See options and pricing</a>
+   </div>
+
+Options and pricing
+-------------------
+
+Every program has a fixed price and a simple format,
+so you can get started with a single email to `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org>`__.
+
+.. list-table::
+   :class: sponsorship-pricing
+   :header-rows: 1
+   :widths: 30 45 25
+
+   * - Program
+     - Who you reach
+     - Price
+   * - :doc:`Newsletter sponsorship </sponsorship/newsletter>`
+     - Over {{ newsletter_subs }} subscribers, 42% open rate
+     - **$500** / month
+   * - :doc:`Slack sponsorship </sponsorship/slack>`
+     - Over {{ slack_members }} Slack members
+     - **$350** / month
+   * - :doc:`Job posting </sponsorship/jobs>`
+     - Newsletter and Slack jobs channel
+     - **$250** / posting
+   * - :doc:`Website sidebar ad </sponsorship/website>`
+     - {{ website_visits }}+ website visits a month
+     - **$250** / month
+   * - :doc:`Website footer logo </sponsorship/website>`
+     - Every page of our community website
+     - **$500** / year
+
+We accept payment online by card, or we can issue an invoice — whichever works best for your company.
+
+Conference sponsorship
+----------------------
+
+Our conferences are the best way to meet the community in person,
+with packages for organizations of every size.
+Each conference has its own sponsorship prospectus:
+
+* Our hybrid :doc:`Berlin 2026 conference </conf/berlin/2026/sponsors/prospectus>` (September 6-8, 2026)
+* Our :doc:`Australia 2026 conference </conf/australia/2026/sponsors/prospectus>` (December 3-4, 2026)
+
+How to sponsor
+--------------
+
+#. **Pick a program** from the options above — or tell us your goals and we'll recommend one.
+#. **Email us** at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?subject=Sponsoring%20Write%20the%20Docs>`__ with the program and month you'd like.
+#. **Pay and send your assets.** We'll confirm availability, send a payment link or invoice, and walk you through the asset requirements.
 
 In addition to these existing programs,
-we're always interested in working together with organizations in our community to build new approaches to sponsorship. 
+we're always interested in working together with organizations in our community to build new approaches to sponsorship.
 We believe we have one of the most skilled and forward-looking communities in the software industry,
 and look forward to working together to keep it sustainable.
-
-You can `reach out to us`_ directly if you have any questions or ideas for sponsorship.
-
-.. _reach out to us: mailto:sponsorship@writethedocs.org
 
 What your money supports
 ------------------------
 
 Write the Docs was founded in 2013 to build a community for documentarians. There are many communities for particular technologies, or particular areas of writing. Write the Docs is quite unique in including everyone who cares about communication, documentation, and their users. That includes programmers, tech writers, developer advocates, customer support, marketers, and anyone else who wants people to have great experiences with software.
 
-Over the years, we have grown to a community that includes:
-
-* A Slack network with over {{ slack_members }} members.
-* Yearly conferences on four continents, and video archives from all conference years.
-* Meetup groups in over {{ meetup_cities }} cities.
-* A monthly newsletter with over {{ newsletter_subs }} subscribers.
-* An extensive documentation guide.
-
 We also run other activities, such as our annual salary survey, and are currently exploring even more ways to support the community and help our community stay connected.
+
+Your sponsorship directly covers the cost of running these programs,
+and keeps them available to everyone in the community.
+
+.. raw:: html
+
+   <div class="cta-group">
+      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Sponsoring%20Write%20the%20Docs">Become a sponsor</a>
+   </div>
 
 .. toctree::
    :hidden:

--- a/docs/sponsorship/index.rst
+++ b/docs/sponsorship/index.rst
@@ -2,7 +2,22 @@ Community Sponsorship
 =====================
 
 We support our community in a variety of ways, and you can choose to focus
-your sponsorship on any one of them, at a level that suits you:
+your sponsorship on any one of them, at a level that suits you.
+
+Conferences
+-----------
+
+Our conferences are the best way to get in front of our community in person.
+Each conference has its own sponsorship prospectus:
+
+* Our hybrid :doc:`Berlin 2026 conference </conf/berlin/2026/sponsors/prospectus>` (September 6-8, 2026)
+* Our :doc:`Australia 2026 conference </conf/australia/2026/sponsors/prospectus>` (December 3-4, 2026)
+* **Portland 2027** (May 2-4, 2027) — planning next year's budget? `Email us <mailto:sponsorship@writethedocs.org?subject=Portland%202027%20sponsorship>`__ and we'll send you the prospectus as soon as it's ready.
+
+Community programs
+------------------
+
+Our year-round programs put your name in front of the community every day:
 
 .. list-table::
    :class: sponsorship-pricing
@@ -29,11 +44,6 @@ your sponsorship on any one of them, at a level that suits you:
      - **$500** / year
 
 We accept payment online by card, or we can issue an invoice — whichever works best for your company.
-
-Our conferences each have their own sponsorship prospectus:
-
-* Our hybrid :doc:`Berlin 2026 conference </conf/berlin/2026/sponsors/prospectus>` (September 6-8, 2026)
-* Our :doc:`Australia 2026 conference </conf/australia/2026/sponsors/prospectus>` (December 3-4, 2026)
 
 In addition to these existing programs,
 we're always interested in working together with organizations in our community to build new approaches to sponsorship.

--- a/docs/sponsorship/index.rst
+++ b/docs/sponsorship/index.rst
@@ -23,7 +23,7 @@ Each conference has its own sponsorship prospectus:
      - From **€2,250**
    * - :doc:`Australia 2026 </conf/australia/2026/sponsors/prospectus>`
      - December 3-4, 2026 in Melbourne, Australia
-     - From **$1,500**
+     - From **AU$1,500**
    * - **Portland 2027**
      - May 2-4, 2027 in Portland, Oregon
      - Coming soon

--- a/docs/sponsorship/index.rst
+++ b/docs/sponsorship/index.rst
@@ -29,7 +29,7 @@ Each conference has its own sponsorship prospectus:
      - Coming soon
 
 **Planning your 2027 budget?**
-`Email us <mailto:sponsorship@writethedocs.org?subject=Portland%202027%20sponsorship>`__ and we'll send you the Portland 2027 prospectus as soon as it's ready.
+Email `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?subject=Portland%202027%20sponsorship>`__ and we'll send you the Portland 2027 prospectus as soon as it's ready.
 
 Community programs
 ------------------
@@ -67,9 +67,7 @@ we're always interested in working together with organizations in our community 
 We believe we have one of the most skilled and forward-looking communities in the software industry,
 and look forward to working together to keep it sustainable.
 
-You can `reach out to us`_ directly if you have any questions or ideas for sponsorship.
-
-.. _reach out to us: mailto:sponsorship@writethedocs.org
+You can reach out to us directly at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org>`__ if you have any questions or ideas for sponsorship.
 
 .. raw:: html
 

--- a/docs/sponsorship/index.rst
+++ b/docs/sponsorship/index.rst
@@ -10,9 +10,26 @@ Conferences
 Our conferences are the best way to get in front of our community in person.
 Each conference has its own sponsorship prospectus:
 
-* Our hybrid :doc:`Berlin 2026 conference </conf/berlin/2026/sponsors/prospectus>` (September 6-8, 2026)
-* Our :doc:`Australia 2026 conference </conf/australia/2026/sponsors/prospectus>` (December 3-4, 2026)
-* **Portland 2027** (May 2-4, 2027) — planning next year's budget? `Email us <mailto:sponsorship@writethedocs.org?subject=Portland%202027%20sponsorship>`__ and we'll send you the prospectus as soon as it's ready.
+.. list-table::
+   :class: sponsorship-pricing
+   :header-rows: 1
+   :widths: 30 45 25
+
+   * - Conference
+     - When and where
+     - Price
+   * - :doc:`Berlin 2026 </conf/berlin/2026/sponsors/prospectus>` (hybrid)
+     - September 6-8, 2026 in Berlin, Germany
+     - From **€2,250**
+   * - :doc:`Australia 2026 </conf/australia/2026/sponsors/prospectus>`
+     - December 3-4, 2026 in Melbourne, Australia
+     - From **$1,500**
+   * - **Portland 2027**
+     - May 2-4, 2027 in Portland, Oregon
+     - Coming soon
+
+**Planning your 2027 budget?**
+`Email us <mailto:sponsorship@writethedocs.org?subject=Portland%202027%20sponsorship>`__ and we'll send you the Portland 2027 prospectus as soon as it's ready.
 
 Community programs
 ------------------

--- a/docs/sponsorship/index.rst
+++ b/docs/sponsorship/index.rst
@@ -24,7 +24,7 @@ Each conference has its own sponsorship prospectus:
    * - :doc:`Australia 2026 </conf/australia/2026/sponsors/prospectus>`
      - December 3-4, 2026 in Melbourne, Australia
      - From **AU$1,500**
-   * - **Portland 2027**
+   * - Portland 2027
      - May 2-4, 2027 in Portland, Oregon
      - Coming soon
 

--- a/docs/sponsorship/jobs.rst
+++ b/docs/sponsorship/jobs.rst
@@ -1,16 +1,15 @@
 Job Posting Sponsorship
 =======================
 
-Hiring documentarians? Our community is full of folks that are passionate about software documentation,
+We offer a sponsorship for companies looking to hire documentarians.
+It's a great way to promote your job to our community,
+which is full of folks that are passionate about software documentation,
 in particular around Docs as Code, API documentation, and developer experience.
-A job posting sponsorship is the best way to promote your open role to them.
 
-At a glance
------------
+This sponsorship includes:
 
-* **Price:** $250 per job posting
-* **Reach:** Our monthly newsletter (over {{ newsletter_subs }} subscribers) and our ``#job-posts-only`` Slack channel ({{ slack_members }} members)
-* **Format:** Company name, job title, location, optional salary, and a link to your posting
+* A job posting in our monthly newsletter jobs section (Over {{ newsletter_subs }} subscribers)
+* A highlighted job posting in our ``#job-posts-only`` Slack channel ({{ slack_members }} members)
 
 .. raw:: html
 
@@ -38,19 +37,22 @@ Schedule
 We publish the newsletter once a month, typically in the first week of the month.
 The Slack post will be made within 1 week of the sponsorship being purchased.
 
+Pricing
+-------
+
+The price for our hiring sponsorship is **$250** per job posting.
+
 Examples
 --------
 
 .. image:: /_static/img/sponsorship/job-example.png
    :width: 45%
 
-How to order
-------------
+Ordering
+--------
 
-The price for our hiring sponsorship is **$250** per job posting.
-We can send you a payment link or issue an invoice — whichever works best for your company.
-
-Email us at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?subject=Job%20posting%20sponsorship>`_ with your job details, and we'll take it from there.
+Email us at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?subject=Job%20posting%20sponsorship>`__ to purchase your sponsorship,
+or if you have any questions.
 
 .. raw:: html
 

--- a/docs/sponsorship/jobs.rst
+++ b/docs/sponsorship/jobs.rst
@@ -1,15 +1,22 @@
 Job Posting Sponsorship
 =======================
 
-We have added a new sponsorship opportunity for companies looking to hire documentarians.
-It's a great way to promote your job to our community,
-which is full of folks that are passionate about software documentation,
+Hiring documentarians? Our community is full of folks that are passionate about software documentation,
 in particular around Docs as Code, API documentation, and developer experience.
+A job posting sponsorship is the best way to promote your open role to them.
 
-This sponsorship includes: 
+At a glance
+-----------
 
-* A job posting in our monthly newsletter jobs section (Over {{ newsletter_subs }} subscribers)
-* A highlighted job posting in our ``#job-posts-only`` Slack channel ({{ slack_members }} members)
+* **Price:** $250 per job posting
+* **Reach:** Our monthly newsletter (over {{ newsletter_subs }} subscribers) and our ``#job-posts-only`` Slack channel ({{ slack_members }} members)
+* **Format:** Company name, job title, location, optional salary, and a link to your posting
+
+.. raw:: html
+
+   <div class="cta-group">
+      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Job%20posting%20sponsorship">Post your job — $250</a>
+   </div>
 
 Sponsored entry format
 ----------------------
@@ -31,22 +38,22 @@ Schedule
 We publish the newsletter once a month, typically in the first week of the month.
 The Slack post will be made within 1 week of the sponsorship being purchased.
 
-Pricing
--------
-
-The price for our hiring sponsorship is **$250** per job posting.
-
 Examples
 --------
 
 .. image:: /_static/img/sponsorship/job-example.png
    :width: 45%
 
-Ordering
---------
+How to order
+------------
 
-Email us at sponsorship@writethedocs.org to purchase your sponsorship,
-or if you have any questions.
+The price for our hiring sponsorship is **$250** per job posting.
+We can send you a payment link or issue an invoice — whichever works best for your company.
 
+Email us at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?subject=Job%20posting%20sponsorship>`_ with your job details, and we'll take it from there.
 
+.. raw:: html
 
+   <div class="cta-group">
+      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Job%20posting%20sponsorship">Post your job — $250</a>
+   </div>

--- a/docs/sponsorship/jobs.rst
+++ b/docs/sponsorship/jobs.rst
@@ -14,7 +14,7 @@ This sponsorship includes:
 .. raw:: html
 
    <div class="cta-group">
-      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Job%20posting%20sponsorship">Post your job — $250</a>
+      <a class="cta-button" href="https://buy.stripe.com/fZe4gE2jyal76liaEM">Post your job — $250</a>
    </div>
 
 Sponsored entry format
@@ -42,6 +42,9 @@ Pricing
 
 The price for our hiring sponsorship is **$250** per job posting.
 
+You can pay via our `online payment form <https://buy.stripe.com/fZe4gE2jyal76liaEM>`_,
+or we can issue you an invoice.
+
 Examples
 --------
 
@@ -57,5 +60,5 @@ or if you have any questions.
 .. raw:: html
 
    <div class="cta-group">
-      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Job%20posting%20sponsorship">Post your job — $250</a>
+      <a class="cta-button" href="https://buy.stripe.com/fZe4gE2jyal76liaEM">Post your job — $250</a>
    </div>

--- a/docs/sponsorship/newsletter.rst
+++ b/docs/sponsorship/newsletter.rst
@@ -9,18 +9,26 @@ Sponsorship of the newsletter does two things:
 * It allows you to get your name and message in front of our audience of :doc:`/documentarians`
 * It allows us to cover the cost of producing the newsletter for our community
 
+At a glance
+-----------
+
+* **Price:** $500 per issue, published monthly
+* **Reach:** Over {{ newsletter_subs }} subscribers, with a 42% open rate
+* **Format:** Your logo, up to 2 paragraphs of copy, and up to 2 links
+
+.. raw:: html
+
+   <div class="cta-group">
+      <a class="cta-button" href="https://buy.stripe.com/3cs6oMgao9h3eRO8wC">Buy a newsletter sponsorship — $500</a>
+      <a class="cta-button cta-secondary" href="mailto:sponsorship@writethedocs.org?subject=Newsletter%20sponsorship">Email us to book a month</a>
+   </div>
+
 You can see our newsletter archives to get a better idea of the content that we produce:
 
 .. raw:: html
 
-   <div style="margin: 2em 0;">
-   <table border="0" cellpadding="0" cellspacing="0" style="background-color:#2ECC71; border:1px solid #4a4a4a; border-radius:5px;">
-   <tr>
-      <td align="center" valign="middle" style="color:#FFFFFF; font-family:Helvetica, Arial, sans-serif; font-size:16px; font-weight:bold; letter-spacing:-.5px; line-height:150%; padding-top:15px; padding-right:30px; padding-bottom:15px; padding-left:30px;">
-         <a href="/blog/archive/tag/newsletter/" target="_blank" style="color:#FFFFFF; text-decoration:none; border-bottom: none;">View Newsletter Archive</a>
-      </td>
-   </tr>
-   </table>
+   <div class="cta-group">
+      <a class="cta-button cta-secondary" href="/blog/archive/tag/newsletter/">View newsletter archive</a>
    </div>
 
 Audience
@@ -32,7 +40,7 @@ The current newsletter stats are:
 * Over {{ newsletter_subs }} subscribers
 * 42% open rate
 
-We don't exact demographic data for our newsletter subscribers, but according to the data gathered from our conferences, our audience is made up of:
+We don't have exact demographic data for our newsletter subscribers, but according to the data gathered from our conferences, our audience is made up of:
 
 .. include:: /include/demographics.rst
 
@@ -53,14 +61,6 @@ Schedule
 We publish the newsletter once a month, typically in the first week of the month.
 **We ask that your assets be submitted by the end of the month prior to the newsletter being published.**
 
-Pricing
--------
-
-The price for our newsletter sponsorship is **$500** per month.
-
-You can pay for the newsletter via our `online payment form <https://buy.stripe.com/3cs6oMgao9h3eRO8wC>`_,
-or we can issue you an invoice.
-
 Examples
 --------
 
@@ -70,7 +70,18 @@ Examples
 .. image:: /_static/img/sponsorship/newsletter-example-2.png
    :width: 45%
 
-Ordering
---------
+How to order
+------------
 
-Email us at sponsorship@writethedocs.org to purchase a Newsletter sponsorship.
+The price for our newsletter sponsorship is **$500** per month.
+
+You can pay directly via our `online payment form <https://buy.stripe.com/3cs6oMgao9h3eRO8wC>`_,
+or email us at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?subject=Newsletter%20sponsorship>`_ if you'd prefer an invoice,
+want to book a specific month, or have any questions.
+
+.. raw:: html
+
+   <div class="cta-group">
+      <a class="cta-button" href="https://buy.stripe.com/3cs6oMgao9h3eRO8wC">Buy a newsletter sponsorship — $500</a>
+      <a class="cta-button cta-secondary" href="mailto:sponsorship@writethedocs.org?subject=Newsletter%20sponsorship">Email sponsorship@writethedocs.org</a>
+   </div>

--- a/docs/sponsorship/newsletter.rst
+++ b/docs/sponsorship/newsletter.rst
@@ -9,27 +9,13 @@ Sponsorship of the newsletter does two things:
 * It allows you to get your name and message in front of our audience of :doc:`/documentarians`
 * It allows us to cover the cost of producing the newsletter for our community
 
-At a glance
------------
-
-* **Price:** $500 per issue, published monthly
-* **Reach:** Over {{ newsletter_subs }} subscribers, with a 42% open rate
-* **Format:** Your logo, up to 2 paragraphs of copy, and up to 2 links
-
 .. raw:: html
 
    <div class="cta-group">
       <a class="cta-button" href="https://buy.stripe.com/3cs6oMgao9h3eRO8wC">Buy a newsletter sponsorship — $500</a>
-      <a class="cta-button cta-secondary" href="mailto:sponsorship@writethedocs.org?subject=Newsletter%20sponsorship">Email us to book a month</a>
    </div>
 
-You can see our newsletter archives to get a better idea of the content that we produce:
-
-.. raw:: html
-
-   <div class="cta-group">
-      <a class="cta-button cta-secondary" href="/blog/archive/tag/newsletter/">View newsletter archive</a>
-   </div>
+You can browse our `newsletter archive </blog/archive/tag/newsletter/>`__ to get a better idea of the content that we produce.
 
 Audience
 --------
@@ -61,6 +47,14 @@ Schedule
 We publish the newsletter once a month, typically in the first week of the month.
 **We ask that your assets be submitted by the end of the month prior to the newsletter being published.**
 
+Pricing
+-------
+
+The price for our newsletter sponsorship is **$500** per month.
+
+You can pay for the newsletter via our `online payment form <https://buy.stripe.com/3cs6oMgao9h3eRO8wC>`_,
+or we can issue you an invoice.
+
 Examples
 --------
 
@@ -70,18 +64,13 @@ Examples
 .. image:: /_static/img/sponsorship/newsletter-example-2.png
    :width: 45%
 
-How to order
-------------
+Ordering
+--------
 
-The price for our newsletter sponsorship is **$500** per month.
-
-You can pay directly via our `online payment form <https://buy.stripe.com/3cs6oMgao9h3eRO8wC>`_,
-or email us at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?subject=Newsletter%20sponsorship>`_ if you'd prefer an invoice,
-want to book a specific month, or have any questions.
+Email us at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?subject=Newsletter%20sponsorship>`__ to purchase a Newsletter sponsorship.
 
 .. raw:: html
 
    <div class="cta-group">
       <a class="cta-button" href="https://buy.stripe.com/3cs6oMgao9h3eRO8wC">Buy a newsletter sponsorship — $500</a>
-      <a class="cta-button cta-secondary" href="mailto:sponsorship@writethedocs.org?subject=Newsletter%20sponsorship">Email sponsorship@writethedocs.org</a>
    </div>

--- a/docs/sponsorship/slack.rst
+++ b/docs/sponsorship/slack.rst
@@ -12,7 +12,7 @@ Sponsorship of our Slack network does two things:
 .. raw:: html
 
    <div class="cta-group">
-      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Slack%20sponsorship">Book a Slack sponsorship — $350</a>
+      <a class="cta-button" href="https://buy.stripe.com/aEUcNa6zOdxjeRO5kp">Buy a Slack sponsorship — $350</a>
    </div>
 
 You can join our Slack and read some of the messages to get a feel for the community.
@@ -72,6 +72,9 @@ Pricing
 
 The price for reaching our audience is **$350** per month.
 
+You can pay via our `online payment form <https://buy.stripe.com/aEUcNa6zOdxjeRO5kp>`_,
+or we can issue you an invoice.
+
 Contact
 -------
 
@@ -80,5 +83,5 @@ Email us at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?s
 .. raw:: html
 
    <div class="cta-group">
-      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Slack%20sponsorship">Book a Slack sponsorship — $350</a>
+      <a class="cta-button" href="https://buy.stripe.com/aEUcNa6zOdxjeRO5kp">Buy a Slack sponsorship — $350</a>
    </div>

--- a/docs/sponsorship/slack.rst
+++ b/docs/sponsorship/slack.rst
@@ -9,6 +9,19 @@ Sponsorship of our Slack network does two things:
 * It allows us to cover the cost of moderating and managing our Slack community
 * It allows you to get your name and message in front of our audience of :doc:`/documentarians`
 
+At a glance
+-----------
+
+* **Price:** $350 per month
+* **Reach:** Over {{ slack_members }} Slack members, via the ``#announcements`` channel that every member joins
+* **Format:** Up to 2 paragraphs of copy with 1 link, posted once a month
+
+.. raw:: html
+
+   <div class="cta-group">
+      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Slack%20sponsorship">Book a Slack sponsorship — $350</a>
+   </div>
+
 You can join our Slack and read some of the messages to get a feel for the community.
 
 Audience
@@ -43,7 +56,7 @@ Content Guidance
 
 The provided copy must respect our general `Slack
 Rules <https://www.writethedocs.org/slack/>`__ and `Code of
-Conduct <https://www.writethedocs.org/code-of-conduct/>`__. 
+Conduct <https://www.writethedocs.org/code-of-conduct/>`__.
 
 With regards to the *No Sales-Y Content* rule, sponsored posts have an
 exemption to the *No Direct Pitches*, *No links without context*, and
@@ -61,22 +74,16 @@ We currently allow 1 sponsored post per month on our Slack.
 We aim to send these during the first week of the month,
 but can be flexible if we haven't sold our current month.
 
-Pricing
--------
+How to order
+------------
 
 The price for reaching our audience is **$350** per month.
+We can send you a payment link or issue an invoice — whichever works best for your company.
 
-.. 
-	Examples
-	--------
+Email us at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?subject=Slack%20sponsorship>`_ with the month you'd like, and we'll confirm availability.
 
-	.. image:: /_static/img/sponsorship/newsletter-example.png
-	   :width: 45%
+.. raw:: html
 
-	.. image:: /_static/img/sponsorship/newsletter-example-2.png
-	   :width: 45%
-
-Contact
--------
-
-Email us at sponsorship@writethedocs.org to purchase a Slack sponsorship.
+   <div class="cta-group">
+      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Slack%20sponsorship">Book a Slack sponsorship — $350</a>
+   </div>

--- a/docs/sponsorship/slack.rst
+++ b/docs/sponsorship/slack.rst
@@ -9,13 +9,6 @@ Sponsorship of our Slack network does two things:
 * It allows us to cover the cost of moderating and managing our Slack community
 * It allows you to get your name and message in front of our audience of :doc:`/documentarians`
 
-At a glance
------------
-
-* **Price:** $350 per month
-* **Reach:** Over {{ slack_members }} Slack members, via the ``#announcements`` channel that every member joins
-* **Format:** Up to 2 paragraphs of copy with 1 link, posted once a month
-
 .. raw:: html
 
    <div class="cta-group">
@@ -74,13 +67,15 @@ We currently allow 1 sponsored post per month on our Slack.
 We aim to send these during the first week of the month,
 but can be flexible if we haven't sold our current month.
 
-How to order
-------------
+Pricing
+-------
 
 The price for reaching our audience is **$350** per month.
-We can send you a payment link or issue an invoice — whichever works best for your company.
 
-Email us at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?subject=Slack%20sponsorship>`_ with the month you'd like, and we'll confirm availability.
+Contact
+-------
+
+Email us at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?subject=Slack%20sponsorship>`__ to purchase a Slack sponsorship.
 
 .. raw:: html
 

--- a/docs/sponsorship/website.rst
+++ b/docs/sponsorship/website.rst
@@ -3,8 +3,14 @@ Website Sponsorship
 
 You can sponsor the Write the Docs community website in two ways:
 
-* `Sidebar advertising`_
-* `Footer sponsorship`_
+* `Sidebar advertising`_ — **$250 per month** — the best way to actively sell something to our community
+* `Footer sponsorship`_ — **$500 per year** — your logo and link on every page of our community site
+
+.. raw:: html
+
+   <div class="cta-group">
+      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Website%20sponsorship">Book a website sponsorship</a>
+   </div>
 
 Website Stats
 -------------
@@ -71,8 +77,15 @@ Cost
 The footer logo sponsorship costs **$500 per year**.
 Sponsorship runs for a calendar year, or 365 days from the date of purchase.
 
-Contact
--------
+How to order
+------------
 
-If you are interested in sponsorship you can reach us at sponsorship@writethedocs.org.
-We're happy to work with you to craft the best sponsorship for your organization.
+Email us at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?subject=Website%20sponsorship>`_ and tell us which option you'd like.
+We can send you a payment link or issue an invoice,
+and we're happy to work with you to craft the best sponsorship for your organization.
+
+.. raw:: html
+
+   <div class="cta-group">
+      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Website%20sponsorship">Book a website sponsorship</a>
+   </div>

--- a/docs/sponsorship/website.rst
+++ b/docs/sponsorship/website.rst
@@ -3,8 +3,8 @@ Website Sponsorship
 
 You can sponsor the Write the Docs community website in two ways:
 
-* `Sidebar advertising`_ — **$250 per month** — the best way to actively sell something to our community
-* `Footer sponsorship`_ — **$500 per year** — your logo and link on every page of our community site
+* `Sidebar advertising`_ — **$250 per month**
+* `Footer sponsorship`_ — **$500 per year**
 
 .. raw:: html
 
@@ -77,12 +77,11 @@ Cost
 The footer logo sponsorship costs **$500 per year**.
 Sponsorship runs for a calendar year, or 365 days from the date of purchase.
 
-How to order
-------------
+Contact
+-------
 
-Email us at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?subject=Website%20sponsorship>`_ and tell us which option you'd like.
-We can send you a payment link or issue an invoice,
-and we're happy to work with you to craft the best sponsorship for your organization.
+If you are interested in sponsorship you can reach us at `sponsorship@writethedocs.org <mailto:sponsorship@writethedocs.org?subject=Website%20sponsorship>`__.
+We're happy to work with you to craft the best sponsorship for your organization.
 
 .. raw:: html
 

--- a/docs/sponsorship/website.rst
+++ b/docs/sponsorship/website.rst
@@ -9,7 +9,8 @@ You can sponsor the Write the Docs community website in two ways:
 .. raw:: html
 
    <div class="cta-group">
-      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Website%20sponsorship">Book a website sponsorship</a>
+      <a class="cta-button" href="https://buy.stripe.com/cNibIUaGl7vYeggfNOfEk09">Buy a sidebar ad — $250</a>
+      <a class="cta-button" href="https://buy.stripe.com/8x23co8yddUm6NO7hifEk0a">Buy a footer logo — $500</a>
    </div>
 
 Website Stats
@@ -50,6 +51,9 @@ Cost
 The sidebar sponsorship is **$250 per month**.
 It runs for a full calendar month, or 30 days from the date of purchase.
 
+You can pay via our `online payment form <https://buy.stripe.com/cNibIUaGl7vYeggfNOfEk09>`_,
+or we can issue you an invoice.
+
 Footer sponsorship
 ------------------
 
@@ -77,6 +81,9 @@ Cost
 The footer logo sponsorship costs **$500 per year**.
 Sponsorship runs for a calendar year, or 365 days from the date of purchase.
 
+You can pay via our `online payment form <https://buy.stripe.com/8x23co8yddUm6NO7hifEk0a>`__,
+or we can issue you an invoice.
+
 Contact
 -------
 
@@ -86,5 +93,6 @@ We're happy to work with you to craft the best sponsorship for your organization
 .. raw:: html
 
    <div class="cta-group">
-      <a class="cta-button" href="mailto:sponsorship@writethedocs.org?subject=Website%20sponsorship">Book a website sponsorship</a>
+      <a class="cta-button" href="https://buy.stripe.com/cNibIUaGl7vYeggfNOfEk09">Buy a sidebar ad — $250</a>
+      <a class="cta-button" href="https://buy.stripe.com/8x23co8yddUm6NO7hifEk0a">Buy a footer logo — $500</a>
    </div>


### PR DESCRIPTION
Makes it more obvious how to sponsor Write the Docs on the community sponsorship pages:

- Adds matching pricing tables to the sponsorship index — conferences first (with Portland 2027 listed for budget planning), then the community programs with reach and price
- Adds a green CTA button near the top and bottom of each program page, extracting the existing inline-styled newsletter button into a shared `.cta-button` class
- Links the newsletter CTAs directly to the Stripe payment form, and uses mailto links with pre-filled subjects everywhere else, with the email address always visible as text for broken mail handlers
- Small cleanups: a typo fix, removing a commented-out section, labeling Australia pricing as AUD, and demoting the newsletter archive button to a plain link

Original page copy and structure are otherwise unchanged.

## Screenshots

**Sponsorship index** — conference and community pricing tables with CTAs:

![Sponsorship index page](https://raw.githubusercontent.com/writethedocs/www/159ff883e2c85db4be052fe5513f1adcf498d042/pr-index.png)

**Newsletter page** — Stripe buy button up top, email as fallback:

![Newsletter sponsorship page](https://raw.githubusercontent.com/writethedocs/www/159ff883e2c85db4be052fe5513f1adcf498d042/pr-newsletter.png)

---
*Generated by AI*

https://claude.ai/code/session_015b1ezeD4frgFjJT6khmN2n

----
📚 Documentation preview 📚: https://writethedocs-www--2750.org.readthedocs.build/
