### PR TITLE
docs: Add top-of-page date buttons and anchors to Portland 2026 schedule

### DIFF
--- a/docs/conf/portland/2026/schedule.md
+++ b/docs/conf/portland/2026/schedule.md
@@ -6,6 +6,21 @@ og:image: _static/conf/images/headers/{{shortcode}}-{{year}}-opengraph.jpg
 
 # Schedule
 
+{% if flaghasschedule %}
+
+```{raw} html
+<nav class="uk-flex uk-flex-wrap uk-flex-center" aria-label="Schedule dates">
+{% if flaghashike or flaghasboat %}
+  <a class="uk-button uk-button-secondary uk-margin-small-right uk-margin-small-bottom" href="#day-one">{{date.day_one.dotw}}, {{date.day_one.date}}</a>
+{% endif %}
+  <a class="uk-button uk-button-secondary uk-margin-small-right uk-margin-small-bottom" href="#day-two">{{date.day_two.dotw}}, {{date.day_two.date}}</a>
+  <a class="uk-button uk-button-secondary uk-margin-small-right uk-margin-small-bottom" href="#day-three">{{date.day_three.dotw}}, {{date.day_three.date}}</a>
+  <a class="uk-button uk-button-secondary uk-margin-small-bottom" href="#day-four">{{date.day_four.dotw}}, {{date.day_four.date}}</a>
+</nav>
+```
+
+{% endif %}
+
 Write the Docs is more than a conference. Each year we organize a wide range of events so that people can come together, collaborate, and learn from each other in different ways.
 
 {% if not flaghasschedule %}
@@ -16,13 +31,9 @@ Write the Docs is more than a conference. Each year we organize a wide range of 
 
 All times are in [{{ tz }}](https://time.is/{{ tz | replace(' ', '_') }}).
 
-```{contents}
-:local:
-:depth: 1
-:backlinks: none
-```
-
 {% if flaghashike or flaghasboat %}
+
+<span id="day-one"></span>
 
 ## {{date.day_one.dotw}}, {{date.day_one.date}}
 
@@ -39,6 +50,8 @@ All times are in [{{ tz }}](https://time.is/{{ tz | replace(' ', '_') }}).
 {% endif %}
 
 <hr>
+
+<span id="day-two"></span>
 
 ## {{date.day_two.dotw}}, {{date.day_two.date}}
 
@@ -57,6 +70,8 @@ A detailed schedule will be announced soon.
 
 <hr>
 
+<span id="day-three"></span>
+
 ## {{date.day_three.dotw}}, {{date.day_three.date}}
 
 {% if flaghasschedule %}
@@ -73,6 +88,8 @@ A detailed schedule will be announced soon.
 {% endif %}
 
 <hr>
+
+<span id="day-four"></span>
 
 ## {{date.day_four.dotw}}, {{date.day_four.date}}
 


### PR DESCRIPTION
### Motivation

- Improve discoverability and navigation of the Portland 2026 schedule by surfacing the conference dates at the top of the page as clickable buttons. 
- Make each schedule day linkable so users (and external links) can jump directly to a specific day.

### Description

- Added a conditional Jinja block at the top of `docs/conf/portland/2026/schedule.md` that renders a responsive navigation bar of date buttons using the site's UIKit button classes wrapped in a raw HTML block. 
- Added stable anchor targets (`span id="day-one"`, `day-two`, `day-three`, `day-four`) immediately before each day's heading so the buttons scroll to the correct section. 
- Removed the in-page contents directive and kept the schedule include blocks intact; the only modified file is `docs/conf/portland/2026/schedule.md`.

### Testing

- Ran `git diff --check` to validate there are no whitespace/indexing issues and it returned clean results. (success)
- Built the docs with `cd docs && uv run make html` to verify the Sphinx build and output generation, and the build completed successfully and produced HTML in `_build/html`. (success)
- Verified the generated HTML contains the new `nav` and anchors by inspecting `docs/_build/html/conf/portland/2026/schedule/index.html`. (success)
- Ran `uv run pre-commit run --all-files` but the `pre-commit` executable was not available in the environment so hooks could not be executed. (skipped/failure)
- Attempted to install Playwright for visual/screenshot checks but the package download failed due to network/PyPI access, so visual tests were not run. (skipped/failure)

Footer: This PR was generated by AI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9ecb3b77008320988485bb48619007)

<!-- readthedocs-preview writethedocs-www start -->
----
📚 Documentation preview 📚: https://writethedocs-www--2763.org.readthedocs.build/

<!-- readthedocs-preview writethedocs-www end -->