### PR TITLE
conf: use qa.event_id variable for Slido links on 2026 Q&A pages

### DIFF
--- a/docs/_data/australia-2026-config.yaml
+++ b/docs/_data/australia-2026-config.yaml
@@ -146,6 +146,9 @@ unconf:
   url: https://bit.ly/wtd-au-2026
   date: "Thursday and Friday after the morning tea break"
 
+qa:
+  event_id: pheuiBqUcsduHbivhQgBQV  # TODO: replace with the Australia 2026 Slido event (this is Portland 2025's)
+
 writing_day:
   url: ""
   date: Saturday, December 4, 10:00-17:00 AEDT

--- a/docs/_data/berlin-2026-config.yaml
+++ b/docs/_data/berlin-2026-config.yaml
@@ -169,6 +169,9 @@ unconf:
 lightning_talks:
   signup_url: "https://docs.google.com/forms/d/e/1FAIpQLSduOPKqF2wIZM79cGL4ZttjnRXVX2f_tz3YfiR_HhOnhBMLoA/viewform"
 
+qa:
+  event_id: 7dS4HFHyZcnQmCS4kW9c7q
+
 writing_day:
   url: "https://docs.google.com/forms/d/e/1FAIpQLSf5dN0o3HkPMY5UTVzyhO6nq7T07OL6awFHv9fkfX_jdV98iQ/viewform"
   git_signup_url: "https://ti.to/writethedocs/write-the-docs-berlin-2026/with/qyxd-bvuzc"

--- a/docs/_data/portland-2026-config.yaml
+++ b/docs/_data/portland-2026-config.yaml
@@ -182,6 +182,9 @@ unconf:
 lightning_talks:
   signup_url: "https://docs.google.com/forms/d/e/1FAIpQLSdeeMs_x9_6WPIl_ERai_3_5zkEBD7MrMK835igFY07zN156A/viewform"
 
+qa:
+  event_id: a2qmjbDYGqei5UxQQpy554
+
 writing_day:
   url: "https://docs.google.com/forms/d/e/1FAIpQLSfr5-2yJOFVjYLA2jaik8nP17nxm3fKDX6GA64SAyC14uKr1Q/viewform?usp=header"
   date: Sunday, May 3, 9 AM - 5 PM

--- a/docs/conf/australia/2026/qa.md
+++ b/docs/conf/australia/2026/qa.md
@@ -8,8 +8,8 @@ banner: _static/conf/images/headers/2026/qa.jpg
 
 This page allows you to ask questions of our speakers, and to vote on questions that you would like to see answered. Refresh this page on the day of the conference talks to see them!
 
- <iframe src="https://app.sli.do/event/pheuiBqUcsduHbivhQgBQV" height="100%" width="100%" frameBorder="0" style="min-height: 560px;" allow="clipboard-write" title="Slido"></iframe>
+ <iframe src="https://app.sli.do/event/{{qa.event_id}}" height="100%" width="100%" frameBorder="0" style="min-height: 560px;" allow="clipboard-write" title="Slido"></iframe>
 
-You can also use this link: <https://app.sli.do/event/pheuiBqUcsduHbivhQgBQV>
+You can also use this link: <https://app.sli.do/event/{{qa.event_id}}>
 
 If you experience technical issues, please report them in the \#wtd-conferences channel on Slack.

--- a/docs/conf/berlin/2026/qa.md
+++ b/docs/conf/berlin/2026/qa.md
@@ -8,8 +8,8 @@ banner: _static/conf/images/headers/2026/qa.jpg
 
 This page allows you to ask questions of our speakers, and to vote on questions that you would like to see answered. Refresh this page on the day of the conference talks to see them!
 
- <iframe src="https://app.sli.do/event/pheuiBqUcsduHbivhQgBQV" height="100%" width="100%" frameBorder="0" style="min-height: 560px;" allow="clipboard-write" title="Slido"></iframe>
+ <iframe src="https://app.sli.do/event/{{qa.event_id}}" height="100%" width="100%" frameBorder="0" style="min-height: 560px;" allow="clipboard-write" title="Slido"></iframe>
 
-You can also use this link: <https://app.sli.do/event/pheuiBqUcsduHbivhQgBQV>
+You can also use this link: <https://app.sli.do/event/{{qa.event_id}}>
 
 If you experience technical issues, please report them in the \#wtd-conferences channel on Slack.

--- a/docs/conf/portland/2026/qa.md
+++ b/docs/conf/portland/2026/qa.md
@@ -8,8 +8,8 @@ banner: _static/conf/images/headers/2026/qa.jpg
 
 This page allows you to ask questions of our speakers, and to vote on questions that you would like to see answered. Refresh this page on the day of the conference talks to see them!
 
- <iframe src="https://app.sli.do/event/a2qmjbDYGqei5UxQQpy554" height="100%" width="100%" frameBorder="0" style="min-height: 560px;" allow="clipboard-write" title="Slido"></iframe>
+ <iframe src="https://app.sli.do/event/{{qa.event_id}}" height="100%" width="100%" frameBorder="0" style="min-height: 560px;" allow="clipboard-write" title="Slido"></iframe>
 
-You can also use this link: <https://app.sli.do/event/a2qmjbDYGqei5UxQQpy554>
+You can also use this link: <https://app.sli.do/event/{{qa.event_id}}>
 
 If you experience technical issues, please report them in the \#wtd-conferences channel on Slack.


### PR DESCRIPTION
Updates the Berlin 2026 speaker Q&A page to the new Slido event (https://app.sli.do/event/7dS4HFHyZcnQmCS4kW9c7q), replacing the Portland 2025 event ID that was carried over.

All three 2026 Q&A pages (Berlin, Portland, Australia) now reference their Slido event via the `{{qa.event_id}}` config variable instead of hardcoding it, matching the Berlin 2025 setup, so the pages carry forward cleanly when copied to future years. Australia 2026 still has Portland 2025's event ID — it's now flagged with a TODO in the config for when the real event is created.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EFdQWya5T6oHjHfeSLqgTs